### PR TITLE
Bye-bye Orange Bubbles!

### DIFF
--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -77,7 +77,8 @@ GiddyUp.TestResult = DS.Model.extend({
   }.property('status'),
 
   log_url: DS.attr('string'),
-  created_at: DS.attr('date'),
+  created_at: DS.attr('date'),,
+  long_version: DS.attr('string'),
   platformBinding: 'test.platform',
   backendBinding: 'test.backend',
   nameBinding: 'test.name'

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -77,7 +77,7 @@ GiddyUp.TestResult = DS.Model.extend({
   }.property('status'),
 
   log_url: DS.attr('string'),
-  created_at: DS.attr('date'),,
+  created_at: DS.attr('date'),
   long_version: DS.attr('string'),
   platformBinding: 'test.platform',
   backendBinding: 'test.backend',

--- a/assets/javascripts/app/templates/test_results_collection_item_view.hbs
+++ b/assets/javascripts/app/templates/test_results_collection_item_view.hbs
@@ -1,8 +1,8 @@
 {{#with view.content}}
   {{#if success}}
-  <a {{action showTestResult this href=true}}><span class="label label-success">Success</span> Test Result: {{id}} {{long_version}}</a>
+  <a {{action showTestResult this href=true}}><span class="label label-success">Success</span> Test Result: {{long_version}}</a>
   {{/if}}
   {{#if failure}}
-  <a {{action showTestResult this href=true}}><span class="label label-important">Failure</span> Test Result: {{id}} {{long_version}}</a>
+  <a {{action showTestResult this href=true}}><span class="label label-important">Failure</span> Test Result: {{long_version}}</a>
   {{/if}}
 {{/with}}

--- a/assets/javascripts/app/templates/test_results_collection_item_view.hbs
+++ b/assets/javascripts/app/templates/test_results_collection_item_view.hbs
@@ -1,8 +1,8 @@
 {{#with view.content}}
   {{#if success}}
-  <a {{action showTestResult this href=true}}><span class="label label-success">Success</span> Test Result: {{id}}</a>
+  <a {{action showTestResult this href=true}}><span class="label label-success">Success</span> Test Result: {{id}} {{long_version}}</a>
   {{/if}}
   {{#if failure}}
-  <a {{action showTestResult this href=true}}><span class="label label-important">Failure</span> Test Result: {{id}}</a>
+  <a {{action showTestResult this href=true}}><span class="label label-important">Failure</span> Test Result: {{id}} {{long_version}}</a>
   {{/if}}
 {{/with}}

--- a/assets/javascripts/app/views.js
+++ b/assets/javascripts/app/views.js
@@ -36,21 +36,21 @@ GiddyUp.ScorecardSubcellView = Ember.View.extend({
   labelClass: 'badge',
   classNameBindings: ['labelClass', 'statusClass'],
   attributeBindings: ['title'],
-  titleBinding: 'percent',
   statusClass: function(){
     var status = this.get('content.status');
-    if(status.total === 0)
+    if(status.get('total') === 0)
       return '';
-    else if(status.passing === status.total)
+    else if(status.get('latest'))
       return 'badge-success';
-    else if(status.failing === status.total)
-      return 'badge-important';
     else
-      return 'badge-warning';
+      return 'badge-important';
   }.property('content.status'),
-  percent: function(){
-    var status = this.get('content.status');
-    return status.percent.toFixed(1).toString() + "%";
+  title: function(){
+    var percent = this.get('content.status.percent');
+    if(percent != null || percent != undefined)
+      return percent.toFixed(1).toString() + "%";
+    else
+      return "0%";
   }.property('content.status'),
   backendAbbr: function(){
     var backend = this.get('content.test.backend');

--- a/assets/javascripts/app/views.js
+++ b/assets/javascripts/app/views.js
@@ -47,7 +47,7 @@ GiddyUp.ScorecardSubcellView = Ember.View.extend({
   }.property('content.status'),
   title: function(){
     var percent = this.get('content.status.percent');
-    if(percent != null || percent != undefined)
+    if(percent !== null || percent !== undefined)
       return percent.toFixed(1).toString() + "%";
     else
       return "0%";

--- a/db/migrate/2012111418271352935658_consolidate_scorecards.rb
+++ b/db/migrate/2012111418271352935658_consolidate_scorecards.rb
@@ -15,7 +15,7 @@ class ConsolidateScorecards < ActiveRecord::Migration
     say_with_time "Consolidating scorecards" do
       Project.all.each do |project|
         project.scorecards.each do |scorecard|
-          normalized_version = scorecard.name[Test::VERSION_REGEX, 0]
+          normalized_version = GiddyUp.normalize_version(scorecard.name)
           if normalized_version.blank?
             say("#{project.name}: #{scorecard.name} SKIP", true)
             next

--- a/db/migrate/2012111418271352935658_consolidate_scorecards.rb
+++ b/db/migrate/2012111418271352935658_consolidate_scorecards.rb
@@ -1,0 +1,40 @@
+class ConsolidateScorecards < ActiveRecord::Migration
+  def up
+    # First, we capture the entire version name in the test result
+    # table (for later reference)
+    add_column :test_results, :long_version, :string
+
+    TestResult.reset_column_information
+    say_with_time "Recording long_version info on test results" do
+      TestResult.find_each do |result|
+        result.update_attributes(:long_version => result.scorecard.name)
+      end
+    end
+
+    # Now we consolidate scorecards by VERSION_REGEX, per project
+    say_with_time "Consolidating scorecards" do
+      Project.all.each do |project|
+        project.scorecards.each do |scorecard|
+          normalized_version = scorecard.name[Test::VERSION_REGEX, 0]
+          if normalized_version.blank?
+            say("#{project.name}: #{scorecard.name} SKIP", true)
+            next
+          end
+          say "#{project.name}: #{scorecard.name} -> #{normalized_version}", true
+          if existing_scorecard = project.scorecards.where(:name => normalized_version).first
+            # If the normalized scorecard name already exists, give it the test_results from this one.
+            existing_scorecard.test_results << scorecard.test_results
+            scorecard.destroy
+          else
+            scorecard.update_attributes(:name => normalized_version)
+          end
+        end
+      end
+    end
+  end
+
+  def down
+    # This is lossy!
+    remove_column :test_results, :long_version
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 2012111316281352842088) do
+ActiveRecord::Schema.define(:version => 2012111418271352935658) do
 
   create_table "projects", :force => true do |t|
     t.string "name"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(:version => 2012111316281352842088) do
     t.datetime "created_at",   :null => false
     t.datetime "updated_at",   :null => false
     t.string   "log_url"
+    t.string   "long_version"
   end
 
   add_index "test_results", ["scorecard_id"], :name => "index_test_results_on_scorecard_id"

--- a/lib/giddyup.rb
+++ b/lib/giddyup.rb
@@ -5,6 +5,17 @@ module GiddyUp
       config.adapter = :Rack
     end
   end
+
+  VERSION_REGEX = /\d+\.\d+\.\d+\w*/
+
+  def self.version(version_string)
+    strict = normalize_version(version_string)
+    strict.blank? ? version_string : strict
+  end
+
+  def self.normalize_version(version_string)
+    version_string[VERSION_REGEX, 0]
+  end
 end
 
 require 'giddyup/hstore'

--- a/lib/giddyup/contexts.rb
+++ b/lib/giddyup/contexts.rb
@@ -13,8 +13,10 @@ module GiddyUp
       begin
         @test_result.test_id = data['test_id'] || data['id']
         @test_result.status = data['status']
+        @test_result.long_version = data['version']
         project = Project.find_by_name(data['project'])
-        @test_result.scorecard = project.scorecards.find_or_create_by_name(data['version'])
+        version = GiddyUp.version(data['version'])
+        @test_result.scorecard = project.scorecards.find_or_create_by_name(version)
         if log = create_log(data['log'])
           @test_result.log_url = log.public_url
         end

--- a/lib/giddyup/records.rb
+++ b/lib/giddyup/records.rb
@@ -15,12 +15,8 @@ class Test < ActiveRecord::Base
 
   def self.for_version(version, scope = self)
     version = GiddyUp.normalize_version(version)
-    if version.present?
-      scope.where(["((NOT exist(tests.tags::hstore, 'min_version')) OR (tests.tags::hstore -> ARRAY['min_version'] <= ARRAY[?]))", version]).
+    scope.where(["((NOT exist(tests.tags::hstore, 'min_version')) OR (tests.tags::hstore -> ARRAY['min_version'] <= ARRAY[?]))", version]).
       where(["((NOT exist(tests.tags::hstore, 'max_version')) OR (tests.tags::hstore -> ARRAY['max_version'] >= ARRAY[?]))", version])
-    else
-      scope
-    end
   end
 end
 

--- a/lib/giddyup/records.rb
+++ b/lib/giddyup/records.rb
@@ -13,12 +13,14 @@ class Test < ActiveRecord::Base
   default_scope order(:name)
   serialize :tags, HstoreSerializer
 
-  VERSION_REGEX = /\d+\.\d+\.\d+\w*/
-
   def self.for_version(version, scope = self)
-    version = version[VERSION_REGEX, 0]
-    scope.where(["((NOT exist(tests.tags::hstore, 'min_version')) OR (tests.tags::hstore -> ARRAY['min_version'] <= ARRAY[?]))", version]).
+    version = GiddyUp.normalize_version(version)
+    if version.present?
+      scope.where(["((NOT exist(tests.tags::hstore, 'min_version')) OR (tests.tags::hstore -> ARRAY['min_version'] <= ARRAY[?]))", version]).
       where(["((NOT exist(tests.tags::hstore, 'max_version')) OR (tests.tags::hstore -> ARRAY['max_version'] >= ARRAY[?]))", version])
+    else
+      scope
+    end
   end
 end
 

--- a/lib/giddyup/serializers.rb
+++ b/lib/giddyup/serializers.rb
@@ -12,7 +12,7 @@ class LogSerializer < ActiveModel::Serializer
 end
 
 class TestResultSerializer < ActiveModel::Serializer
-  attributes :id, :status, :log_url, :test_id, :scorecard_id, :created_at
+  attributes :id, :status, :log_url, :test_id, :scorecard_id, :created_at, :long_version
 end
 
 class ScorecardSerializer < ActiveModel::Serializer


### PR DESCRIPTION
This pull-request accomplishes several things I discussed with @joedevivo and @cmeiklejohn today, namely:
1. Orange bubbles indicating mixed results are no more. The bubble on the scorecard now shows the result of the **latest** recorded test.
2. **Scorecard names are normalized** to a version string more closely resembling our release process (grouping whole versions and release-candidates together). **Test results still record the entire version string** for comparison purposes, meaning we can see whether given builds fix tests before cutting a new tag.

Example:

![screenshot](http://seancribbs-skitch.s3.amazonaws.com/GiddyUp__riak_test_reports-20121114-192505.png)
