### PR TITLE
Version tags, Fedora 15

### DIFF
--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -88,7 +88,10 @@ GiddyUp.Test = DS.Model.extend({
   name: DS.attr('string'),
   tags: DS.attr('hash'),
   platform: function(){ return this.get('tags.platform'); }.property('tags'),
-  backend: function(){ return this.get('tags.backend'); }.property('tags')
+  backend: function(){ return this.get('tags.backend'); }.property('tags'),
+  upgrade_version: function(){
+    return this.get('tags.upgrade_version')
+  }.property('tags')
 });
 
 GiddyUp.Log = DS.Model.extend({

--- a/assets/javascripts/app/templates/scorecard.hbs
+++ b/assets/javascripts/app/templates/scorecard.hbs
@@ -15,7 +15,7 @@
         {{#each cell in test}}
           <td>
             {{#each cell.subcells}}
-              {{#view GiddyUp.ScorecardSubcellView contentBinding="this" titleBinding="percent"}}<a {{action showTestResults this href=true}}>{{view.backendAbbr}}</a>{{/view}}&nbsp;
+              {{#view GiddyUp.ScorecardSubcellView contentBinding="this" titleBinding="percent"}}<a {{action showTestResults this href=true}}>{{view.abbr}}</a>{{/view}}
             {{/each}}
           </td>
         {{/each}}

--- a/assets/javascripts/app/views.js
+++ b/assets/javascripts/app/views.js
@@ -52,24 +52,36 @@ GiddyUp.ScorecardSubcellView = Ember.View.extend({
     else
       return "0%";
   }.property('content.status'),
-  backendAbbr: function(){
+  abbr: function(){
     var backend = this.get('content.test.backend');
+    var upgrade_version = this.get('content.test.upgrade_version');
+    var abbr = ''
+    switch(upgrade_version){
+    case 'previous':
+      abbr = '-1'; break;
+    case 'legacy':
+      abbr = '-2'; break;
+    default:
+      break;
+    }
     switch(backend){
     case 'bitcask':
-      return 'B';
+      abbr = 'B' + abbr;
       break;
     case 'eleveldb':
-      return 'L';
+      abbr = 'L' + abbr;
       break;
     case 'memory':
-      return 'M';
+      abbr = 'M'+abbr;
       break;
     default:
-      return 'U';
+      break;
     }
-
-    return true;
-  }.property('content.test.backend')
+    if(abbr.length == 0)
+      return 'U';
+    else
+      return abbr;
+  }.property('content.test.backend', 'content.test.upgrade_version')
 });
 
 GiddyUp.CollectionView = Ember.CollectionView.extend({

--- a/assets/javascripts/app/views.js
+++ b/assets/javascripts/app/views.js
@@ -77,7 +77,7 @@ GiddyUp.ScorecardSubcellView = Ember.View.extend({
     default:
       break;
     }
-    if(abbr.length == 0)
+    if(abbr.length === 0)
       return 'U';
     else
       return abbr;

--- a/db/migrate/2012111613531353092003_deprecate_fedora15.rb
+++ b/db/migrate/2012111613531353092003_deprecate_fedora15.rb
@@ -1,0 +1,22 @@
+class DeprecateFedora15 < ActiveRecord::Migration
+  def up
+    say_with_time "Setting max_version on fedora-15 tests to 1.2.99" do
+      Test.where(['tests.tags::hstore @> ?',
+                  HstoreSerializer.dump('platform' => 'fedora-15-64')]).each do |test|
+        test.tags['max_version'] = '1.2.99'
+        test.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time "Removing max_version from fedora-15 tests" do
+      Test.where(['tests.tags::hstore @> ?',
+                  HstoreSerializer.dump('platform' => 'fedora-15-64',
+                                        'max_version' =>  '1.2.99')]).each do |test|
+        test.tags.delete('max_version')
+        test.save!
+      end
+    end
+  end
+end

--- a/db/migrate/2012111614451353095159_specify_upgrade_versions.rb
+++ b/db/migrate/2012111614451353095159_specify_upgrade_versions.rb
@@ -1,0 +1,41 @@
+class SpecifyUpgradeVersions < ActiveRecord::Migration
+  def up
+    say_with_time 'Adding upgrade_version tags to the upgrade tests' do
+      @projects = Project.where(:name => %w{riak riak_ee}).all
+      %w{loaded_upgrade verify_basic_upgrade}.each do |name|
+        Test.where(:name => name).each do |test|
+          unless test.tags['upgrade_version']
+            test.tags['upgrade_version'] = 'previous'
+            test.save!
+            create_riak_test name, test.tags.dup.merge('upgrade_version' => 'legacy')
+          end
+        end
+      end
+    end
+  end
+
+  def down
+    say_with_time 'Removing upgrade_version tags from upgrade tests' do
+      %w{loaded_upgrade verify_basic_upgrade}.each do |name|
+        Test.where(:name => name).each do |test|
+          if test.tags['upgrade_version'] == 'legacy'
+            test.destroy!
+          else
+            test.tags.delete('upgrade_version')
+            test.save!
+          end
+        end
+      end
+    end
+  end
+
+  def create_riak_test(name, tags)
+    unless Test.where(:name => name).where(['tests.tags::hstore @> ?', HstoreSerializer.dump(tags) ]).exists?
+      if tags['platform'] =~ /fedora-15/
+        tags['max_version'] = '1.2.99'
+      end
+      test = Test.create!(:name => name, :tags => tags)
+      @projects.each {|p| p.tests << test }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 2012111613531353092003) do
+ActiveRecord::Schema.define(:version => 2012111614451353095159) do
 
   create_table "projects", :force => true do |t|
     t.string "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 2012111418271352935658) do
+ActiveRecord::Schema.define(:version => 2012111613531353092003) do
 
   create_table "projects", :force => true do |t|
     t.string "name"

--- a/db/seed.rb
+++ b/db/seed.rb
@@ -80,7 +80,7 @@ end
 ## Test upgrades on only persistent backends, from two different versions
 platforms.each do |p|
   %w{bitcask eleveldb}.each do |b|
-    %{previous legacy}.each do |v|
+    %w{previous legacy}.each do |v|
       create_riak_test "loaded_upgrade", 'platform' => p, 'backend' => b, 'upgrade_version' => v
       create_riak_test "verify_basic_upgrade", 'platform' => p, 'backend' => b, 'upgrade_version' => v
     end

--- a/db/seed.rb
+++ b/db/seed.rb
@@ -50,6 +50,9 @@ def create_riak_test(name, *args)
   tags = args.pop || {}
   projects = args.first || %w{riak riak_ee}
   unless Test.where(:name => name).where(['tests.tags::hstore @> ?', HstoreSerializer.dump(tags) ]).exists?
+    if tags['platform'] =~ /fedora-15/
+      tags['max_version'] = '1.2.99'
+    end
     test = Test.create(:name => name, :tags => tags)
     projects.each do |p|
       $projects[p].tests << test
@@ -84,5 +87,6 @@ end
 
 ## Riak 1.3 features
 platforms.each do |p|
+  next if p =~ /fedora-15/
   create_riak_test "verify_reset_bucket_props", 'platform' => p, 'min_version' => '1.3.0'
 end

--- a/db/seed.rb
+++ b/db/seed.rb
@@ -34,7 +34,6 @@ riak_tests = %w{
   riaknostic_rt
   rolling_capabilities
   rt_basic_test
-  verify_basic_upgrade
   verify_build_cluster
   verify_capabilities
   verify_claimant
@@ -73,15 +72,18 @@ platforms.each do |p|
   end
 end
 
-## Special handling for Ruby tests
+## Special handling for Ruby tests, memory only
 platforms.each do |p|
   create_riak_test "client_ruby_verify", 'platform' => p, 'backend' => 'memory'
 end
 
-## Test loaded_upgrade on only persistent backends
+## Test upgrades on only persistent backends, from two different versions
 platforms.each do |p|
   %w{bitcask eleveldb}.each do |b|
-    create_riak_test "loaded_upgrade", 'platform' => p, 'backend' => b
+    %{previous legacy}.each do |v|
+      create_riak_test "loaded_upgrade", 'platform' => p, 'backend' => b, 'upgrade_version' => v
+      create_riak_test "verify_basic_upgrade", 'platform' => p, 'backend' => b, 'upgrade_version' => v
+    end
   end
 end
 


### PR DESCRIPTION
This PR does two things:
1. Deprecates Fedora 15 for versions past 1.2. 1.3+ will use Fedora 17.
2. Adds `previous` and `legacy` version tags for the "upgrade" tests, letting us parameterize whether we're upgrading from `current - 1` or `current - 2`.

If this is not merged right away, I will likely adjust the bubbles in the UI to reflect the new tag and add a commit for that.
