### PR TITLE
Ember.js Upgrade

### DIFF
--- a/assets/javascripts/app/adapter.js
+++ b/assets/javascripts/app/adapter.js
@@ -91,6 +91,18 @@ GiddyUp.ProxyStore = Ember.Object.extend({
   }
 });
 
+GiddyUp.serializer = DS.JSONSerializer.create();
+
+GiddyUp.serializer.registerTransform('hash', {
+  deserialize: function(serialized) {
+    return Ember.none(serialized) ? null : serialized;
+  },
+
+  serialize: function(deserialized) {
+    return Ember.none(deserialized) ? null : deserialized;
+  }
+});
+
 // Implements an adapter that caches immutable records locally in the
 // Indexed DB API.
 GiddyUp.CachingAdapter = DS.RESTAdapter.extend({
@@ -226,7 +238,12 @@ GiddyUp.CachingAdapter = DS.RESTAdapter.extend({
 });
 
 if(indexedDB){
-  GiddyUp.Adapter = GiddyUp.CachingAdapter.extend({name: 'giddyup'});
+  GiddyUp.Adapter = GiddyUp.CachingAdapter.extend({
+    name: 'giddyup',
+    serializer: GiddyUp.serializer
+  });
 } else {
-  GiddyUp.Adapter = DS.RESTAdapter.extend();
+  GiddyUp.Adapter = DS.RESTAdapter.extend({
+    serializer: GiddyUp.serializer
+  });
 }

--- a/assets/javascripts/app/adapter.js
+++ b/assets/javascripts/app/adapter.js
@@ -255,5 +255,6 @@ GiddyUp.Adapter.map('GiddyUp.Project', {
 
 GiddyUp.Adapter.map('GiddyUp.Scorecard', {
   project: { key: 'project' },
-  test_results: { key: 'test_result_ids' }
+  test_results: { key: 'test_result_ids' },
+  tests: { key: 'test_ids' }
 });

--- a/assets/javascripts/app/adapter.js
+++ b/assets/javascripts/app/adapter.js
@@ -125,7 +125,7 @@ GiddyUp.CachingAdapter = DS.RESTAdapter.extend({
 
     request.addEventListener('success', function(event){
       self.set('db', request.result);
-    })
+    });
 
     return this._super();
   },
@@ -205,7 +205,7 @@ GiddyUp.CachingAdapter = DS.RESTAdapter.extend({
         stateManager.send('missedRecord', mid);
       }, function(fid) {
         stateManager.send('foundRecord', fid);
-      })
+      });
     });
   },
 

--- a/assets/javascripts/app/adapter.js
+++ b/assets/javascripts/app/adapter.js
@@ -247,3 +247,7 @@ if(indexedDB){
     serializer: GiddyUp.serializer
   });
 }
+
+GiddyUp.Adapter.map('GiddyUp.Project', {
+  primaryKey: 'name'
+});

--- a/assets/javascripts/app/adapter.js
+++ b/assets/javascripts/app/adapter.js
@@ -254,5 +254,6 @@ GiddyUp.Adapter.map('GiddyUp.Project', {
 });
 
 GiddyUp.Adapter.map('GiddyUp.Scorecard', {
+  project: { key: 'project' },
   test_results: { key: 'test_result_ids' }
 });

--- a/assets/javascripts/app/adapter.js
+++ b/assets/javascripts/app/adapter.js
@@ -249,5 +249,10 @@ if(indexedDB){
 }
 
 GiddyUp.Adapter.map('GiddyUp.Project', {
-  primaryKey: 'name'
+  primaryKey: 'name',
+  scorecards: { key: 'scorecard_ids' }
+});
+
+GiddyUp.Adapter.map('GiddyUp.Scorecard', {
+  test_results: { key: 'test_result_ids' }
 });

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -23,7 +23,7 @@ GiddyUp.Scorecard = DS.Model.extend({
   name: DS.attr('string'),
   project: DS.belongsTo('GiddyUp.Project'),
   test_results: DS.hasMany('GiddyUp.TestResult'),
-  tests: DS.hasMany('GiddyUp.Test', { embedded: true }),
+  tests: DS.hasMany('GiddyUp.Test'),
   cells: function(){
     if(!this.get('project.isLoaded')){
       return [];

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -21,7 +21,7 @@ GiddyUp.Project = DS.Model.extend({
 
 GiddyUp.Scorecard = DS.Model.extend({
   name: DS.attr('string'),
-  project: DS.belongsTo('GiddyUp.Project', { key: 'project' }),
+  project: DS.belongsTo('GiddyUp.Project'),
   test_results: DS.hasMany('GiddyUp.TestResult'),
   tests: DS.hasMany('GiddyUp.Test', { embedded: true }),
   cells: function(){

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -15,7 +15,6 @@ GiddyUp.propertyComparator = function() {
 };
 
 GiddyUp.Project = DS.Model.extend({
-  primaryKey: 'name',
   name: DS.attr('string'),
   scorecards: DS.hasMany('GiddyUp.Scorecard', { key: 'scorecard_ids' })
 });

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -1,13 +1,3 @@
-// Hack to allow the 'tags' field on Test, which is an hstore column
-// in postgresql.
-DS.attr.transforms.hash = {
-  from: function(serialized) {
-    return Ember.none(serialized) ? null : serialized;
-  },
-  to: function(deserialized) {
-    return Ember.none(deserialized) ? null : deserialized;
-  }
-};
 
 // Sorts Ember objects in an Array by the given properties.
 GiddyUp.propertyComparator = function() {

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -39,14 +39,14 @@ GiddyUp.Scorecard = DS.Model.extend({
           scorecard: scorecard
         });
       });
-    })
+    });
   }.property('project.isLoaded'),
   platforms: function(){
     return this.get('tests').getEach('platform').sort().uniq();
-  }.property('tests').cacheable(),
+  }.property('tests.@each.isLoaded'),
   testNames: function(){
     return this.get('tests').getEach('name').sort().uniq();
-  }.property('tests').cacheable()
+  }.property('tests.@each.isLoaded')
 });
 
 GiddyUp.TestResult = DS.Model.extend({

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -11,7 +11,7 @@ GiddyUp.propertyComparator = function() {
       if(bv < av) return 1;
     }
     return 0;
-  }
+  };
 };
 
 GiddyUp.Project = DS.Model.extend({

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -16,13 +16,13 @@ GiddyUp.propertyComparator = function() {
 
 GiddyUp.Project = DS.Model.extend({
   name: DS.attr('string'),
-  scorecards: DS.hasMany('GiddyUp.Scorecard', { key: 'scorecard_ids' })
+  scorecards: DS.hasMany('GiddyUp.Scorecard')
 });
 
 GiddyUp.Scorecard = DS.Model.extend({
   name: DS.attr('string'),
   project: DS.belongsTo('GiddyUp.Project', { key: 'project' }),
-  test_results: DS.hasMany('GiddyUp.TestResult', { key: 'test_result_ids' }),
+  test_results: DS.hasMany('GiddyUp.TestResult'),
   tests: DS.hasMany('GiddyUp.Test', { embedded: true }),
   cells: function(){
     if(!this.get('project.isLoaded')){

--- a/assets/javascripts/app/store.js
+++ b/assets/javascripts/app/store.js
@@ -1,21 +1,8 @@
-GiddyUp.serializer = DS.JSONSerializer.create();
-
-GiddyUp.serializer.registerTransform('hash', {
-  deserialize: function(serialized) {
-    return Ember.none(serialized) ? null : serialized;
-  },
-
-  serialize: function(deserialized) {
-    return Ember.none(deserialized) ? null : deserialized;
-  }
-});
-
 GiddyUp.adapter = GiddyUp.Adapter.create();
 
 GiddyUp.Store = DS.Store.extend({
   revision: 10,
-  adapter: GiddyUp.adapter,
-  serializer: GiddyUp.serializer
+  adapter: GiddyUp.adapter
 });
 
 GiddyUp.store = GiddyUp.Store.create();

--- a/assets/javascripts/app/store.js
+++ b/assets/javascripts/app/store.js
@@ -1,6 +1,21 @@
+GiddyUp.serializer = DS.JSONSerializer.create();
+
+GiddyUp.serializer.registerTransform('hash', {
+  deserialize: function(serialized) {
+    return Ember.none(serialized) ? null : serialized;
+  },
+
+  serialize: function(deserialized) {
+    return Ember.none(deserialized) ? null : deserialized;
+  }
+});
+
+GiddyUp.adapter = GiddyUp.Adapter.create();
+
 GiddyUp.Store = DS.Store.extend({
-  revision: 4,
-  adapter: GiddyUp.Adapter.create()
+  revision: 10,
+  adapter: GiddyUp.adapter,
+  serializer: GiddyUp.serializer
 });
 
 GiddyUp.store = GiddyUp.Store.create();

--- a/assets/javascripts/app/views.js
+++ b/assets/javascripts/app/views.js
@@ -52,10 +52,13 @@ GiddyUp.ScorecardView = Ember.View.extend({
   templateName: 'scorecard',
   isLoaded: function(){
     var result = this.get('controller.content.isLoaded') &&
+      this.get('controller.content.tests').getEach('isLoaded').
+      every(function(l){ return l; }) &&
       this.get('controller.content.test_results').getEach('isLoaded').
       every(function(l){ return l; });
     return result;
   }.property('controller.content.isLoaded',
+             'controller.content.tests.@each.isLoaded',
              'controller.content.test_results.@each.isLoaded')
 });
 

--- a/assets/javascripts/vendor/ember-data.js
+++ b/assets/javascripts/vendor/ember-data.js
@@ -1,6 +1,6 @@
 (function() {
 window.DS = Ember.Namespace.create({
-  CURRENT_API_REVISION: 4
+  CURRENT_API_REVISION: 10
 });
 
 })();
@@ -18,8 +18,7 @@ var get = Ember.get, set = Ember.set;
   in response to queries.
 */
 
-DS.RecordArray = Ember.ArrayProxy.extend({
-
+DS.RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
   /**
     The model type contained by this record array.
 
@@ -33,6 +32,9 @@ DS.RecordArray = Ember.ArrayProxy.extend({
   // necessary, by the store.
   content: null,
 
+  isLoaded: false,
+  isUpdating: false,
+
   // The store that created this record array.
   store: null,
 
@@ -44,6 +46,24 @@ DS.RecordArray = Ember.ArrayProxy.extend({
     if (clientId !== undefined) {
       return store.findByClientId(get(this, 'type'), clientId);
     }
+  },
+
+  materializedObjectAt: function(index) {
+    var clientId = get(this, 'content').objectAt(index);
+    if (!clientId) { return; }
+
+    if (get(this, 'store').recordIsMaterialized(clientId)) {
+      return this.objectAt(index);
+    }
+  },
+
+  update: function() {
+    if (get(this, 'isUpdating')) { return; }
+
+    var store = get(this, 'store'),
+        type = get(this, 'type');
+
+    store.fetchAll(type, this);
   }
 });
 
@@ -56,6 +76,7 @@ var get = Ember.get;
 
 DS.FilteredRecordArray = DS.RecordArray.extend({
   filterFunction: null,
+  isLoaded: true,
 
   replace: function() {
     var type = get(this, 'type').toString();
@@ -77,7 +98,6 @@ var get = Ember.get, set = Ember.set;
 
 DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
   query: null,
-  isLoaded: false,
 
   replace: function() {
     var type = get(this, 'type').toString();
@@ -93,9 +113,10 @@ DS.AdapterPopulatedRecordArray = DS.RecordArray.extend({
     set(this, 'content', Ember.A(clientIds));
     set(this, 'isLoaded', true);
     this.endPropertyChanges();
+
+    this.trigger('didLoad');
   }
 });
-
 
 })();
 
@@ -180,7 +201,7 @@ var states = {
     }
   }),
 
-  clean: LoadedState.create({
+  clean: LoadedState.createWithMixins({
     isLoaded: true,
     isDirty: false,
 
@@ -195,7 +216,7 @@ var states = {
     }
   }),
 
-  dirty: LoadedState.create({
+  dirty: LoadedState.createWithMixins({
     isLoaded: true,
     isDirty: true,
 
@@ -250,25 +271,65 @@ DS.ManyArrayStateManager = Ember.StateManager.extend({
 (function() {
 var get = Ember.get, set = Ember.set;
 
+/**
+  A ManyArray is a RecordArray that represents the contents of a has-many
+  association.
+
+  The ManyArray is instantiated lazily the first time the association is
+  requested.
+
+  ### Inverses
+
+  Often, the associations in Ember Data applications will have
+  an inverse. For example, imagine the following models are
+  defined:
+
+      App.Post = DS.Model.extend({
+        comments: DS.hasMany('App.Comment')
+      });
+
+      App.Comment = DS.Model.extend({
+        post: DS.belongsTo('App.Post')
+      });
+
+  If you created a new instance of `App.Post` and added
+  a `App.Comment` record to its `comments` has-many
+  association, you would expect the comment's `post`
+  property to be set to the post that contained
+  the has-many.
+
+  We call the record to which an association belongs the
+  association's _owner_.
+*/
 DS.ManyArray = DS.RecordArray.extend({
   init: function() {
-    set(this, 'stateManager', DS.ManyArrayStateManager.create({ manyArray: this }));
-
-    return this._super();
+    this._super.apply(this, arguments);
+    this._changesToSync = Ember.OrderedSet.create();
   },
 
-  parentRecord: null,
+  /**
+    @private
 
-  isDirty: Ember.computed(function() {
-    return get(this, 'stateManager.currentState.isDirty');
-  }).property('stateManager.currentState').cacheable(),
+    The record to which this association belongs.
 
-  isLoaded: Ember.computed(function() {
-    return get(this, 'stateManager.currentState.isLoaded');
-  }).property('stateManager.currentState').cacheable(),
+    @property {DS.Model}
+  */
+  owner: null,
 
-  send: function(event, context) {
-    this.get('stateManager').send(event, context);
+  // LOADING STATE
+
+  isLoaded: false,
+
+  loadingRecordsCount: function(count) {
+    this.loadingRecordsCount = count;
+  },
+
+  loadedRecord: function() {
+    this.loadingRecordsCount--;
+    if (this.loadingRecordsCount === 0) {
+      set(this, 'isLoaded', true);
+      this.trigger('didLoad');
+    }
   },
 
   fetch: function() {
@@ -281,92 +342,137 @@ DS.ManyArray = DS.RecordArray.extend({
 
   // Overrides Ember.Array's replace method to implement
   replaceContent: function(index, removed, added) {
-    var parentRecord = get(this, 'parentRecord');
-    var pendingParent = parentRecord && !get(parentRecord, 'id');
-    var stateManager = get(this, 'stateManager');
-
     // Map the array of record objects into an array of  client ids.
     added = added.map(function(record) {
       Ember.assert("You can only add records of " + (get(this, 'type') && get(this, 'type').toString()) + " to this association.", !get(this, 'type') || (get(this, 'type') === record.constructor));
-
-      // If the record to which this many array belongs does not yet
-      // have an id, notify the newly-added record that it must wait
-      // for the parent to receive an id before the child can be
-      // saved.
-      if (pendingParent) {
-        record.send('waitingOn', parentRecord);
-      }
-
-      var oldParent = this.assignInverse(record, parentRecord);
-
-      record.get('transaction')
-        .relationshipBecameDirty(record, oldParent, parentRecord);
-
-      stateManager.send('recordWasAdded', record);
-
       return record.get('clientId');
     }, this);
-
-    var store = this.store;
-
-    var len = index+removed, record;
-    for (var i = index; i < len; i++) {
-      // TODO: null out inverse FK
-      record = this.objectAt(i);
-      var oldParent = this.assignInverse(record, parentRecord, true);
-
-      record.get('transaction')
-        .relationshipBecameDirty(record, parentRecord, null);
-
-      // If we put the child record into a pending state because
-      // we were waiting on the parent record to get an id, we
-      // can tell the child it no longer needs to wait.
-      if (pendingParent) {
-        record.send('doneWaitingOn', parentRecord);
-      }
-
-      stateManager.send('recordWasAdded', record);
-    }
 
     this._super(index, removed, added);
   },
 
-  assignInverse: function(record, parentRecord, remove) {
-    var associationMap = get(record.constructor, 'associations'),
-        possibleAssociations = associationMap.get(parentRecord.constructor),
-        possible, actual, oldParent;
+  arrangedContentDidChange: function() {
+    this.fetch();
+  },
 
-    if (!possibleAssociations) { return; }
+  arrayContentWillChange: function(index, removed, added) {
+    var owner = get(this, 'owner'),
+        name = get(this, 'name');
 
-    for (var i = 0, l = possibleAssociations.length; i < l; i++) {
-      possible = possibleAssociations[i];
+    if (!owner._suspendedAssociations) {
+      // This code is the first half of code that continues inside
+      // of arrayContentDidChange. It gets or creates a change from
+      // the child object, adds the current owner as the old
+      // parent if this is the first time the object was removed
+      // from a ManyArray, and sets `newParent` to null.
+      //
+      // Later, if the object is added to another ManyArray,
+      // the `arrayContentDidChange` will set `newParent` on
+      // the change.
+      for (var i=index; i<index+removed; i++) {
+        var clientId = get(this, 'content').objectAt(i);
+        //var record = this.objectAt(i);
+        //if (!record) { continue; }
 
-      if (possible.kind === 'belongsTo') {
-        actual = possible;
-        break;
+        var change = DS.OneToManyChange.forChildAndParent(clientId, get(this, 'store'), {
+          parentType: owner.constructor,
+          hasManyName: name
+        });
+        change.hasManyName = name;
+
+        if (change.oldParent === undefined) { change.oldParent = get(owner, 'clientId'); }
+        change.newParent = null;
+        this._changesToSync.add(change);
       }
     }
 
-    if (actual) {
-      oldParent = get(record, actual.name);
-      set(record, actual.name, remove ? null : parentRecord);
-      return oldParent;
+    return this._super.apply(this, arguments);
+  },
+
+  arrayContentDidChange: function(index, removed, added) {
+    this._super.apply(this, arguments);
+
+    var owner = get(this, 'owner'),
+        name = get(this, 'name');
+
+    if (!owner._suspendedAssociations) {
+      // This code is the second half of code that started in
+      // `arrayContentWillChange`. It gets or creates a change
+      // from the child object, and adds the current owner as
+      // the new parent.
+      for (var i=index; i<index+added; i++) {
+        var clientId = get(this, 'content').objectAt(i);
+
+        var change = DS.OneToManyChange.forChildAndParent(clientId, get(this, 'store'), {
+          parentType: owner.constructor,
+          hasManyName: name
+        });
+        change.hasManyName = name;
+
+        // The oldParent will be looked up in `sync` if it
+        // was not set by `belongsToWillChange`.
+        change.newParent = get(owner, 'clientId');
+        this._changesToSync.add(change);
+      }
+
+      // We wait until the array has finished being
+      // mutated before syncing the OneToManyChanges created
+      // in arrayContentWillChange, so that the array
+      // membership test in the sync() logic operates
+      // on the final results.
+      this._changesToSync.forEach(function(change) {
+        change.sync();
+      });
+      this._changesToSync.clear();
     }
   },
 
-  // Create a child record within the parentRecord
+  // Create a child record within the owner
   createRecord: function(hash, transaction) {
-    var parentRecord = get(this, 'parentRecord'),
-        store = get(parentRecord, 'store'),
+    var owner = get(this, 'owner'),
+        store = get(owner, 'store'),
         type = get(this, 'type'),
         record;
 
-    transaction = transaction || get(parentRecord, 'transaction');
+    transaction = transaction || get(owner, 'transaction');
 
     record = store.createRecord.call(store, type, hash, transaction);
     this.pushObject(record);
 
     return record;
+  },
+
+  /**
+    METHODS FOR USE BY INVERSE RELATIONSHIPS
+    ========================================
+
+    These methods exists so that belongsTo relationships can
+    set their inverses without causing an infinite loop.
+
+    This creates two APIs:
+
+    * the normal enumerable API, which is used by clients
+      of the `ManyArray` and triggers a change to inverse
+      `belongsTo` relationships.
+    * `removeFromContent` and `addToContent`, which are
+      used by inverse relationships and do not trigger a
+      change to `belongsTo` relationships.
+
+    Unlike the normal `addObject` and `removeObject` APIs,
+    these APIs manipulate the `content` array without
+    triggering side-effects.
+  */
+
+  /** @private */
+  removeFromContent: function(record) {
+    var clientId = get(record, 'clientId');
+    get(this, 'content').removeObject(clientId);
+  },
+
+  /** @private */
+  addToContent: function(record) {
+    var clientId = get(record, 'clientId');
+    get(this, 'content').addObject(clientId);
   }
 });
 
@@ -382,7 +488,7 @@ DS.ManyArray = DS.RecordArray.extend({
 
 (function() {
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt,
-    removeObject = Ember.EnumerableUtils.removeObject;
+    removeObject = Ember.EnumerableUtils.removeObject, forEach = Ember.EnumerableUtils.forEach;
 
 /**
   A transaction allows you to collect multiple records into a unit of work
@@ -421,7 +527,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt,
 
   Add records to a transaction using the `add()` method:
 
-      record = App.store.find(Person, 1);
+      record = App.store.find(App.Person, 1);
       transaction.add(record);
 
   Note that only records whose `isDirty` flag is `false` may be added
@@ -438,7 +544,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt,
   For example, instead of this:
 
     var transaction = store.transaction();
-    var person = Person.createRecord({ name: "Steve" });
+    var person = App.Person.createRecord({ name: "Steve" });
 
     // won't work because person is dirty
     transaction.add(person);
@@ -446,7 +552,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt,
   Call `createRecord()` on the transaction directly:
 
     var transaction = store.transaction();
-    transaction.createRecord(Person, { name: "Steve" });
+    transaction.createRecord(App.Person, { name: "Steve" });
 
   ### Asynchronous Commits
 
@@ -462,6 +568,8 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt,
   calling commit.
 */
 
+var arrayDefault = function() { return []; };
+
 DS.Transaction = Ember.Object.extend({
   /**
     @private
@@ -471,18 +579,14 @@ DS.Transaction = Ember.Object.extend({
   */
   init: function() {
     set(this, 'buckets', {
-      clean:    Ember.Map.create(),
-      created:  Ember.Map.create(),
-      updated:  Ember.Map.create(),
-      deleted:  Ember.Map.create(),
-      inflight: Ember.Map.create()
+      clean:    Ember.OrderedSet.create(),
+      created:  Ember.OrderedSet.create(),
+      updated:  Ember.OrderedSet.create(),
+      deleted:  Ember.OrderedSet.create(),
+      inflight: Ember.OrderedSet.create()
     });
 
-    this.dirtyRelationships = {
-      byChild: Ember.Map.create(),
-      byNewParent: Ember.Map.create(),
-      byOldParent: Ember.Map.create()
-    };
+    set(this, 'relationships', Ember.OrderedSet.create());
   },
 
   /**
@@ -501,6 +605,16 @@ DS.Transaction = Ember.Object.extend({
     return store.createRecord(type, hash, this);
   },
 
+  isEqualOrDefault: function(other) {
+    if (this === other || other === get(this, 'store.defaultTransaction')) {
+      return true;
+    }
+  },
+
+  isDefault: Ember.computed(function() {
+    return this === get(this, 'store.defaultTransaction');
+  }),
+
   /**
     Adds an existing record to this transaction. Only records without
     modficiations (i.e., records whose `isDirty` property is `false`)
@@ -509,15 +623,30 @@ DS.Transaction = Ember.Object.extend({
     @param {DS.Model} record the record to add to the transaction
   */
   add: function(record) {
-    // we could probably make this work if someone has a valid use case. Do you?
-    Ember.assert("Once a record has changed, you cannot move it into a different transaction", !get(record, 'isDirty'));
+    Ember.assert("You must pass a record into transaction.add()", record instanceof DS.Model);
 
     var recordTransaction = get(record, 'transaction'),
         defaultTransaction = get(this, 'store.defaultTransaction');
 
+    // Make `add` idempotent
+    if (recordTransaction === this) { return; }
+
+    // XXX it should be possible to move a dirty transaction from the default transaction
+
+    // we could probably make this work if someone has a valid use case. Do you?
+    Ember.assert("Once a record has changed, you cannot move it into a different transaction", !get(record, 'isDirty'));
+
     Ember.assert("Models cannot belong to more than one transaction at a time.", recordTransaction === defaultTransaction);
 
     this.adoptRecord(record);
+  },
+
+  relationshipBecameDirty: function(relationship) {
+    get(this, 'relationships').add(relationship);
+  },
+
+  relationshipBecameClean: function(relationship) {
+    get(this, 'relationships').remove(relationship);
   },
 
   /**
@@ -530,50 +659,44 @@ DS.Transaction = Ember.Object.extend({
     moved back to the store's default transaction.
   */
   commit: function() {
-    var self = this,
-        iterate;
-
-    iterate = function(bucketType, fn, binding) {
-      var dirty = self.bucketForType(bucketType);
-
-      dirty.forEach(function(type, records) {
-        if (records.isEmpty()) { return; }
-
-        var array = [];
-
-        records.forEach(function(record) {
-          record.send('willCommit');
-
-          if (get(record, 'isPending') === false) {
-            array.push(record);
-          }
-        });
-
-        fn.call(binding, type, array);
-      });
-    };
-
-    var commitDetails = {
-      updated: {
-        eachType: function(fn, binding) { iterate('updated', fn, binding); }
-      },
-
-      created: {
-        eachType: function(fn, binding) { iterate('created', fn, binding); }
-      },
-
-      deleted: {
-        eachType: function(fn, binding) { iterate('deleted', fn, binding); }
-      }
-    };
-
     var store = get(this, 'store');
     var adapter = get(store, '_adapter');
+    var defaultTransaction = get(store, 'defaultTransaction');
+
+    var iterate = function(records) {
+      var set = records.copy();
+      set.forEach(function (record) {
+        record.send('willCommit');
+      });
+      return set;
+    };
+
+    var relationships = get(this, 'relationships');
+
+    var commitDetails = {
+      created: iterate(this.bucketForType('created')),
+      updated: iterate(this.bucketForType('updated')),
+      deleted: iterate(this.bucketForType('deleted')),
+      relationships: relationships
+    };
+
+    if (this === defaultTransaction) {
+      set(store, 'defaultTransaction', store.transaction());
+    }
 
     this.removeCleanRecords();
 
-    if (adapter && adapter.commit) { adapter.commit(store, commitDetails); }
-    else { throw fmt("Adapter is either null or does not implement `commit` method", this); }
+    if (!commitDetails.created.isEmpty() || !commitDetails.updated.isEmpty() || !commitDetails.deleted.isEmpty() || !relationships.isEmpty()) {
+      if (adapter && adapter.commit) { adapter.commit(store, commitDetails); }
+      else { throw fmt("Adapter is either null or does not implement `commit` method", this); }
+    }
+
+    // Once we've committed the transaction, there is no need to
+    // keep the OneToManyChanges around. Destroy them so they
+    // can be garbage collected.
+    relationships.forEach(function(relationship) {
+      relationship.destroy();
+    });
   },
 
   /**
@@ -590,21 +713,16 @@ DS.Transaction = Ember.Object.extend({
     current transaction should not be used again.
   */
   rollback: function() {
-    var store = get(this, 'store'),
-        dirty;
-
     // Loop through all of the records in each of the dirty states
     // and initiate a rollback on them. As a side effect of telling
     // the record to roll back, it should also move itself out of
     // the dirty bucket and into the clean bucket.
     ['created', 'updated', 'deleted', 'inflight'].forEach(function(bucketType) {
-      dirty = this.bucketForType(bucketType);
-
-      dirty.forEach(function(type, records) {
-        records.forEach(function(record) {
-          record.send('rollback');
-        });
+      var records = this.bucketForType(bucketType);
+      forEach(records, function(record) {
+        record.send('rollback');
       });
+      records.clear();
     }, this);
 
     // Now that all records in the transaction are guaranteed to be
@@ -635,14 +753,11 @@ DS.Transaction = Ember.Object.extend({
     Removes all of the records in the transaction's clean bucket.
   */
   removeCleanRecords: function() {
-    var clean = this.bucketForType('clean'),
-        self = this;
-
-    clean.forEach(function(type, records) {
-      records.forEach(function(record) {
-        self.remove(record);
-      });
-    });
+    var clean = this.bucketForType('clean');
+    clean.forEach(function(record) {
+      this.remove(record);
+    }, this);
+    clean.clear();
   },
 
   /**
@@ -694,17 +809,7 @@ DS.Transaction = Ember.Object.extend({
     @param {String} bucketType one of `clean`, `created`, `updated`, or `deleted`
   */
   addToBucket: function(bucketType, record) {
-    var bucket = this.bucketForType(bucketType),
-        type = record.constructor;
-
-    var records = bucket.get(type);
-
-    if (!records) {
-      records = Ember.OrderedSet.create();
-      bucket.set(type, records);
-    }
-
-    records.add(record);
+    this.bucketForType(bucketType).add(record);
   },
 
   /**
@@ -715,118 +820,7 @@ DS.Transaction = Ember.Object.extend({
     @param {String} bucketType one of `clean`, `created`, `updated`, or `deleted`
   */
   removeFromBucket: function(bucketType, record) {
-    var bucket = this.bucketForType(bucketType),
-        type = record.constructor;
-
-    var records = bucket.get(type);
-    records.remove(record);
-  },
-
-  /**
-    @private
-
-    Called by a ManyArray when a new record is added to it. This
-    method will index a relationship description by the child
-    record, its old parent, and its new parent.
-
-    The store will provide this description to the adapter's
-    shouldCommit method, so it can determine whether any of
-    the records is pending another record. The store will also
-    provide a list of these descriptions to the adapter's commit
-    method.
-
-    @param {DS.Model} record the new child record
-    @param {DS.Model} oldParent the parent that the child is
-      moving from, or null
-    @param {DS.Model} newParent the parent that the child is
-      moving to, or null
-  */
-  relationshipBecameDirty: function(child, oldParent, newParent) {
-    var relationships = this.dirtyRelationships, relationship;
-
-    var relationshipsForChild = relationships.byChild.get(child),
-        possibleRelationship,
-        needsNewEntries = true;
-
-    // If the child has any existing dirty relationships in this
-    // transaction, we need to collapse the old relationship
-    // into the new one. For example, if we change the parent of
-    // a child record before saving, there is no need to save the
-    // record that was its parent temporarily.
-    if (relationshipsForChild) {
-
-      // Loop through all of the relationships we know about that
-      // contain the same child as the new relationship.
-      for (var i=0, l=relationshipsForChild.length; i<l; i++) {
-        relationship = relationshipsForChild[i];
-
-        // If the parent of the child record has changed, there is
-        // no need to update the old parent that had not yet been saved.
-        //
-        // This case is two changes in a record's parent:
-        //
-        //   A -> B
-        //   B -> C
-        //
-        // In this case, there is no need to remember the A->B
-        // change. We can collapse both changes into:
-        //
-        //   A -> C
-        //
-        // Another possible case is:
-        //
-        //   A -> B
-        //   B -> A
-        //
-        // In this case, we don't need to do anything. We can
-        // simply remove the original A->B change and call it
-        // a day.
-        if (relationship.newParent === oldParent) {
-          oldParent = relationship.oldParent;
-          this.removeRelationship(relationship);
-
-          // This is the case of A->B followed by B->A.
-          if (relationship.oldParent === newParent) {
-            needsNewEntries = false;
-          }
-        }
-      }
-    }
-
-    relationship = {
-      child: child,
-      oldParent: oldParent,
-      newParent: newParent
-    };
-
-    // If we didn't go A->B and then B->A, add new dirty relationship
-    // entries.
-    if (needsNewEntries) {
-      this.addRelationshipTo('byChild', child, relationship);
-      this.addRelationshipTo('byOldParent', oldParent, relationship);
-      this.addRelationshipTo('byNewParent', newParent, relationship);
-    }
-  },
-
-  removeRelationship: function(relationship) {
-    var relationships = this.dirtyRelationships;
-
-    removeObject(relationships.byOldParent.get(relationship.oldParent), relationship);
-    removeObject(relationships.byNewParent.get(relationship.newParent), relationship);
-    removeObject(relationships.byChild.get(relationship.child), relationship);
-  },
-
-  addRelationshipTo: function(type, record, description) {
-    var map = this.dirtyRelationships[type];
-
-    var relationships = map.get(record);
-
-    if (!relationships) {
-      relationships = [ description ];
-      map.set(record, relationships);
-    } else {
-      relationships.push(description);
-    }
+    this.bucketForType(bucketType).remove(record);
   },
 
   /**
@@ -857,6 +851,11 @@ DS.Transaction = Ember.Object.extend({
     this.addToBucket('inflight', record);
   },
 
+  recordIsMoving: function(kind, record) {
+    this.removeFromBucket(kind, record);
+    this.addToBucket('clean', record);
+  },
+
   /**
     @private
 
@@ -868,7 +867,6 @@ DS.Transaction = Ember.Object.extend({
   */
   recordBecameClean: function(kind, record) {
     this.removeFromBucket(kind, record);
-
     this.remove(record);
   }
 });
@@ -878,37 +876,180 @@ DS.Transaction = Ember.Object.extend({
 
 
 (function() {
+var classify = Ember.String.classify, get = Ember.get;
+
+/**
+@private
+
+  The Mappable mixin is designed for classes that would like to
+  behave as a map for configuration purposes.
+
+  For example, the DS.Adapter class can behave like a map, with
+  more semantic API, via the `map` API:
+
+    DS.Adapter.map('App.Person', { firstName: { keyName: 'FIRST' } });
+
+  Class configuration via a map-like API has a few common requirements
+  that differentiate it from the standard Ember.Map implementation.
+
+  First, values often are provided as strings that should be normalized
+  into classes the first time the configuration options are used.
+
+  Second, the values configured on parent classes should also be taken
+  into account.
+
+  Finally, setting the value of a key sometimes should merge with the
+  previous value, rather than replacing it.
+
+  This mixin provides a instance method, `createInstanceMapFor`, that
+  will reify all of the configuration options set on an instance's
+  constructor and provide it for the instance to use.
+
+  Classes can implement certain hooks that allow them to customize
+  the requirements listed above:
+
+  * `resolveMapConflict` - called when a value is set for an existing
+    value
+  * `transformMapKey` - allows a key name (for example, a global path
+    to a class) to be normalized
+  * `transformMapValue` - allows a value (for example, a class that
+    should be instantiated) to be normalized
+
+  Classes that implement this mixin should also implement a class
+  method built using the `generateMapFunctionFor` method:
+
+    DS.Adapter.reopenClass({
+      map: DS.Mappable.generateMapFunctionFor('attributes', function(key, newValue, map) {
+        var existingValue = map.get(key);
+
+        for (var prop in newValue) {
+          if (!newValue.hasOwnProperty(prop)) { continue; }
+          existingValue[prop] = newValue[prop];
+        }
+      })
+    });
+
+   The function passed to `generateMapFunctionFor` is invoked every time a
+   new value is added to the map.
+**/
+
+var resolveMapConflict = function(oldValue, newValue, mappingsKey) {
+  return oldValue;
+};
+
+var transformMapKey = function(key, value) {
+  return key;
+};
+
+var transformMapValue = function(key, value) {
+  return value;
+};
+
+DS._Mappable = Ember.Mixin.create({
+  createInstanceMapFor: function(mapName) {
+    var instanceMeta = Ember.metaPath(this, ['DS.Mappable'], true);
+
+    instanceMeta.values = instanceMeta.values || {};
+
+    if (instanceMeta.values[mapName]) { return instanceMeta.values[mapName]; }
+
+    var instanceMap = instanceMeta.values[mapName] = new Ember.Map();
+
+    var klass = this.constructor;
+
+    while (klass && klass !== DS.Store) {
+      this._copyMap(mapName, klass, instanceMap);
+      klass = klass.superclass;
+    }
+
+    instanceMeta.values[mapName] = instanceMap;
+    return instanceMap;
+  },
+
+  _copyMap: function(mapName, klass, instanceMap) {
+    var classMeta = Ember.metaPath(klass, ['DS.Mappable'], true);
+
+    var classMap = classMeta[mapName];
+    if (classMap) {
+      classMap.forEach(eachMap, this);
+    }
+
+    function eachMap(key, value) {
+      var transformedKey = (klass.transformMapKey || transformMapKey)(key, value);
+      var transformedValue = (klass.transformMapValue || transformMapValue)(key, value);
+
+      var oldValue = instanceMap.get(transformedKey);
+      var newValue = transformedValue;
+
+      if (oldValue) {
+        newValue = (this.constructor.resolveMapConflict || resolveMapConflict)(oldValue, newValue, mapName);
+      }
+
+      instanceMap.set(transformedKey, newValue);
+    }
+  },
+
+
+});
+
+DS._Mappable.generateMapFunctionFor = function(mapName, transform) {
+  return function(key, value) {
+    var meta = Ember.metaPath(this, ['DS.Mappable'], true);
+    var map = meta[mapName] || Ember.MapWithDefault.create({
+      defaultValue: function() { return {}; }
+    });
+
+    transform.call(this, key, value, map);
+
+    meta[mapName] = map;
+  };
+};
+
+})();
+
+
+
+(function() {
 /*globals Ember*/
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
-
-var DATA_PROXY = {
-  get: function(name) {
-    return this.savedData[name];
-  }
-};
 
 // These values are used in the data cache when clientIds are
 // needed but the underlying data has not yet been loaded by
 // the server.
 var UNLOADED = 'unloaded';
 var LOADING = 'loading';
+var MATERIALIZED = { materialized: true };
+var CREATED = { created: true };
 
 // Implementors Note:
 //
 //   The variables in this file are consistently named according to the following
 //   scheme:
 //
-//   * +id+ means an identifier managed by an external source, provided inside the
-//     data hash provided by that source.
+//   * +id+ means an identifier managed by an external source, provided inside
+//     the data provided by that source.
 //   * +clientId+ means a transient numerical identifier generated at runtime by
 //     the data store. It is important primarily because newly created objects may
 //     not yet have an externally generated id.
 //   * +type+ means a subclass of DS.Model.
 
+// Used by the store to normalize IDs entering the store.  Despite the fact
+// that developers may provide IDs as numbers (e.g., `store.find(Person, 1)`),
+// it is important that internally we use strings, since IDs may be serialized
+// and lose type information.  For example, Ember's router may put a record's
+// ID into the URL, and if we later try to deserialize that URL and find the
+// corresponding record, we will not know if it is a string or a number.
+var coerceId = function(id) {
+  return id+'';
+};
+
+var map = Ember.EnumerableUtils.map;
+
 /**
-  The store contains all of the hashes for records loaded from the server.
-  It is also responsible for creating instances of DS.Model when you request one
-  of these data hashes, so that they can be bound to in your Handlebars templates.
+  The store contains all of the data for records loaded from the server.
+  It is also responsible for creating instances of DS.Model that wraps
+  the individual data for a record, so that they can be bound to in your
+  Handlebars templates.
 
   Create a new store like this:
 
@@ -929,7 +1070,7 @@ var LOADING = 'loading';
     You can learn more about writing a custom adapter by reading the `DS.Adapter`
     documentation.
 */
-DS.Store = Ember.Object.extend({
+DS.Store = Ember.Object.extend(DS._Mappable, {
 
   /**
     Many methods can be invoked without specifying which store should be used.
@@ -955,22 +1096,34 @@ DS.Store = Ember.Object.extend({
     this.typeMaps = {};
     this.recordCache = [];
     this.clientIdToId = {};
+    this.clientIdToType = {};
+    this.clientIdToData = {};
     this.recordArraysByClientId = {};
+    this.relationshipChanges = {};
 
     // Internally, we maintain a map of all unloaded IDs requested by
-    // a ManyArray. As the adapter loads hashes into the store, the
+    // a ManyArray. As the adapter loads data into the store, the
     // store notifies any interested ManyArrays. When the ManyArray's
     // total number of loading records drops to zero, it becomes
     // `isLoaded` and fires a `didLoad` event.
     this.loadingRecordArrays = {};
 
     set(this, 'defaultTransaction', this.transaction());
-
-    return this._super();
   },
 
   /**
-    Returns a new transaction scoped to this store.
+    Returns a new transaction scoped to this store. This delegates
+    responsibility for invoking the adapter's commit mechanism to
+    a transaction.
+
+    Transaction are responsible for tracking changes to records
+    added to them, and supporting `commit` and `rollback`
+    functionality. Committing a transaction invokes the store's
+    adapter, while rolling back a transaction reverses all
+    changes made to records added to the transaction.
+
+    A store has an implicit (default) transaction, which tracks changes
+    made to records not explicitly added to a transaction.
 
     @see {DS.Transaction}
     @returns DS.Transaction
@@ -982,14 +1135,58 @@ DS.Store = Ember.Object.extend({
   /**
     @private
 
-    This is used only by the record's DataProxy. Do not use this directly.
-  */
-  dataForRecord: function(record) {
-    var type = record.constructor,
-        clientId = get(record, 'clientId'),
-        typeMap = this.typeMapFor(type);
+    Instructs the store to materialize the data for a given record.
 
-    return typeMap.cidToHash[clientId];
+    To materialize a record, the store first retrieves the opaque data that was
+    passed to either `load()` or `loadMany()`. Then, the data and the record
+    are passed to the adapter's `materialize()` method, which allows the adapter
+    to translate arbitrary data structures from the adapter into the normalized
+    form the record expects.
+
+    The adapter's `materialize()` method will invoke `materializeAttribute()`,
+    `materializeHasMany()` and `materializeBelongsTo()` on the record to
+    populate it with normalized values.
+
+    @param {DS.Model} record
+  */
+  materializeData: function(record) {
+    var clientId = get(record, 'clientId'),
+        cidToData = this.clientIdToData,
+        adapter = this.adapterForType(record.constructor),
+        data = cidToData[clientId];
+
+    cidToData[clientId] = MATERIALIZED;
+
+    // Ensures the record's data structures are setup
+    // before being populated by the adapter.
+    record.setupData();
+
+    if (data !== CREATED) {
+      // Instructs the adapter to extract information from the
+      // opaque data and materialize the record's attributes and
+      // relationships.
+      adapter.materialize(record, data);
+    }
+  },
+
+  /**
+    @private
+
+    Returns true if there is already a record for this clientId.
+
+    This is used to determine whether cleanup is required, so that
+    "changes" to unmaterialized records do not trigger mass
+    materialization.
+
+    For example, if a parent record in an association with a large
+    number of children is deleted, we want to avoid materializing
+    those children.
+
+    @param {String|Number} clientId
+    @return {Boolean}
+  */
+  recordIsMaterialized: function(clientId) {
+    return !!this.recordCache[clientId];
   },
 
   /**
@@ -1000,25 +1197,66 @@ DS.Store = Ember.Object.extend({
 
     @property {DS.Adapter|String}
   */
-  adapter: null,
+  adapter: 'DS.Adapter',
 
   /**
     @private
 
-    This property returns the adapter, after resolving a possible String.
+    Returns a JSON representation of the record using the adapter's
+    serialization strategy. This method exists primarily to enable
+    a record, which has access to its store (but not the store's
+    adapter) to provide a `serialize()` convenience.
+
+    The available options are:
+
+    * `includeId`: `true` if the record's ID should be included in
+      the JSON representation
+
+    @param {DS.Model} record the record to serialize
+    @param {Object} options an options hash
+  */
+  serialize: function(record, options) {
+    return this.adapterForType(record.constructor).serialize(record, options);
+  },
+
+  /**
+    @private
+
+    This property returns the adapter, after resolving a possible
+    property path.
+
+    If the supplied `adapter` was a class, or a String property
+    path resolved to a class, this property will instantiate the
+    class.
+
+    This property is cacheable, so the same instance of a specified
+    adapter class should be used for the lifetime of the store.
 
     @returns DS.Adapter
   */
   _adapter: Ember.computed(function() {
     var adapter = get(this, 'adapter');
     if (typeof adapter === 'string') {
-      return get(this, adapter, false) || get(window, adapter);
+      adapter = get(this, adapter, false) || get(Ember.lookup, adapter);
     }
-    return adapter;
-  }).property('adapter').cacheable(),
 
-  // A monotonically increasing number to be used to uniquely identify
-  // data hashes and records.
+    if (DS.Adapter.detect(adapter)) {
+      adapter = adapter.create();
+    }
+
+    return adapter;
+  }).property('adapter'),
+
+  /**
+    @private
+
+    A monotonically increasing number to be used to uniquely identify
+    data and records.
+
+    It starts at 1 so other parts of the code can test for truthiness
+    when provided a `clientId` instead of having to explicitly test
+    for undefined.
+  */
   clientIdCounter: 1,
 
   // .....................
@@ -1028,6 +1266,10 @@ DS.Store = Ember.Object.extend({
   /**
     Create a new record in the current store. The properties passed
     to this method are set on the newly created record.
+
+    Note: The third `transaction` property is for internal use only.
+    If you want to create a record inside of a given transaction,
+    use `transaction.createRecord()` instead of `store.createRecord()`.
 
     @param {subclass of DS.Model} type
     @param {Object} properties a hash of properties to set on the
@@ -1040,54 +1282,60 @@ DS.Store = Ember.Object.extend({
     // Create a new instance of the model `type` and put it
     // into the specified `transaction`. If no transaction is
     // specified, the default transaction will be used.
-    //
-    // NOTE: A `transaction` is specified when the
-    // `transaction.createRecord` API is used.
     var record = type._create({
       store: this
     });
 
     transaction = transaction || get(this, 'defaultTransaction');
+
+    // adoptRecord is an internal API that allows records to move
+    // into a transaction without assertions designed for app
+    // code. It is used here to ensure that regardless of new
+    // restrictions on the use of the public `transaction.add()`
+    // API, we will always be able to insert new records into
+    // their transaction.
     transaction.adoptRecord(record);
 
-    // Extract the primary key from the `properties` hash,
-    // based on the `primaryKey` for the model type.
-    var primaryKey = get(record, 'primaryKey'),
-        id = properties[primaryKey] || null;
+    // `id` is a special property that may not be a `DS.attr`
+    var id = properties.id;
 
     // If the passed properties do not include a primary key,
-    // give the adapter an opportunity to generate one.
+    // give the adapter an opportunity to generate one. Typically,
+    // client-side ID generators will use something like uuid.js
+    // to avoid conflicts.
     var adapter;
     if (Ember.none(id)) {
       adapter = get(this, 'adapter');
       if (adapter && adapter.generateIdForRecord) {
-        id = adapter.generateIdForRecord(this, record);
+        id = coerceId(adapter.generateIdForRecord(this, record));
         properties.id = id;
       }
     }
 
-    var hash = {}, clientId;
+    id = coerceId(id);
 
-    // Push the hash into the store. If present, associate the
-    // extracted `id` with the hash.
-    clientId = this.pushHash(hash, id, type);
-
-    record.send('didChangeData');
-
-    var recordCache = get(this, 'recordCache');
+    // Create a new `clientId` and associate it with the
+    // specified (or generated) `id`. Since we don't have
+    // any data for the server yet (by definition), store
+    // the sentinel value CREATED as the data for this
+    // clientId. If we see this value later, we will skip
+    // materialization.
+    var clientId = this.pushData(CREATED, id, type);
 
     // Now that we have a clientId, attach it to the record we
     // just created.
     set(record, 'clientId', clientId);
 
+    // Move the record out of its initial `empty` state into
+    // the `loaded` state.
+    record.loadedData();
+
     // Store the record we just created in the record cache for
     // this clientId.
-    recordCache[clientId] = record;
+    this.recordCache[clientId] = record;
 
     // Set the properties specified on the record.
     record.setProperties(properties);
-
-    this.updateRecordArrays(type, clientId, get(record, 'data'));
 
     return record;
   },
@@ -1102,7 +1350,16 @@ DS.Store = Ember.Object.extend({
     @param {DS.Model} record
   */
   deleteRecord: function(record) {
-    record.send('deleteRecord');
+    record.deleteRecord();
+  },
+
+  /**
+    For symmetry, a record can be unloaded via the store.
+
+    @param {DS.Model} record
+  */
+  unloadRecord: function(record) {
+    record.unloadRecord();
   },
 
   // ................
@@ -1110,13 +1367,12 @@ DS.Store = Ember.Object.extend({
   // ................
 
   /**
-    This is the main entry point into finding records. The first
-    parameter to this method is always a subclass of `DS.Model`.
+    This is the main entry point into finding records. The first parameter to
+    this method is always a subclass of `DS.Model`.
 
-    You can use the `find` method on a subclass of `DS.Model`
-    directly if your application only has one store. For
-    example, instead of `store.find(App.Person, 1)`, you could
-    say `App.Person.find(1)`.
+    You can use the `find` method on a subclass of `DS.Model` directly if your
+    application only has one store. For example, instead of
+    `store.find(App.Person, 1)`, you could say `App.Person.find(1)`.
 
     ---
 
@@ -1125,101 +1381,132 @@ DS.Store = Ember.Object.extend({
         store.find(App.Person, 1);
         App.Person.find(1);
 
-    If the record with that `id` had not previously been loaded,
-    the store will return an empty record immediately and ask
-    the adapter to find the data by calling the adapter's `find`
-    method.
+    If the record with that `id` had not previously been loaded, the store will
+    return an empty record immediately and ask the adapter to find the data by
+    calling the adapter's `find` method.
 
-    The `find` method will always return the same object for a
-    given type and `id`. To check whether the adapter has populated
-    a record, you can check its `isLoaded` property.
+    The `find` method will always return the same object for a given type and
+    `id`. To check whether the adapter has populated a record, you can check
+    its `isLoaded` property.
 
     ---
 
-    To find all records for a type, call `find` with no additional
-    parameters:
+    To find all records for a type, call `find` with no additional parameters:
 
         store.find(App.Person);
         App.Person.find();
 
-    This will return a `RecordArray` representing all known records
-    for the given type and kick off a request to the adapter's
-    `findAll` method to load any additional records for the type.
+    This will return a `RecordArray` representing all known records for the
+    given type and kick off a request to the adapter's `findAll` method to load
+    any additional records for the type.
 
-    The `RecordArray` returned by `find()` is live. If any more
-    records for the type are added at a later time through any
-    mechanism, it will automatically update to reflect the change.
+    The `RecordArray` returned by `find()` is live. If any more records for the
+    type are added at a later time through any mechanism, it will automatically
+    update to reflect the change.
 
     ---
 
-    To find a record by a query, call `find` with a hash as the
-    second parameter:
+    To find a record by a query, call `find` with a hash as the second
+    parameter:
 
         store.find(App.Person, { page: 1 });
         App.Person.find({ page: 1 });
 
-    This will return a `RecordArray` immediately, but it will always
-    be an empty `RecordArray` at first. It will call the adapter's
-    `findQuery` method, which will populate the `RecordArray` once
-    the server has returned results.
+    This will return a `RecordArray` immediately, but it will always be an
+    empty `RecordArray` at first. It will call the adapter's `findQuery`
+    method, which will populate the `RecordArray` once the server has returned
+    results.
 
-    You can check whether a query results `RecordArray` has loaded
-    by checking its `isLoaded` property.
+    You can check whether a query results `RecordArray` has loaded by checking
+    its `isLoaded` property.
   */
-  find: function(type, id, query) {
+  find: function(type, id) {
     if (id === undefined) {
       return this.findAll(type);
     }
 
-    if (query !== undefined) {
-      return this.findMany(type, id, query);
-    } else if (Ember.typeOf(id) === 'object') {
+    // We are passed a query instead of an id.
+    if (Ember.typeOf(id) === 'object') {
       return this.findQuery(type, id);
     }
 
-    if (Ember.isArray(id)) {
-      return this.findMany(type, id);
-    }
-
-    var clientId = this.typeMapFor(type).idToCid[id];
-
-    return this.findByClientId(type, clientId, id);
+    return this.findById(type, coerceId(id));
   },
 
-  findByClientId: function(type, clientId, id) {
-    var recordCache = get(this, 'recordCache'),
-        dataCache, record;
+  /**
+    @private
 
-    // If there is already a clientId assigned for this
-    // type/id combination, try to find an existing
-    // record for that id and return. Otherwise,
-    // materialize a new record and set its data to the
-    // value we already have.
-    if (clientId !== undefined) {
-      record = recordCache[clientId];
+    This method returns a record for a given type and id combination.
 
-      if (!record) {
-        // create a new instance of the model type in the
-        // 'isLoading' state
-        record = this.materializeRecord(type, clientId);
+    If the store has never seen this combination of type and id before, it
+    creates a new `clientId` with the LOADING sentinel and asks the adapter to
+    load the data.
 
-        dataCache = this.typeMapFor(type).cidToHash;
+    If the store has seen the combination, this method delegates to
+    `findByClientId`.
+  */
+  findById: function(type, id) {
+    var clientId = this.typeMapFor(type).idToCid[id];
 
-        if (typeof dataCache[clientId] === 'object') {
-          record.send('didChangeData');
-        }
-      }
-    } else {
-      clientId = this.pushHash(LOADING, id, type);
+    if (clientId) {
+      return this.findByClientId(type, clientId);
+    }
 
+    clientId = this.pushData(LOADING, id, type);
+
+    // create a new instance of the model type in the
+    // 'isLoading' state
+    var record = this.materializeRecord(type, clientId, id);
+
+    // let the adapter set the data, possibly async
+    var adapter = this.adapterForType(type);
+    if (adapter && adapter.find) { adapter.find(this, type, id); }
+    else { throw "Adapter is either null or does not implement `find` method"; }
+
+    return record;
+  },
+
+  /**
+    @private
+
+    This method returns a record for a given clientId.
+
+    If there is no record object yet for the clientId, this method materializes
+    a new record object. This allows adapters to eagerly load large amounts of
+    data into the store, and avoid incurring the cost to create the objects
+    until they are requested.
+
+    Several parts of Ember Data call this method:
+
+    * findById, if a clientId already exists for a given type and
+      id combination
+    * OneToManyChange, which is backed by clientIds, when getChild,
+      getOldParent or getNewParent are called
+    * RecordArray, which is backed by clientIds, when an object at
+      a particular index is looked up
+
+    In short, it's a convenient way to get a record for a known
+    clientId, materializing it if necessary.
+
+    @param {Class} type
+    @param {Number|String} clientId
+  */
+  findByClientId: function(type, clientId) {
+    var cidToData, record, id;
+
+    record = this.recordCache[clientId];
+
+    if (!record) {
       // create a new instance of the model type in the
       // 'isLoading' state
+      id = this.clientIdToId[clientId];
       record = this.materializeRecord(type, clientId, id);
 
-      // let the adapter set the data, possibly async
-      var adapter = get(this, '_adapter');
-      if (adapter && adapter.find) { adapter.find(this, type, id); }
-      else { throw fmt("Adapter is either null or does not implement `find` method", this); }
+      cidToData = this.clientIdToData;
+
+      if (typeof cidToData[clientId] === 'object') {
+        record.loadedData();
+      }
     }
 
     return record;
@@ -1236,15 +1523,14 @@ DS.Store = Ember.Object.extend({
   */
   neededClientIds: function(type, clientIds) {
     var neededClientIds = [],
-        typeMap = this.typeMapFor(type),
-        dataCache = typeMap.cidToHash,
+        cidToData = this.clientIdToData,
         clientId;
 
     for (var i=0, l=clientIds.length; i<l; i++) {
       clientId = clientIds[i];
-      if (dataCache[clientId] === UNLOADED) {
+      if (cidToData[clientId] === UNLOADED) {
         neededClientIds.push(clientId);
-        dataCache[clientId] = LOADING;
+        cidToData[clientId] = LOADING;
       }
     }
 
@@ -1280,15 +1566,15 @@ DS.Store = Ember.Object.extend({
   fetchMany: function(type, clientIds) {
     var clientIdToId = this.clientIdToId;
 
-    var neededIds = Ember.EnumerableUtils.map(clientIds, function(clientId) {
+    var neededIds = map(clientIds, function(clientId) {
       return clientIdToId[clientId];
     });
 
     if (!neededIds.length) { return; }
 
-    var adapter = get(this, '_adapter');
+    var adapter = this.adapterForType(type);
     if (adapter && adapter.findMany) { adapter.findMany(this, type, neededIds); }
-    else { throw fmt("Adapter is either null or does not implement `findMany` method", this); }
+    else { throw "Adapter is either null or does not implement `findMany` method"; }
   },
 
   /**
@@ -1311,7 +1597,7 @@ DS.Store = Ember.Object.extend({
     * ask the adapter to load the unloaded elements, by invoking
       findMany with the still-unloaded IDs.
   */
-  findMany: function(type, ids) {
+  findMany: function(type, ids, record, relationship) {
     // 1. Convert ids to client ids
     // 2. Determine which of the client ids need to be loaded
     // 3. Create a new ManyArray whose content is ALL of the clientIds
@@ -1321,19 +1607,34 @@ DS.Store = Ember.Object.extend({
     // 6. Ask the adapter to load the records for the unloaded clientIds (but
     //    convert them back to ids)
 
+    if (!Ember.isArray(ids)) {
+      var adapter = this.adapterForType(type);
+      if (adapter && adapter.findAssociation) { adapter.findAssociation(this, record, relationship, ids); }
+      else { throw fmt("Adapter is either null or does not implement `findMany` method", this); }
+
+      return this.createManyArray(type, Ember.A());
+    }
+
+    ids = map(ids, function(id) { return coerceId(id); });
     var clientIds = this.clientIdsForIds(type, ids);
 
     var neededClientIds = this.neededClientIds(type, clientIds),
         manyArray = this.createManyArray(type, Ember.A(clientIds)),
-        loadedCount = clientIds.length - neededClientIds.length,
         loadingRecordArrays = this.loadingRecordArrays,
         clientId, i, l;
 
-    manyArray.send('loadedRecords', loadedCount);
+    // Start the decrementing counter on the ManyArray at the number of
+    // records we need to load from the adapter
+    manyArray.loadingRecordsCount(neededClientIds.length);
 
     if (neededClientIds.length) {
       for (i=0, l=neededClientIds.length; i<l; i++) {
         clientId = neededClientIds[i];
+
+        // keep track of the record arrays that a given loading record
+        // is part of. This way, if the same record is in multiple
+        // ManyArrays, all of their loading records counters will be
+        // decremented when the adapter provides the data.
         if (loadingRecordArrays[clientId]) {
           loadingRecordArrays[clientId].push(manyArray);
         } else {
@@ -1342,36 +1643,133 @@ DS.Store = Ember.Object.extend({
       }
 
       this.fetchMany(type, neededClientIds);
+    } else {
+      // all requested records are available
+      manyArray.set('isLoaded', true);
     }
 
     return manyArray;
   },
 
+  /**
+    @private
+
+    This method delegates a query to the adapter. This is the one place where
+    adapter-level semantics are exposed to the application.
+
+    Exposing queries this way seems preferable to creating an abstract query
+    language for all server-side queries, and then require all adapters to
+    implement them.
+
+    @param {Class} type
+    @param {Object} query an opaque query to be used by the adapter
+    @return {DS.AdapterPopulatedRecordArray}
+  */
   findQuery: function(type, query) {
-    var array = DS.AdapterPopulatedRecordArray.create({ type: type, content: Ember.A([]), store: this });
-    var adapter = get(this, '_adapter');
+    var array = DS.AdapterPopulatedRecordArray.create({ type: type, query: query, content: Ember.A([]), store: this });
+    var adapter = this.adapterForType(type);
     if (adapter && adapter.findQuery) { adapter.findQuery(this, type, query, array); }
-    else { throw fmt("Adapter is either null or does not implement `findQuery` method", this); }
+    else { throw "Adapter is either null or does not implement `findQuery` method"; }
     return array;
   },
 
-  findAll: function(type) {
+  /**
+    @private
 
+    This method returns an array of all records adapter can find.
+    It triggers the adapter's `findAll` method to give it an opportunity to populate
+    the array with records of that type.
+
+    @param {Class} type
+    @return {DS.AdapterPopulatedRecordArray}
+  */
+  findAll: function(type) {
+    var array = this.all(type);
+    this.fetchAll(type, array);
+    return array;
+  },
+
+  /**
+    @private
+  */
+  fetchAll: function(type, array) {
+    var sinceToken = this.typeMapFor(type).sinceToken,
+        adapter = this.adapterForType(type);
+
+    set(array, 'isUpdating', true);
+
+    if (adapter && adapter.findAll) { adapter.findAll(this, type, sinceToken); }
+    else { throw "Adapter is either null or does not implement `findAll` method"; }
+  },
+
+  /**
+  */
+  sinceForType: function(type, sinceToken) {
+    this.typeMapFor(type).sinceToken = sinceToken;
+  },
+
+  /**
+  */
+  didUpdateAll: function(type) {
+    var findAllCache = this.typeMapFor(type).findAllCache;
+    set(findAllCache, 'isUpdating', false);
+  },
+
+  /**
+    This method returns a filtered array that contains all of the known records
+    for a given type.
+
+    Note that because it's just a filter, it will have any locally
+    created records of the type.
+
+    Also note that multiple calls to `all` for a given type will always
+    return the same RecordArray.
+
+    @param {Class} type
+    @return {DS.RecordArray}
+  */
+  all: function(type) {
     var typeMap = this.typeMapFor(type),
         findAllCache = typeMap.findAllCache;
 
     if (findAllCache) { return findAllCache; }
 
-    var array = DS.RecordArray.create({ type: type, content: Ember.A([]), store: this });
+    var array = DS.RecordArray.create({ type: type, content: Ember.A([]), store: this, isLoaded: true });
     this.registerRecordArray(array, type);
-
-    var adapter = get(this, '_adapter');
-    if (adapter && adapter.findAll) { adapter.findAll(this, type); }
 
     typeMap.findAllCache = array;
     return array;
   },
 
+  /**
+    Takes a type and filter function, and returns a live RecordArray that
+    remains up to date as new records are loaded into the store or created
+    locally.
+
+    The callback function takes a materialized record, and returns true
+    if the record should be included in the filter and false if it should
+    not.
+
+    The filter function is called once on all records for the type when
+    it is created, and then once on each newly loaded or created record.
+
+    If any of a record's properties change, or if it changes state, the
+    filter function will be invoked again to determine whether it should
+    still be in the array.
+
+    Note that the existence of a filter on a type will trigger immediate
+    materialization of all loaded data for a given type, so you might
+    not want to use filters for a type if you are loading many records
+    into the store, many of which are not active at any given time.
+
+    In this scenario, you might want to consider filtering the raw
+    data before loading it into the store.
+
+    @param {Class} type
+    @param {Function} filter
+
+    @return {DS.FilteredRecordArray}
+  */
   filter: function(type, query, filter) {
     // allow an optional server query
     if (arguments.length === 3) {
@@ -1387,6 +1785,9 @@ DS.Store = Ember.Object.extend({
     return array;
   },
 
+  /**
+    TODO: What is this method trying to do?
+  */
   recordIsLoaded: function(type, id) {
     return !Ember.none(this.typeMapFor(type).idToCid[id]);
   },
@@ -1395,9 +1796,23 @@ DS.Store = Ember.Object.extend({
   // . UPDATING .
   // ............
 
-  hashWasUpdated: function(type, clientId, record) {
-    // Because hash updates are invoked at the end of the run loop,
-    // it is possible that a record might be deleted after its hash
+  /**
+    @private
+
+    If the adapter updates attributes or acknowledges creation
+    or deletion, the record will notify the store to update its
+    membership in any filters.
+
+    To avoid thrashing, this method is invoked only once per
+    run loop per record.
+
+    @param {Class} type
+    @param {Number|String} clientId
+    @param {DS.Model} record
+  */
+  dataWasUpdated: function(type, clientId, record) {
+    // Because data updates are invoked at the end of the run loop,
+    // it is possible that a record might be deleted after its data
     // has been modified and this method was scheduled to be called.
     //
     // If that's the case, the record would have already been removed
@@ -1406,126 +1821,377 @@ DS.Store = Ember.Object.extend({
     // give us any more trouble after this.
 
     if (get(record, 'isDeleted')) { return; }
-    this.updateRecordArrays(type, clientId, get(record, 'data'));
+
+    var cidToData = this.clientIdToData,
+        data = cidToData[clientId];
+
+    if (typeof data === "object") {
+      this.updateRecordArrays(type, clientId);
+    }
   },
 
   // ..............
   // . PERSISTING .
   // ..............
 
+  /**
+    This method delegates committing to the store's implicit
+    transaction.
+
+    Calling this method is essentially a request to persist
+    any changes to records that were not explicitly added to
+    a transaction.
+  */
   commit: function() {
-    var defaultTransaction = get(this, 'defaultTransaction');
-    set(this, 'defaultTransaction', this.transaction());
-
-    defaultTransaction.commit();
+    get(this, 'defaultTransaction').commit();
   },
 
-  didUpdateRecords: function(array, hashes) {
-    if (hashes) {
-      array.forEach(function(record, idx) {
-        this.didUpdateRecord(record, hashes[idx]);
-      }, this);
+  /**
+    Adapters should call this method if they would like to acknowledge
+    that all changes related to a record (other than relationship
+    changes) have persisted.
+
+    Because relationship changes affect multiple records, the adapter
+    is responsible for acknowledging the change to the relationship
+    directly (using `store.didUpdateRelationship`) when all aspects
+    of the relationship change have persisted.
+
+    It can be called for created, deleted or updated records.
+
+    If the adapter supplies new data, that data will become the new
+    canonical data for the record. That will result in blowing away
+    all local changes and rematerializing the record with the new
+    data (the "sledgehammer" approach).
+
+    Alternatively, if the adapter does not supply new data, the record
+    will collapse all local changes into its saved data. Subsequent
+    rollbacks of the record will roll back to this point.
+
+    If an adapter is acknowledging receipt of a newly created record
+    that did not generate an id in the client, it *must* either
+    provide data or explicitly invoke `store.didReceiveId` with
+    the server-provided id.
+
+    Note that an adapter may not supply new data when acknowledging
+    a deleted record.
+
+    @see DS.Store#didUpdateRelationship
+
+    @param {DS.Model} record the in-flight record
+    @param {Object} data optional data (see above)
+  */
+  didSaveRecord: function(record, data) {
+    record.adapterDidCommit();
+
+    if (data) {
+      this.updateId(record, data);
+      this.updateRecordData(record, data);
     } else {
-      array.forEach(function(record) {
-        this.didUpdateRecord(record);
-      }, this);
+      this.didUpdateAttributes(record);
     }
   },
 
-  didUpdateRecord: function(record, hash) {
-    if (hash) {
-      var clientId = get(record, 'clientId'),
-          dataCache = this.typeMapFor(record.constructor).cidToHash;
+  /**
+    For convenience, if an adapter is performing a bulk commit, it can also
+    acknowledge all of the records at once.
 
-      dataCache[clientId] = hash;
-      record.send('didChangeData');
-      record.hashWasUpdated();
-    } else {
-      record.send('didSaveData');
-    }
+    If the adapter supplies an array of data, they must be in the same order as
+    the array of records passed in as the first parameter.
 
-    record.send('didCommit');
+    @param {#forEach} list a list of records whose changes the
+      adapter is acknowledging. You can pass any object that
+      has an ES5-like `forEach` method, including the
+      `OrderedSet` objects passed into the adapter at commit
+      time.
+    @param {Array[Object]} dataList an Array of data. This
+      parameter must be an integer-indexed Array-like.
+  */
+  didSaveRecords: function(list, dataList) {
+    var i = 0;
+    list.forEach(function(record) {
+      this.didSaveRecord(record, dataList && dataList[i++]);
+    }, this);
   },
 
-  didDeleteRecords: function(array) {
-    array.forEach(function(record) {
-      record.send('didCommit');
-    });
-  },
+  /**
+    This method allows the adapter to specify that a record
+    could not be saved because it had backend-supplied validation
+    errors.
 
-  didDeleteRecord: function(record) {
-    record.send('didCommit');
-  },
+    The errors object must have keys that correspond to the
+    attribute names. Once each of the specified attributes have
+    changed, the record will automatically move out of the
+    invalid state and be ready to commit again.
 
-  _didCreateRecord: function(record, hash, typeMap, clientId, primaryKey) {
-    var recordData = get(record, 'data'), id, changes;
+    TODO: We should probably automate the process of converting
+    server names to attribute names using the existing serializer
+    infrastructure.
 
-    if (hash) {
-      typeMap.cidToHash[clientId] = hash;
-
-      // If the server returns a hash, we assume that the server's version
-      // of the data supercedes the local changes.
-      record.beginPropertyChanges();
-      record.send('didChangeData');
-      recordData.adapterDidUpdate();
-      record.hashWasUpdated();
-      record.endPropertyChanges();
-
-      id = hash[primaryKey];
-
-      typeMap.idToCid[id] = clientId;
-      this.clientIdToId[clientId] = id;
-    } else {
-      recordData.commit();
-    }
-
-    record.send('didCommit');
-  },
-
-
-  didCreateRecords: function(type, array, hashes) {
-    var primaryKey = type.proto().primaryKey,
-        typeMap = this.typeMapFor(type),
-        clientId;
-
-    for (var i=0, l=get(array, 'length'); i<l; i++) {
-      var record = array[i], hash = hashes[i];
-      clientId = get(record, 'clientId');
-
-      this._didCreateRecord(record, hash, typeMap, clientId, primaryKey);
-    }
-  },
-
-  didCreateRecord: function(record, hash) {
-    var type = record.constructor,
-        typeMap = this.typeMapFor(type),
-        clientId, primaryKey;
-
-    // The hash is optional, but if it is not provided, the client must have
-    // provided a primary key.
-
-    primaryKey = type.proto().primaryKey;
-
-    // TODO: Make Ember.assert more flexible
-    if (hash) {
-      Ember.assert("The server must provide a primary key: " + primaryKey, get(hash, primaryKey));
-    } else {
-      Ember.assert("The server did not return data, and you did not create a primary key (" + primaryKey + ") on the client", get(get(record, 'data'), primaryKey));
-    }
-
-    clientId = get(record, 'clientId');
-
-    this._didCreateRecord(record, hash, typeMap, clientId, primaryKey);
-  },
-
+    @param {DS.Model} record
+    @param {Object} errors
+  */
   recordWasInvalid: function(record, errors) {
-    record.send('becameInvalid', errors);
+    record.adapterDidInvalidate(errors);
+  },
+
+  /**
+     This method allows the adapter to specify that a record
+     could not be saved because the server returned an unhandled
+     error.
+
+     @param {DS.Model} record
+  */
+  recordWasError: function(record) {
+    record.adapterDidError();
+  },
+
+  /**
+    This is a lower-level API than `didSaveRecord` that allows an
+    adapter to acknowledge the persistence of a single attribute.
+
+    This is useful if an adapter needs to make multiple asynchronous
+    calls to fully persist a record. The record will keep track of
+    which attributes and relationships are still outstanding and
+    automatically move into the `saved` state once the adapter has
+    acknowledged everything.
+
+    If a value is provided, it clobbers the locally specified value.
+    Otherwise, the local value becomes the record's last known
+    saved value (which is used when rolling back a record).
+
+    Note that the specified attributeName is the normalized name
+    specified in the definition of the `DS.Model`, not a key in
+    the server-provided data.
+
+    Also note that the adapter is responsible for performing any
+    transformations on the value using the serializer API.
+
+    @param {DS.Model} record
+    @param {String} attributeName
+    @param {Object} value
+  */
+  didUpdateAttribute: function(record, attributeName, value) {
+    record.adapterDidUpdateAttribute(attributeName, value);
+  },
+
+  /**
+    This method allows an adapter to acknowledge persistence
+    of all attributes of a record but not relationships or
+    other factors.
+
+    It loops through the record's defined attributes and
+    notifies the record that they are all acknowledged.
+
+    This method does not take optional values, because
+    the adapter is unlikely to have a hash of normalized
+    keys and transformed values, and instead of building
+    one up, it should just call `didUpdateAttribute` as
+    needed.
+
+    This method is intended as a middle-ground between
+    `didSaveRecord`, which acknowledges all changes to
+    a record, and `didUpdateAttribute`, which allows an
+    adapter fine-grained control over updates.
+
+    @param {DS.Model} record
+  */
+  didUpdateAttributes: function(record) {
+    record.eachAttribute(function(attributeName) {
+      this.didUpdateAttribute(record, attributeName);
+    }, this);
+  },
+
+  /**
+    This allows an adapter to acknowledge that it has saved all
+    necessary aspects of a relationship change.
+
+    This is separated from acknowledging the record itself
+    (via `didSaveRecord`) because a relationship change can
+    involve as many as three separate records. Records should
+    only move out of the in-flight state once the server has
+    acknowledged all of their relationships, and this differs
+    based upon the adapter's semantics.
+
+    There are three basic scenarios by which an adapter can
+    save a relationship.
+
+    ### Foreign Key
+
+    An adapter can save all relationship changes by updating
+    a foreign key on the child record. If it does this, it
+    should acknowledge the changes when the child record is
+    saved.
+
+        record.eachAssociation(function(name, meta) {
+          if (meta.kind === 'belongsTo') {
+            store.didUpdateRelationship(record, name);
+          }
+        });
+
+        store.didSaveRecord(record, data);
+
+    ### Embedded in Parent
+
+    An adapter can save one-to-many relationships by embedding
+    IDs (or records) in the parent object. In this case, the
+    relationship is not considered acknowledged until both the
+    old parent and new parent have acknowledged the change.
+
+    In this case, the adapter should keep track of the old
+    parent and new parent, and acknowledge the relationship
+    change once both have acknowledged. If one of the two
+    sides does not exist (e.g. the new parent does not exist
+    because of nulling out the belongs-to relationship),
+    the adapter should acknowledge the relationship once
+    the other side has acknowledged.
+
+    ### Separate Entity
+
+    An adapter can save relationships as separate entities
+    on the server. In this case, they should acknowledge
+    the relationship as saved once the server has
+    acknowledged the entity.
+
+    @see DS.Store#didSaveRecord
+
+    @param {DS.Model} record
+    @param {DS.Model} relationshipName
+  */
+  didUpdateRelationship: function(record, relationshipName) {
+    var relationship = this.relationshipChangeFor(get(record, 'clientId'), relationshipName);
+    if (relationship) { relationship.adapterDidUpdate(); }
+  },
+
+  materializeHasMany: function(record, name, ids) {
+    record.materializeHasMany(name, ids);
+    record.adapterDidUpdateHasMany(name);
+  },
+
+  /**
+    This allows an adapter to acknowledge all relationship changes
+    for a given record.
+
+    Like `didUpdateAttributes`, this is intended as a middle ground
+    between `didSaveRecord` and fine-grained control via the
+    `didUpdateRelationship` API.
+  */
+  didUpdateRelationships: function(record) {
+    var changes = this.relationshipChangesFor(get(record, 'clientId'));
+
+    for (var name in changes) {
+      if (!changes.hasOwnProperty(name)) { continue; }
+      changes[name].adapterDidUpdate();
+    }
+  },
+
+  /**
+    When acknowledging the creation of a locally created record,
+    adapters must supply an id (if they did not implement
+    `generateIdForRecord` to generate an id locally).
+
+    If an adapter does not use `didSaveRecord` and supply a hash
+    (for example, if it needs to make multiple HTTP requests to
+    create and then update the record), it will need to invoke
+    `didReceiveId` with the backend-supplied id.
+
+    When not using `didSaveRecord`, an adapter will need to
+    invoke:
+
+    * didReceiveId (unless the id was generated locally)
+    * didCreateRecord
+    * didUpdateAttribute(s)
+    * didUpdateRelationship(s)
+
+    @param {DS.Model} record
+    @param {Number|String} id
+  */
+  didReceiveId: function(record, id) {
+    var typeMap = this.typeMapFor(record.constructor),
+        clientId = get(record, 'clientId'),
+        oldId = get(record, 'id');
+
+    Ember.assert("An adapter cannot assign a new id to a record that already has an id. " + record + " had id: " + oldId + " and you tried to update it with " + id + ". This likely happened because your server returned data in response to a find or update that had a different id than the one you sent.", oldId === undefined || id === oldId);
+
+    typeMap.idToCid[id] = clientId;
+    this.clientIdToId[clientId] = id;
+  },
+
+  /**
+    @private
+
+    This method re-indexes the data by its clientId in the store
+    and then notifies the record that it should rematerialize
+    itself.
+
+    @param {DS.Model} record
+    @param {Object} data
+  */
+  updateRecordData: function(record, data) {
+    var clientId = get(record, 'clientId'),
+        cidToData = this.clientIdToData;
+
+    cidToData[clientId] = data;
+
+    record.didChangeData();
+  },
+
+  /**
+    @private
+
+    If an adapter invokes `didSaveRecord` with data, this method
+    extracts the id from the supplied data (using the adapter's
+    `extractId()` method) and indexes the clientId with that id.
+
+    @param {DS.Model} record
+    @param {Object} data
+  */
+  updateId: function(record, data) {
+    var typeMap = this.typeMapFor(record.constructor),
+        clientId = get(record, 'clientId'),
+        oldId = get(record, 'id'),
+        type = record.constructor,
+        id = this.preprocessData(type, data);
+
+    Ember.assert("An adapter cannot assign a new id to a record that already has an id. " + record + " had id: " + oldId + " and you tried to update it with " + id + ". This likely happened because your server returned data in response to a find or update that had a different id than the one you sent.", oldId === undefined || id === oldId);
+
+    typeMap.idToCid[id] = clientId;
+    this.clientIdToId[clientId] = id;
+  },
+
+  /**
+    @private
+
+    This method receives opaque data provided by the adapter and
+    preprocesses it, returning an ID.
+
+    The actual preprocessing takes place in the adapter. If you would
+    like to change the default behavior, you should override the
+    appropriate hooks in `DS.Serializer`.
+
+    @see {DS.Serializer}
+    @return {String} id the id represented by the data
+  */
+  preprocessData: function(type, data) {
+    this.adapterForType(type).extractEmbeddedData(this, type, data);
+    return this.adapterForType(type).extractId(type, data);
   },
 
   // .................
   // . RECORD ARRAYS .
   // .................
 
+  /**
+    @private
+
+    Register a RecordArray for a given type to be backed by
+    a filter function. This will cause the array to update
+    automatically when records of that type change attribute
+    values or states.
+
+    @param {DS.RecordArray} array
+    @param {Class} type
+    @param {Function} filter
+  */
   registerRecordArray: function(array, type, filter) {
     var recordArrays = this.typeMapFor(type).recordArrays;
 
@@ -1534,6 +2200,19 @@ DS.Store = Ember.Object.extend({
     this.updateRecordArrayFilter(array, type, filter);
   },
 
+  /**
+    @private
+
+    Create a `DS.ManyArray` for a type and list of clientIds
+    and index the `ManyArray` under each clientId. This allows
+    us to efficiently remove records from `ManyArray`s when
+    they are deleted.
+
+    @param {Class} type
+    @param {Array} clientIds
+
+    @return {DS.ManyArray}
+  */
   createManyArray: function(type, clientIds) {
     var array = DS.ManyArray.create({ type: type, content: clientIds, store: this });
 
@@ -1545,67 +2224,95 @@ DS.Store = Ember.Object.extend({
     return array;
   },
 
+  /**
+    @private
+
+    This method is invoked if the `filterFunction` property is
+    changed on a `DS.FilteredRecordArray`.
+
+    It essentially re-runs the filter from scratch. This same
+    method is invoked when the filter is created in th first place.
+  */
   updateRecordArrayFilter: function(array, type, filter) {
     var typeMap = this.typeMapFor(type),
-        dataCache = typeMap.cidToHash,
+        cidToData = this.clientIdToData,
         clientIds = typeMap.clientIds,
-        clientId, hash, proxy;
-
-    var recordCache = get(this, 'recordCache'),
-        foundRecord,
-        record;
+        clientId, data, shouldFilter, record;
 
     for (var i=0, l=clientIds.length; i<l; i++) {
       clientId = clientIds[i];
-      foundRecord = false;
+      shouldFilter = false;
 
-      hash = dataCache[clientId];
-      if (typeof hash === 'object') {
-        if (record = recordCache[clientId]) {
-          if (!get(record, 'isDeleted')) {
-            proxy = get(record, 'data');
-            foundRecord = true;
-          }
+      data = cidToData[clientId];
+
+      if (typeof data === 'object') {
+        if (record = this.recordCache[clientId]) {
+          if (!get(record, 'isDeleted')) { shouldFilter = true; }
         } else {
-          DATA_PROXY.savedData = hash;
-          proxy = DATA_PROXY;
-          foundRecord = true;
+          shouldFilter = true;
         }
 
-        if (foundRecord) { this.updateRecordArray(array, filter, type, clientId, proxy); }
+        if (shouldFilter) {
+          this.updateRecordArray(array, filter, type, clientId);
+        }
       }
     }
   },
 
-  updateRecordArrays: function(type, clientId, dataProxy) {
+  /**
+    @private
+
+    This method is invoked whenever data is loaded into the store
+    by the adapter or updated by the adapter, or when an attribute
+    changes on a record.
+
+    It updates all filters that a record belongs to.
+
+    To avoid thrashing, it only runs once per run loop per record.
+
+    @param {Class} type
+    @param {Number|String} clientId
+  */
+  updateRecordArrays: function(type, clientId) {
     var recordArrays = this.typeMapFor(type).recordArrays,
         filter;
 
     recordArrays.forEach(function(array) {
       filter = get(array, 'filterFunction');
-      this.updateRecordArray(array, filter, type, clientId, dataProxy);
+      this.updateRecordArray(array, filter, type, clientId);
     }, this);
 
     // loop through all manyArrays containing an unloaded copy of this
     // clientId and notify them that the record was loaded.
-    var manyArrays = this.loadingRecordArrays[clientId], manyArray;
+    var manyArrays = this.loadingRecordArrays[clientId];
 
     if (manyArrays) {
       for (var i=0, l=manyArrays.length; i<l; i++) {
-        manyArrays[i].send('loadedRecords', 1);
+        manyArrays[i].loadedRecord();
       }
 
       this.loadingRecordArrays[clientId] = null;
     }
   },
 
-  updateRecordArray: function(array, filter, type, clientId, dataProxy) {
-    var shouldBeInArray;
+  /**
+    @private
+
+    Update an individual filter.
+
+    @param {DS.FilteredRecordArray} array
+    @param {Function} filter
+    @param {Class} type
+    @param {Number|String} clientId
+  */
+  updateRecordArray: function(array, filter, type, clientId) {
+    var shouldBeInArray, record;
 
     if (!filter) {
       shouldBeInArray = true;
     } else {
-      shouldBeInArray = filter(dataProxy);
+      record = this.findByClientId(type, clientId);
+      shouldBeInArray = filter(record);
     }
 
     var content = get(array, 'content');
@@ -1622,6 +2329,14 @@ DS.Store = Ember.Object.extend({
     }
   },
 
+  /**
+    @private
+
+    When a record is deleted, it is removed from all its
+    record arrays.
+
+    @param {DS.Model} record
+  */
   removeFromRecordArrays: function(record) {
     var clientId = get(record, 'clientId');
     var recordArrays = this.recordArraysForClientId(clientId);
@@ -1636,6 +2351,14 @@ DS.Store = Ember.Object.extend({
   // . INDEXING .
   // ............
 
+  /**
+    @private
+
+    Return a list of all `DS.RecordArray`s a clientId is
+    part of.
+
+    @return {Object(clientId: Ember.OrderedSet)}
+  */
   recordArraysForClientId: function(clientId) {
     var recordArrays = get(this, 'recordArraysByClientId');
     var ret = recordArrays[clientId];
@@ -1660,7 +2383,6 @@ DS.Store = Ember.Object.extend({
         {
           idToCid: {},
           clientIds: [],
-          cidToHash: {},
           recordArrays: []
       });
     }
@@ -1675,11 +2397,12 @@ DS.Store = Ember.Object.extend({
     @param {String|Number} id
   */
   clientIdForId: function(type, id) {
-    var clientId = this.typeMapFor(type).idToCid[id];
+    id = coerceId(id);
 
+    var clientId = this.typeMapFor(type).idToCid[id];
     if (clientId !== undefined) { return clientId; }
 
-    return this.pushHash(UNLOADED, id, type);
+    return this.pushData(UNLOADED, id, type);
   },
 
   /**
@@ -1693,11 +2416,21 @@ DS.Store = Ember.Object.extend({
     var typeMap = this.typeMapFor(type),
         idToClientIdMap = typeMap.idToCid;
 
-    return Ember.EnumerableUtils.map(ids, function(id) {
+    return map(ids, function(id) {
+      id = coerceId(id);
+
       var clientId = idToClientIdMap[id];
       if (clientId) { return clientId; }
-      return this.pushHash(UNLOADED, id, type);
+      return this.pushData(UNLOADED, id, type);
     }, this);
+  },
+
+  typeForClientId: function(clientId) {
+    return this.clientIdToType[clientId];
+  },
+
+  idForClientId: function(clientId) {
+    return this.clientIdToId[clientId];
   },
 
   // ................
@@ -1705,7 +2438,7 @@ DS.Store = Ember.Object.extend({
   // ................
 
   /**
-    Load a new data hash into the store for a given id and type combination.
+    Load new data into the store for a given id and type combination.
     If data for that record had been loaded previously, the new information
     overwrites the old.
 
@@ -1714,53 +2447,54 @@ DS.Store = Ember.Object.extend({
 
     @param {DS.Model} type
     @param {String|Number} id
-    @param {Object} hash the data hash to load
+    @param {Object} data the data to load
   */
-  load: function(type, id, hash) {
-    if (hash === undefined) {
-      hash = id;
-      var primaryKey = type.proto().primaryKey;
-      Ember.assert("A data hash was loaded for a record of type " + type.toString() + " but no primary key '" + primaryKey + "' was provided.", primaryKey in hash);
-      id = hash[primaryKey];
+  load: function(type, id, data) {
+    if (data === undefined) {
+      data = id;
+
+      var adapter = this.adapterForType(type);
+      id = this.preprocessData(type, data);
     }
+
+    id = coerceId(id);
 
     var typeMap = this.typeMapFor(type),
-        dataCache = typeMap.cidToHash,
-        clientId = typeMap.idToCid[id],
-        recordCache = get(this, 'recordCache');
+        cidToData = this.clientIdToData,
+        clientId = typeMap.idToCid[id];
 
     if (clientId !== undefined) {
-      dataCache[clientId] = hash;
+      cidToData[clientId] = data;
 
-      var record = recordCache[clientId];
+      var record = this.recordCache[clientId];
       if (record) {
-        record.send('didChangeData');
+        record.loadedData();
       }
     } else {
-      clientId = this.pushHash(hash, id, type);
+      clientId = this.pushData(data, id, type);
     }
 
-    DATA_PROXY.savedData = hash;
-    this.updateRecordArrays(type, clientId, DATA_PROXY);
+    this.updateRecordArrays(type, clientId);
 
     return { id: id, clientId: clientId };
   },
 
-  loadMany: function(type, ids, hashes) {
+  loadMany: function(type, ids, dataList) {
     var clientIds = Ember.A([]);
 
-    if (hashes === undefined) {
-      hashes = ids;
+    if (dataList === undefined) {
+      dataList = ids;
       ids = [];
-      var primaryKey = type.proto().primaryKey;
 
-      ids = Ember.EnumerableUtils.map(hashes, function(hash) {
-        return hash[primaryKey];
-      });
+      var adapter = this.adapterForType(type);
+
+      ids = map(dataList, function(data) {
+        return this.preprocessData(type, data);
+      }, this);
     }
 
     for (var i=0, l=get(ids, 'length'); i<l; i++) {
-      var loaded = this.load(type, ids[i], hashes[i]);
+      var loaded = this.load(type, ids[i], dataList[i]);
       clientIds.pushObject(loaded.clientId);
     }
 
@@ -1769,25 +2503,27 @@ DS.Store = Ember.Object.extend({
 
   /** @private
 
-    Stores a data hash for the specified type and id combination and returns
+    Stores data for the specified type and id combination and returns
     the client id.
 
-    @param {Object} hash
+    @param {Object} data
     @param {String|Number} id
     @param {DS.Model} type
     @returns {Number}
   */
-  pushHash: function(hash, id, type) {
+  pushData: function(data, id, type) {
     var typeMap = this.typeMapFor(type);
 
     var idToClientIdMap = typeMap.idToCid,
         clientIdToIdMap = this.clientIdToId,
+        clientIdToTypeMap = this.clientIdToType,
         clientIds = typeMap.clientIds,
-        dataCache = typeMap.cidToHash;
+        cidToData = this.clientIdToData;
 
     var clientId = ++this.clientIdCounter;
 
-    dataCache[clientId] = hash;
+    cidToData[clientId] = data;
+    clientIdToTypeMap[clientId] = type;
 
     // if we're creating an item, this process will be done
     // later, once the object has been persisted.
@@ -1808,16 +2544,34 @@ DS.Store = Ember.Object.extend({
   materializeRecord: function(type, clientId, id) {
     var record;
 
-    get(this, 'recordCache')[clientId] = record = type._create({
+    this.recordCache[clientId] = record = type._create({
       store: this,
       clientId: clientId,
-      _id: id
     });
+
+    set(record, 'id', id);
 
     get(this, 'defaultTransaction').adoptRecord(record);
 
-    record.send('loadingData');
+    record.loadingData();
     return record;
+  },
+
+  dematerializeRecord: function(record) {
+    var id = get(record, 'id'),
+        clientId = get(record, 'clientId'),
+        type = this.typeForClientId(clientId),
+        typeMap = this.typeMapFor(type);
+
+    record.updateRecordArrays();
+
+    delete this.recordCache[clientId];
+    delete this.clientIdToId[clientId];
+    delete this.clientIdToType[clientId];
+    delete this.clientIdToData[clientId];
+    delete this.recordArraysByClientId[clientId];
+
+    if (id) { delete typeMap.idToCid[id]; }
   },
 
   destroy: function() {
@@ -1826,6 +2580,111 @@ DS.Store = Ember.Object.extend({
     }
 
     return this._super();
+  },
+
+  // ........................
+  // . RELATIONSHIP CHANGES .
+  // ........................
+
+  addRelationshipChangeFor: function(clientId, key, change) {
+    var changes = this.relationshipChanges;
+    if (!(clientId in changes)) {
+      changes[clientId] = {};
+    }
+
+    changes[clientId][key] = change;
+  },
+
+  removeRelationshipChangeFor: function(clientId, key) {
+    var changes = this.relationshipChanges;
+    if (!(clientId in changes)) {
+      return;
+    }
+
+    delete changes[clientId][key];
+  },
+
+  relationshipChangeFor: function(clientId, key) {
+    var changes = this.relationshipChanges;
+    if (!(clientId in changes)) {
+      return;
+    }
+
+    return changes[clientId][key];
+  },
+
+  relationshipChangesFor: function(clientId) {
+    return this.relationshipChanges[clientId];
+  },
+
+  // ......................
+  // . PER-TYPE ADAPTERS
+  // ......................
+
+  adapterForType: function(type) {
+    this._adaptersMap = this.createInstanceMapFor('adapters');
+
+    var adapter = this._adaptersMap.get(type);
+    if (adapter) { return adapter; }
+
+    return this.get('_adapter');
+  },
+
+  // ..............................
+  // . RECORD CHANGE NOTIFICATION .
+  // ..............................
+  recordAttributeDidChange: function(record, attributeName, newValue, oldValue) {
+    var dirtySet = new Ember.OrderedSet(),
+        adapter = this.adapterForType(record.constructor);
+
+    if (adapter.dirtyRecordsForAttributeChange) {
+      adapter.dirtyRecordsForAttributeChange(dirtySet, record, attributeName, newValue, oldValue);
+    }
+
+    dirtySet.forEach(function(record) {
+      record.adapterDidDirty();
+    });
+  },
+
+  recordBelongsToDidChange: function(dirtySet, child, relationship) {
+    var adapter = this.adapterForType(child.constructor);
+
+    if (adapter.dirtyRecordsForBelongsToChange) {
+      adapter.dirtyRecordsForBelongsToChange(dirtySet, child, relationship);
+    }
+  },
+
+  recordHasManyDidChange: function(dirtySet, parent, relationship) {
+    var adapter = this.adapterForType(parent.constructor);
+
+    if (adapter.dirtyRecordsForHasManyChange) {
+      adapter.dirtyRecordsForHasManyChange(dirtySet, parent, relationship);
+    }
+  }
+});
+
+DS.Store.reopenClass({
+  registerAdapter: DS._Mappable.generateMapFunctionFor('adapters', function(type, adapter, map) {
+    map.set(type, adapter);
+  }),
+
+  transformMapKey: function(key) {
+    if (typeof key === 'string') {
+      var transformedKey;
+      transformedKey = get(Ember.lookup, key);
+      Ember.assert("Could not find model at path " + key, transformedKey);
+      return transformedKey;
+    } else {
+      return key;
+    }
+  },
+
+  transformMapValue: function(key, value) {
+    if (Ember.Object.detect(value)) {
+      return value.create();
+    }
+
+    return value;
   }
 });
 
@@ -1834,7 +2693,8 @@ DS.Store = Ember.Object.extend({
 
 
 (function() {
-var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor;
+var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor,
+    arrayMap = Ember.ArrayPolyfills.map;
 
 /**
   This file encapsulates the various states that a record can transition
@@ -1863,8 +2723,8 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor;
   string. You can determine a record's current state by getting its manager's
   current state path:
 
-        record.get('stateManager.currentState.path');
-        //=> "created.uncommitted"
+      record.get('stateManager.currentPath');
+      //=> "created.uncommitted"
 
   The `DS.Model` states are themselves stateless. What we mean is that,
   though each instance of a record also has a unique instance of a
@@ -1921,7 +2781,7 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor;
   which will be passed as the second parameter to the event handler.
 
   Events should transition to a different state if appropriate. This can be
-  done by calling the state manager's `goToState()` method with a path to the
+  done by calling the state manager's `transitionTo()` method with a path to the
   desired state. The state manager will attempt to resolve the state path
   relative to the current state. If no state is found at that path, it will
   attempt to resolve it relative to the current state's parent, and then its
@@ -1935,12 +2795,12 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor;
         * inFlight
 
   If we are currently in the `start` state, calling
-  `goToState('inFlight')` would transition to the `created.inFlight` state,
-  while calling `goToState('updated.inFlight')` would transition to
+  `transitionTo('inFlight')` would transition to the `created.inFlight` state,
+  while calling `transitionTo('updated.inFlight')` would transition to
   the `updated.inFlight` state.
 
   Remember that *only events* should ever cause a state transition. You should
-  never call `goToState()` from outside a state's event handler. If you are
+  never call `transitionTo()` from outside a state's event handler. If you are
   tempted to do so, create a new event and send that to the state manager.
 
   #### Flags
@@ -1949,7 +2809,7 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor;
   state in a more user-friendly way than examining its state path. For example,
   instead of doing this:
 
-      var statePath = record.get('stateManager.currentState.path');
+      var statePath = record.get('stateManager.currentPath');
       if (statePath === 'created.inFlight') {
         doSomething();
       }
@@ -2010,6 +2870,27 @@ var hasDefinedProperties = function(object) {
   return false;
 };
 
+var didChangeData = function(manager) {
+  var record = get(manager, 'record');
+  record.materializeData();
+};
+
+var setProperty = function(manager, context) {
+  var record = get(manager, 'record'),
+      store = get(record, 'store'),
+      key = context.key,
+      oldValue = context.oldValue,
+      newValue = context.value;
+
+  store.recordAttributeDidChange(record, key, newValue, oldValue);
+};
+
+// Whenever a property is set, recompute all dependent filters
+var updateRecordArrays = function(manager) {
+  var record = manager.get('record');
+  record.updateRecordArraysLater();
+};
+
 DS.State = Ember.State.extend({
   isLoaded: stateProperty,
   isDirty: stateProperty,
@@ -2018,7 +2899,6 @@ DS.State = Ember.State.extend({
   isError: stateProperty,
   isNew: stateProperty,
   isValid: stateProperty,
-  isPending: stateProperty,
 
   // For states that are substates of a
   // DirtyState (updated or created), it is
@@ -2026,54 +2906,6 @@ DS.State = Ember.State.extend({
   // type of dirty state it is.
   dirtyType: stateProperty
 });
-
-var setProperty = function(manager, context) {
-  var key = context.key, value = context.value;
-
-  var record = get(manager, 'record'),
-      data = get(record, 'data');
-
-  set(data, key, value);
-};
-
-var setAssociation = function(manager, context) {
-  var key = context.key, value = context.value;
-
-  var record = get(manager, 'record'),
-      data = get(record, 'data');
-
-  data.setAssociation(key, value);
-};
-
-var didChangeData = function(manager) {
-  var record = get(manager, 'record'),
-      data = get(record, 'data');
-
-  data._savedData = null;
-  record.notifyPropertyChange('data');
-};
-
-// The waitingOn event shares common functionality
-// between the different dirty states, but each is
-// treated slightly differently. This method is exposed
-// so that each implementation can invoke the common
-// behavior, and then implement the behavior specific
-// to the state.
-var waitingOn = function(manager, object) {
-  var record = get(manager, 'record'),
-      pendingQueue = get(record, 'pendingQueue'),
-      objectGuid = guidFor(object);
-
-  var observer = function() {
-    if (get(object, 'id')) {
-      manager.send('doneWaitingOn', object);
-      Ember.removeObserver(object, 'id', observer);
-    }
-  };
-
-  pendingQueue[objectGuid] = [object, observer];
-  Ember.addObserver(object, 'id', observer);
-};
 
 // Implementation notes:
 //
@@ -2102,51 +2934,6 @@ var waitingOn = function(manager, object) {
 //   did not yet report that it was successfully saved.
 // * isValid: No client-side validations have failed and the
 //   adapter did not report any server-side validation failures.
-// * isPending: A record `isPending` when it belongs to an
-//   association on another record and that record has not been
-//   saved. A record in this state cannot be saved because it
-//   lacks a "foreign key" that will be supplied by its parent
-//   association when the parent record has been created. When
-//   the adapter reports that the parent has saved, the
-//   `isPending` property on all children will become `false`
-//   and the transaction will try to commit the records.
-
-// This mixin is mixed into various uncommitted states. Make
-// sure to mix it in *after* the class definition, so its
-// super points to the class definition.
-var Uncommitted = Ember.Mixin.create({
-  setProperty: setProperty,
-  setAssociation: setAssociation
-});
-
-// These mixins are mixed into substates of the concrete
-// subclasses of DirtyState.
-
-var CreatedUncommitted = Ember.Mixin.create({
-  deleteRecord: function(manager) {
-    var record = get(manager, 'record');
-    this._super(manager);
-
-    record.withTransaction(function(t) {
-      t.recordBecameClean('created', record);
-    });
-    manager.goToState('deleted.saved');
-  }
-});
-
-var UpdatedUncommitted = Ember.Mixin.create({
-  deleteRecord: function(manager) {
-    this._super(manager);
-
-    var record = get(manager, 'record');
-
-    record.withTransaction(function(t) {
-      t.recordBecameClean('updated', record);
-    });
-
-    manager.goToState('deleted');
-  }
-});
 
 // The dirty state is a abstract state whose functionality is
 // shared between the `created` and `updated` states.
@@ -2154,6 +2941,15 @@ var UpdatedUncommitted = Ember.Mixin.create({
 // The deleted state shares the `isDirty` flag with the
 // subclasses of `DirtyState`, but with a very different
 // implementation.
+//
+// Dirty states have three child states:
+//
+// `uncommitted`: the store has not yet handed off the record
+//   to be saved.
+// `inFlight`: the store has handed off the record to be saved,
+//   but the adapter has not yet acknowledged success.
+// `invalid`: the record has invalid information and cannot be
+//   send to the adapter yet.
 var DirtyState = DS.State.extend({
   initialState: 'uncommitted',
 
@@ -2163,8 +2959,8 @@ var DirtyState = DS.State.extend({
   // SUBSTATES
 
   // When a record first becomes dirty, it is `uncommitted`.
-  // This means that there are local pending changes,
-  // but they have not yet begun to be saved.
+  // This means that there are local pending changes, but they
+  // have not yet begun to be saved, and are not invalid.
   uncommitted: DS.State.extend({
     // TRANSITIONS
     enter: function(manager) {
@@ -2177,15 +2973,23 @@ var DirtyState = DS.State.extend({
     },
 
     // EVENTS
-    deleteRecord: Ember.K,
+    setProperty: setProperty,
 
-    waitingOn: function(manager, object) {
-      waitingOn(manager, object);
-      manager.goToState('pending');
-    },
+    becomeDirty: Ember.K,
 
     willCommit: function(manager) {
-      manager.goToState('inFlight');
+      manager.transitionTo('inFlight');
+    },
+
+    becameClean: function(manager) {
+      var record = get(manager, 'record'),
+          dirtyType = get(this, 'dirtyType');
+
+      record.withTransaction(function(t) {
+        t.recordBecameClean(dirtyType, record);
+      });
+
+      manager.transitionTo('loaded.saved');
     },
 
     becameInvalid: function(manager) {
@@ -2196,23 +3000,13 @@ var DirtyState = DS.State.extend({
         t.recordBecameInFlight(dirtyType, record);
       });
 
-      manager.goToState('invalid');
+      manager.transitionTo('invalid');
     },
 
     rollback: function(manager) {
-      var record = get(manager, 'record'),
-          dirtyType = get(this, 'dirtyType'),
-          data = get(record, 'data');
-
-      data.rollback();
-
-      record.withTransaction(function(t) {
-        t.recordBecameClean(dirtyType, record);
-      });
-
-      manager.goToState('saved');
+      get(manager, 'record').rollback();
     }
-  }, Uncommitted),
+  }),
 
   // Once a record has been handed off to the adapter to be
   // saved, it is in the 'in flight' state. Changes to the
@@ -2225,6 +3019,8 @@ var DirtyState = DS.State.extend({
     enter: function(manager) {
       var dirtyType = get(this, 'dirtyType'),
           record = get(manager, 'record');
+
+      record.becameInFlight();
 
       record.withTransaction(function (t) {
         t.recordBecameInFlight(dirtyType, record);
@@ -2240,7 +3036,7 @@ var DirtyState = DS.State.extend({
         t.recordBecameClean('inflight', record);
       });
 
-      manager.goToState('saved');
+      manager.transitionTo('saved');
       manager.send('invokeLifecycleCallbacks', dirtyType);
     },
 
@@ -2249,117 +3045,14 @@ var DirtyState = DS.State.extend({
 
       set(record, 'errors', errors);
 
-      manager.goToState('invalid');
+      manager.transitionTo('invalid');
       manager.send('invokeLifecycleCallbacks');
     },
 
     becameError: function(manager) {
-      manager.goToState('error');
+      manager.transitionTo('error');
       manager.send('invokeLifecycleCallbacks');
-    },
-
-    didChangeData: didChangeData
-  }),
-
-  // If a record becomes associated with a newly created
-  // parent record, it will be `pending` until the parent
-  // record has successfully persisted. Once this happens,
-  // this record can use the parent's primary key as its
-  // foreign key.
-  //
-  // If the record's transaction had already started to
-  // commit, the record will transition to the `inFlight`
-  // state. If it had not, the record will transition to
-  // the `uncommitted` state.
-  pending: DS.State.extend({
-    initialState: 'uncommitted',
-
-    // FLAGS
-    isPending: true,
-
-    // SUBSTATES
-
-    // A pending record whose transaction has not yet
-    // started to commit is in this state.
-    uncommitted: DS.State.extend({
-      // EVENTS
-      deleteRecord: function(manager) {
-        var record = get(manager, 'record'),
-            pendingQueue = get(record, 'pendingQueue'),
-            tuple;
-
-        // since we are leaving the pending state, remove any
-        // observers we have registered on other records.
-        for (var prop in pendingQueue) {
-          if (!pendingQueue.hasOwnProperty(prop)) { continue; }
-
-          tuple = pendingQueue[prop];
-          Ember.removeObserver(tuple[0], 'id', tuple[1]);
-        }
-      },
-
-      willCommit: function(manager) {
-        manager.goToState('committing');
-      },
-
-      doneWaitingOn: function(manager, object) {
-        var record = get(manager, 'record'),
-            pendingQueue = get(record, 'pendingQueue'),
-            objectGuid = guidFor(object);
-
-        delete pendingQueue[objectGuid];
-
-        if (isEmptyObject(pendingQueue)) {
-          manager.send('doneWaiting');
-        }
-      },
-
-      doneWaiting: function(manager) {
-        var dirtyType = get(this, 'dirtyType');
-        manager.goToState(dirtyType + '.uncommitted');
-      }
-    }, Uncommitted),
-
-    // A pending record whose transaction has started
-    // to commit is in this state. Since it has not yet
-    // been sent to the adapter, it is not `inFlight`
-    // until all of its dependencies have been committed.
-    committing: DS.State.extend({
-      // FLAGS
-      isSaving: true,
-
-      // EVENTS
-      doneWaitingOn: function(manager, object) {
-        var record = get(manager, 'record'),
-            pendingQueue = get(record, 'pendingQueue'),
-            objectGuid = guidFor(object);
-
-        delete pendingQueue[objectGuid];
-
-        if (isEmptyObject(pendingQueue)) {
-          manager.send('doneWaiting');
-        }
-      },
-
-      doneWaiting: function(manager) {
-        var record = get(manager, 'record'),
-            transaction = get(record, 'transaction');
-
-        // Now that the record is no longer pending, schedule
-        // the transaction to commit.
-        Ember.run.once(transaction, transaction.commit);
-      },
-
-      willCommit: function(manager) {
-        var record = get(manager, 'record'),
-            pendingQueue = get(record, 'pendingQueue');
-
-        if (isEmptyObject(pendingQueue)) {
-          var dirtyType = get(this, 'dirtyType');
-          manager.goToState(dirtyType + '.inFlight');
-        }
-      }
-    })
+    }
   }),
 
   // A record is in the `invalid` state when its client-side
@@ -2379,14 +3072,11 @@ var DirtyState = DS.State.extend({
 
     // EVENTS
     deleteRecord: function(manager) {
-      manager.goToState('deleted');
+      manager.transitionTo('deleted');
+      get(manager, 'record').clearRelationships();
     },
 
-    setAssociation: setAssociation,
-
     setProperty: function(manager, context) {
-      setProperty(manager, context);
-
       var record = get(manager, 'record'),
           errors = get(record, 'errors'),
           key = context.key;
@@ -2396,7 +3086,11 @@ var DirtyState = DS.State.extend({
       if (!hasDefinedProperties(errors)) {
         manager.send('becameValid');
       }
+
+      setProperty(manager, context);
     },
+
+    becomeDirty: Ember.K,
 
     rollback: function(manager) {
       manager.send('becameValid');
@@ -2404,7 +3098,7 @@ var DirtyState = DS.State.extend({
     },
 
     becameValid: function(manager) {
-      manager.goToState('uncommitted');
+      manager.transitionTo('uncommitted');
     },
 
     invokeLifecycleCallbacks: function(manager) {
@@ -2429,31 +3123,36 @@ var updatedState = DirtyState.create({
   dirtyType: 'updated'
 });
 
-// The created.uncommitted state and created.pending.uncommitted share
-// some logic defined in CreatedUncommitted.
-createdState.states.uncommitted.reopen(CreatedUncommitted);
-createdState.states.pending.states.uncommitted.reopen(CreatedUncommitted);
-
-// The created.uncommitted state needs to immediately transition to the
-// deleted state if it is rolled back.
 createdState.states.uncommitted.reopen({
-  rollback: function(manager) {
-    this._super(manager);
-    manager.goToState('deleted.saved');
+  deleteRecord: function(manager) {
+    var record = get(manager, 'record');
+
+    record.withTransaction(function(t) {
+      t.recordIsMoving('created', record);
+    });
+
+    manager.transitionTo('deleted.saved');
+    record.clearRelationships();
   }
 });
 
-// The updated.uncommitted state and updated.pending.uncommitted share
-// some logic defined in UpdatedUncommitted.
-updatedState.states.uncommitted.reopen(UpdatedUncommitted);
-updatedState.states.pending.states.uncommitted.reopen(UpdatedUncommitted);
-updatedState.states.inFlight.reopen({
-  didSaveData: function(manager) {
-    var record = get(manager, 'record'),
-        data = get(record, 'data');
+createdState.states.uncommitted.reopen({
+  rollback: function(manager) {
+    this._super(manager);
+    manager.transitionTo('deleted.saved');
+  }
+});
 
-    data.saveData();
-    data.adapterDidUpdate();
+updatedState.states.uncommitted.reopen({
+  deleteRecord: function(manager) {
+    var record = get(manager, 'record');
+
+    record.withTransaction(function(t) {
+      t.recordIsMoving('updated', record);
+    });
+
+    manager.transitionTo('deleted');
+    get(manager, 'record').clearRelationships();
   }
 });
 
@@ -2467,7 +3166,6 @@ var states = {
     isError: false,
     isNew: false,
     isValid: true,
-    isPending: false,
 
     // SUBSTATES
 
@@ -2479,13 +3177,11 @@ var states = {
     empty: DS.State.create({
       // EVENTS
       loadingData: function(manager) {
-        manager.goToState('loading');
+        manager.transitionTo('loading');
       },
 
-      didChangeData: function(manager) {
-        didChangeData(manager);
-
-        manager.goToState('loaded.created');
+      loadedData: function(manager) {
+        manager.transitionTo('loaded.created');
       }
     }),
 
@@ -2503,13 +3199,9 @@ var states = {
       },
 
       // EVENTS
-      didChangeData: function(manager, data) {
-        didChangeData(manager);
-        manager.send('loadedData');
-      },
-
       loadedData: function(manager) {
-        manager.goToState('loaded');
+        didChangeData(manager);
+        manager.transitionTo('loaded');
       }
     }),
 
@@ -2529,25 +3221,26 @@ var states = {
       saved: DS.State.create({
 
         // EVENTS
-        setProperty: function(manager, context) {
-          setProperty(manager, context);
-          manager.goToState('updated');
-        },
-
-        setAssociation: function(manager, context) {
-          setAssociation(manager, context);
-          manager.goToState('updated');
-        },
-
+        setProperty: setProperty,
         didChangeData: didChangeData,
+        loadedData: didChangeData,
+
+        becomeDirty: function(manager) {
+          manager.transitionTo('updated');
+        },
 
         deleteRecord: function(manager) {
-          manager.goToState('deleted');
+          manager.transitionTo('deleted');
+          get(manager, 'record').clearRelationships();
         },
 
-        waitingOn: function(manager, object) {
-          waitingOn(manager, object);
-          manager.goToState('updated.pending');
+        unloadRecord: function(manager) {
+          manager.transitionTo('deleted.saved');
+          get(manager, 'record').clearRelationships();
+        },
+
+        willCommit: function(manager) {
+          manager.transitionTo('relationshipsInFlight');
         },
 
         invokeLifecycleCallbacks: function(manager, dirtyType) {
@@ -2557,6 +3250,30 @@ var states = {
           } else {
             record.trigger('didUpdate', record);
           }
+        }
+      }),
+
+      relationshipsInFlight: Ember.State.create({
+        // TRANSITIONS
+        enter: function(manager) {
+          var record = get(manager, 'record');
+
+          record.withTransaction(function (t) {
+            t.recordBecameInFlight('clean', record);
+          });
+        },
+
+        // EVENTS
+        didCommit: function(manager) {
+          var record = get(manager, 'record');
+
+          record.withTransaction(function(t) {
+            t.recordBecameClean('inflight', record);
+          });
+
+          manager.transitionTo('saved');
+
+          manager.send('invokeLifecycleCallbacks');
         }
       }),
 
@@ -2573,13 +3290,16 @@ var states = {
 
     // A record is in this state if it was deleted from the store.
     deleted: DS.State.create({
+      initialState: 'uncommitted',
+      dirtyType: 'deleted',
+
       // FLAGS
       isDeleted: true,
       isLoaded: true,
       isDirty: true,
 
       // TRANSITIONS
-      enter: function(manager) {
+      setup: function(manager) {
         var record = get(manager, 'record'),
             store = get(record, 'store');
 
@@ -2591,7 +3311,7 @@ var states = {
       // When a record is deleted, it enters the `start`
       // state. It will exit this state when the record's
       // transaction starts to commit.
-      start: DS.State.create({
+      uncommitted: DS.State.create({
         // TRANSITIONS
         enter: function(manager) {
           var record = get(manager, 'record');
@@ -2603,18 +3323,23 @@ var states = {
 
         // EVENTS
         willCommit: function(manager) {
-          manager.goToState('inFlight');
+          manager.transitionTo('inFlight');
         },
 
         rollback: function(manager) {
-          var record = get(manager, 'record'),
-              data = get(record, 'data');
+          get(manager, 'record').rollback();
+        },
 
-          data.rollback();
+        becomeDirty: Ember.K,
+
+        becameClean: function(manager) {
+          var record = get(manager, 'record');
+
           record.withTransaction(function(t) {
             t.recordBecameClean('deleted', record);
           });
-          manager.goToState('loaded');
+
+          manager.transitionTo('loaded.saved');
         }
       }),
 
@@ -2630,6 +3355,8 @@ var states = {
         enter: function(manager) {
           var record = get(manager, 'record');
 
+          record.becameInFlight();
+
           record.withTransaction(function (t) {
             t.recordBecameInFlight('deleted', record);
           });
@@ -2643,7 +3370,7 @@ var states = {
             t.recordBecameClean('inflight', record);
           });
 
-          manager.goToState('saved');
+          manager.transitionTo('saved');
 
           manager.send('invokeLifecycleCallbacks');
         }
@@ -2655,6 +3382,13 @@ var states = {
       saved: DS.State.create({
         // FLAGS
         isDirty: false,
+
+        setup: function(manager) {
+          var record = get(manager, 'record'),
+              store = get(record, 'store');
+
+          store.dematerializeRecord(record);
+        },
 
         invokeLifecycleCallbacks: function(manager) {
           var record = get(manager, 'record');
@@ -2682,154 +3416,20 @@ var states = {
 DS.StateManager = Ember.StateManager.extend({
   record: null,
   initialState: 'rootState',
-  states: states
-});
-
-})();
-
-
-
-(function() {
-var get = Ember.get, set = Ember.set;
-
-//  When a record is changed on the client, it is considered "dirty"--there are
-//  pending changes that need to be saved to a persistence layer, such as a
-//  server.
-//
-//  If the record is rolled back, it re-enters a clean state, any changes are
-//  discarded, and its attributes are reset back to the last known good copy
-//  of the data that came from the server.
-//
-//  If the record is committed, the changes are sent to the server to be saved,
-//  and once the server confirms that they are valid, the record's "canonical"
-//  data becomes the original canonical data plus the changes merged in.
-//
-//  A DataProxy is an object that encapsulates this change tracking. It
-//  contains three buckets:
-//
-//  * `savedData` - the last-known copy of the data from the server
-//  * `unsavedData` - a hash that contains any changes that have not yet
-//     been committed
-//  * `associations` - this is similar to `savedData`, but holds the client
-//    ids of associated records
-//
-//  When setting a property on the object, the value is placed into the
-//  `unsavedData` bucket:
-//
-//      proxy.set('key', 'value');
-//
-//      // unsavedData:
-//      {
-//        key: "value"
-//      }
-//
-//  When retrieving a property from the object, it first looks to see
-//  if that value exists in the `unsavedData` bucket, and returns it if so.
-//  Otherwise, it returns the value from the `savedData` bucket.
-//
-//  When the adapter notifies a record that it has been saved, it merges the
-//  `unsavedData` bucket into the `savedData` bucket. If the record's
-//  transaction is rolled back, the `unsavedData` hash is simply discarded.
-//
-//  This object is a regular JS object for performance. It is only
-//  used internally for bookkeeping purposes.
-
-var DataProxy = DS._DataProxy = function(record) {
-  this.record = record;
-
-  this.unsavedData = {};
-
-  this.associations = {};
-};
-
-DataProxy.prototype = {
-  get: function(key) { return Ember.get(this, key); },
-  set: function(key, value) { return Ember.set(this, key, value); },
-
-  setAssociation: function(key, value) {
-    this.associations[key] = value;
-  },
-
-  savedData: function() {
-    var savedData = this._savedData;
-    if (savedData) { return savedData; }
-
-    var record = this.record,
-        clientId = get(record, 'clientId'),
-        store = get(record, 'store');
-
-    if (store) {
-      savedData = store.dataForRecord(record);
-      this._savedData = savedData;
-      return savedData;
-    }
-  },
-
-  unknownProperty: function(key) {
-    var unsavedData = this.unsavedData,
-        associations = this.associations,
-        savedData = this.savedData(),
-        store;
-
-    var value = unsavedData[key], association;
-
-    // if this is a belongsTo association, this will
-    // be a clientId.
-    association = associations[key];
-
-    if (association !== undefined) {
-      store = get(this.record, 'store');
-      return store.clientIdToId[association];
-    }
-
-    if (savedData && value === undefined) {
-      value = savedData[key];
-    }
-
-    return value;
-  },
-
-  setUnknownProperty: function(key, value) {
-    var record = this.record,
-        unsavedData = this.unsavedData;
-
-    unsavedData[key] = value;
-
-    record.hashWasUpdated();
-
-    return value;
-  },
-
-  commit: function() {
-    this.saveData();
-
-    this.record.notifyPropertyChange('data');
-  },
-
-  rollback: function() {
-    this.unsavedData = {};
-
-    this.record.notifyPropertyChange('data');
-  },
-
-  saveData: function() {
-    var record = this.record;
-
-    var unsavedData = this.unsavedData;
-    var savedData = this.savedData();
-
-    for (var prop in unsavedData) {
-      if (unsavedData.hasOwnProperty(prop)) {
-        savedData[prop] = unsavedData[prop];
-        delete unsavedData[prop];
-      }
-    }
-  },
-
-  adapterDidUpdate: function() {
-    this.unsavedData = {};
+  states: states,
+  unhandledEvent: function(manager, originalEvent) {
+    var record = manager.get('record'),
+        contexts = [].slice.call(arguments, 2),
+        errorMessage;
+    errorMessage  = "Attempted to handle event `" + originalEvent + "` ";
+    errorMessage += "on " + record.toString() + " while in state ";
+    errorMessage += get(this, 'currentState.path') + ". Called with ";
+    errorMessage += arrayMap.call(contexts, function(context){
+                      return Ember.inspect(context);
+                    }).join(', ');
+    throw new Ember.Error(errorMessage);
   }
-};
+});
 
 })();
 
@@ -2840,7 +3440,7 @@ var get = Ember.get, set = Ember.set, none = Ember.none;
 
 var retrieveFromCurrentState = Ember.computed(function(key) {
   return get(get(this, 'stateManager.currentState'), key);
-}).property('stateManager.currentState').cacheable();
+}).property('stateManager.currentState');
 
 DS.Model = Ember.Object.extend(Ember.Evented, {
   isLoaded: retrieveFromCurrentState,
@@ -2849,185 +3449,29 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   isDeleted: retrieveFromCurrentState,
   isError: retrieveFromCurrentState,
   isNew: retrieveFromCurrentState,
-  isPending: retrieveFromCurrentState,
   isValid: retrieveFromCurrentState,
 
   clientId: null,
   transaction: null,
   stateManager: null,
-  pendingQueue: null,
   errors: null,
 
-  // because unknownProperty is used, any internal property
-  // must be initialized here.
-  primaryKey: 'id',
-  id: Ember.computed(function(key, value) {
-    var primaryKey = get(this, 'primaryKey'),
-        data = get(this, 'data');
-
-    if (arguments.length === 2) {
-      set(data, primaryKey, value);
-      return value;
-    }
-
-    var id = get(data, primaryKey);
-    return id ? id : this._id;
-  }).property('primaryKey', 'data'),
-
-  // The following methods are callbacks invoked by `toJSON`. You
-  // can override one of the callbacks to override specific behavior,
-  // or toJSON itself.
-  //
-  // If you override toJSON, you can invoke these callbacks manually
-  // to get the default behavior.
-
   /**
-    Add the record's primary key to the JSON hash.
+    Create a JSON representation of the record, using the serialization
+    strategy of the store's adapter.
 
-    The default implementation uses the record's specified `primaryKey`
-    and the `id` computed property, which are passed in as parameters.
+    Available options:
 
-    @param {Object} json the JSON hash being built
-    @param {Number|String} id the record's id
-    @param {String} key the primaryKey for the record
+    * `includeId`: `true` if the record's ID should be included in the
+      JSON representation.
+
+    @param {Object} options
+    @returns {Object} an object whose values are primitive JSON values only
   */
-  addIdToJSON: function(json, id, key) {
-    if (id) { json[key] = id; }
+  serialize: function(options) {
+    var store = get(this, 'store');
+    return store.serialize(this, options);
   },
-
-  /**
-    Add the attributes' current values to the JSON hash.
-
-    The default implementation gets the current value of each
-    attribute from the `data`, and uses a `defaultValue` if
-    specified in the `DS.attr` definition.
-
-    @param {Object} json the JSON hash being build
-    @param {Ember.Map} attributes a Map of attributes
-    @param {DataProxy} data the record's data, accessed with `get` and `set`.
-  */
-  addAttributesToJSON: function(json, attributes, data) {
-    attributes.forEach(function(name, meta) {
-      var key = meta.key(this.constructor),
-          value = get(data, key);
-
-      if (value === undefined) {
-        value = meta.options.defaultValue;
-      }
-
-      json[key] = value;
-    }, this);
-  },
-
-  /**
-    Add the value of a `hasMany` association to the JSON hash.
-
-    The default implementation honors the `embedded` option
-    passed to `DS.hasMany`. If embedded, `toJSON` is recursively
-    called on the child records. If not, the `id` of each
-    record is added.
-
-    Note that if a record is not embedded and does not
-    yet have an `id` (usually provided by the server), it
-    will not be included in the output.
-
-    @param {Object} json the JSON hash being built
-    @param {DataProxy} data the record's data, accessed with `get` and `set`.
-    @param {Object} meta information about the association
-    @param {Object} options options passed to `toJSON`
-  */
-  addHasManyToJSON: function(json, data, meta, options) {
-    var key = meta.key,
-        manyArray = get(this, key),
-        records = [], i, l,
-        clientId, id;
-
-    if (meta.options.embedded) {
-      // TODO: Avoid materializing embedded hashes if possible
-      manyArray.forEach(function(record) {
-        records.push(record.toJSON(options));
-      });
-    } else {
-      var clientIds = get(manyArray, 'content');
-
-      for (i=0, l=clientIds.length; i<l; i++) {
-        clientId = clientIds[i];
-        id = get(this, 'store').clientIdToId[clientId];
-
-        if (id !== undefined) {
-          records.push(id);
-        }
-      }
-    }
-
-    key = meta.options.key || get(this, 'namingConvention').keyToJSONKey(key);
-    json[key] = records;
-  },
-
-  /**
-    Add the value of a `belongsTo` association to the JSON hash.
-
-    The default implementation always includes the `id`.
-
-    @param {Object} json the JSON hash being built
-    @param {DataProxy} data the record's data, accessed with `get` and `set`.
-    @param {Object} meta information about the association
-    @param {Object} options options passed to `toJSON`
-  */
-  addBelongsToToJSON: function(json, data, meta, options) {
-    var key = meta.key, value, id;
-
-    if (meta.options.embedded) {
-      key = meta.options.key || get(this, 'namingConvention').keyToJSONKey(key);
-      value = get(data.record, key);
-      json[key] = value ? value.toJSON(options) : null;
-    } else {
-      key = meta.options.key || get(this, 'namingConvention').foreignKey(key);
-      id = data.get(key);
-      json[key] = none(id) ? null : id;
-    }
-  },
-  /**
-    Create a JSON representation of the record, including its `id`,
-    attributes and associations. Honor any settings defined on the
-    attributes or associations (such as `embedded` or `key`).
-  */
-  toJSON: function(options) {
-    var data = get(this, 'data'),
-        result = {},
-        type = this.constructor,
-        attributes = get(type, 'attributes'),
-        primaryKey = get(this, 'primaryKey'),
-        id = get(this, 'id'),
-        store = get(this, 'store'),
-        associations;
-
-    options = options || {};
-
-    // delegate to `addIdToJSON` callback
-    this.addIdToJSON(result, id, primaryKey);
-
-    // delegate to `addAttributesToJSON` callback
-    this.addAttributesToJSON(result, attributes, data);
-
-    associations = get(type, 'associationsByName');
-
-    // add associations, delegating to `addHasManyToJSON` and
-    // `addBelongsToToJSON`.
-    associations.forEach(function(key, meta) {
-      if (options.associations && meta.kind === 'hasMany') {
-        this.addHasManyToJSON(result, data, meta, options);
-      } else if (meta.kind === 'belongsTo') {
-        this.addBelongsToToJSON(result, data, meta, options);
-      }
-    }, this);
-
-    return result;
-  },
-
-  data: Ember.computed(function() {
-    return new DS._DataProxy(this);
-  }).cacheable(),
 
   didLoad: Ember.K,
   didUpdate: Ember.K,
@@ -3036,22 +3480,36 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
   becameInvalid: Ember.K,
   becameError: Ember.K,
 
-  init: function() {
-    var stateManager = DS.StateManager.create({
-      record: this
+  data: Ember.computed(function() {
+    if (!this._data) {
+      this.materializeData();
+    }
+
+    return this._data;
+  }).property(),
+
+  materializeData: function() {
+    this.setupData();
+    get(this, 'store').materializeData(this);
+
+    this.suspendAssociationObservers(function() {
+      this.notifyPropertyChange('data');
     });
+  },
 
-    set(this, 'pendingQueue', {});
+  _data: null,
 
+  init: function() {
+    var stateManager = DS.StateManager.create({ record: this });
     set(this, 'stateManager', stateManager);
+
+    this.setup();
+
     stateManager.goToState('empty');
   },
 
-  destroy: function() {
-    if (!get(this, 'isDeleted')) {
-      this.deleteRecord();
-    }
-    this._super();
+  setup: function() {
+    this._relationshipChanges = {};
   },
 
   send: function(name, context) {
@@ -3063,91 +3521,230 @@ DS.Model = Ember.Object.extend(Ember.Evented, {
     if (transaction) { fn(transaction); }
   },
 
-  setProperty: function(key, value) {
-    this.send('setProperty', { key: key, value: value });
+  loadingData: function() {
+    this.send('loadingData');
+  },
+
+  loadedData: function() {
+    this.send('loadedData');
+  },
+
+  didChangeData: function() {
+    this.send('didChangeData');
+  },
+
+  setProperty: function(key, value, oldValue) {
+    this.send('setProperty', { key: key, value: value, oldValue: oldValue });
   },
 
   deleteRecord: function() {
     this.send('deleteRecord');
   },
 
-  waitingOn: function(record) {
-    this.send('waitingOn', record);
+  unloadRecord: function() {
+    Ember.assert("You can only unload a loaded, non-dirty record.", !get(this, 'isDirty'));
+
+    this.send('unloadRecord');
   },
 
-  notifyHashWasUpdated: function() {
+  clearRelationships: function() {
+    this.eachAssociation(function(name, relationship) {
+      if (relationship.kind === 'belongsTo') {
+        set(this, name, null);
+      } else if (relationship.kind === 'hasMany') {
+        get(this, name).clear();
+      }
+    }, this);
+  },
+
+  updateRecordArrays: function() {
     var store = get(this, 'store');
     if (store) {
-      store.hashWasUpdated(this.constructor, get(this, 'clientId'), this);
+      store.dataWasUpdated(this.constructor, get(this, 'clientId'), this);
     }
   },
 
-  unknownProperty: function(key) {
-    var data = get(this, 'data');
+  /**
+    If the adapter did not return a hash in response to a commit,
+    merge the changed attributes and associations into the existing
+    saved data.
+  */
+  adapterDidCommit: function() {
+    var attributes = get(this, 'data').attributes;
 
-    if (data && key in data) {
-      Ember.assert("You attempted to access the " + key + " property on a record without defining an attribute.", false);
-    }
+    get(this.constructor, 'attributes').forEach(function(name, meta) {
+      attributes[name] = get(this, name);
+    }, this);
+
+    this.send('didCommit');
+    this.updateRecordArraysLater();
   },
 
-  setUnknownProperty: function(key, value) {
-    var data = get(this, 'data');
-
-    if (data && key in data) {
-      Ember.assert("You attempted to set the " + key + " property on a record without defining an attribute.", false);
-    } else {
-      return this._super(key, value);
-    }
-  },
-
-  namingConvention: {
-    keyToJSONKey: function(key) {
-      // TODO: Strip off `is` from the front. Example: `isHipster` becomes `hipster`
-      return Ember.String.decamelize(key);
-    },
-
-    foreignKey: function(key) {
-      return Ember.String.decamelize(key) + '_id';
-    }
-  },
-
-  /** @private */
-  hashWasUpdated: function() {
-    // At the end of the run loop, notify record arrays that
-    // this record has changed so they can re-evaluate its contents
-    // to determine membership.
-    Ember.run.once(this, this.notifyHashWasUpdated);
+  adapterDidDirty: function() {
+    this.send('becomeDirty');
+    this.updateRecordArraysLater();
   },
 
   dataDidChange: Ember.observer(function() {
     var associations = get(this.constructor, 'associationsByName'),
-        data = get(this, 'data'), store = get(this, 'store'),
+        hasMany = get(this, 'data').hasMany, store = get(this, 'store'),
         idToClientId = store.idToClientId,
         cachedValue;
+
+    this.updateRecordArraysLater();
 
     associations.forEach(function(name, association) {
       if (association.kind === 'hasMany') {
         cachedValue = this.cacheFor(name);
 
         if (cachedValue) {
-          var key = association.options.key || get(this, 'namingConvention').keyToJSONKey(name),
-              ids = data.get(key) || [];
-          
-          var clientIds;   
-          if(association.options.embedded) {
-            clientIds = store.loadMany(association.type, ids).clientIds;
-          } else {
-            clientIds = Ember.EnumerableUtils.map(ids, function(id) {
-              return store.clientIdForId(association.type, id);
-            });
-          }
-          
+          var key = name,
+              ids = hasMany[key] || [];
+
+          var clientIds;
+
+          clientIds = Ember.EnumerableUtils.map(ids, function(id) {
+            return store.clientIdForId(association.type, id);
+          });
+
           set(cachedValue, 'content', Ember.A(clientIds));
-          cachedValue.fetch();
         }
       }
     }, this);
   }, 'data'),
+
+  updateRecordArraysLater: function() {
+    Ember.run.once(this, this.updateRecordArrays);
+  },
+
+  setupData: function() {
+    this._data = {
+      attributes: {},
+      belongsTo: {},
+      hasMany: {},
+      id: null
+    };
+  },
+
+  materializeId: function(id) {
+    set(this, 'id', id);
+  },
+
+  materializeAttributes: function(attributes) {
+    Ember.assert("Must pass a hash of attributes to materializeAttributes", !!attributes);
+    this._data.attributes = attributes;
+  },
+
+  materializeAttribute: function(name, value) {
+    this._data.attributes[name] = value;
+  },
+
+  materializeHasMany: function(name, ids) {
+    this._data.hasMany[name] = ids;
+  },
+
+  materializeBelongsTo: function(name, id) {
+    this._data.belongsTo[name] = id;
+  },
+
+  rollback: function() {
+    this.setup();
+    this.send('becameClean');
+
+    this.suspendAssociationObservers(function() {
+      this.notifyPropertyChange('data');
+    });
+  },
+
+  toStringExtension: function() {
+    return get(this, 'id');
+  },
+
+  /**
+    @private
+
+    The goal of this method is to temporarily disable specific observers
+    that take action in response to application changes.
+
+    This allows the system to make changes (such as materialization and
+    rollback) that should not trigger secondary behavior (such as setting an
+    inverse relationship or marking records as dirty).
+
+    The specific implementation will likely change as Ember proper provides
+    better infrastructure for suspending groups of observers, and if Array
+    observation becomes more unified with regular observers.
+  */
+  suspendAssociationObservers: function(callback, binding) {
+    var observers = get(this.constructor, 'associationNames').belongsTo;
+    var self = this;
+
+    try {
+      this._suspendedAssociations = true;
+      Ember._suspendObservers(self, observers, null, 'belongsToDidChange', function() {
+        Ember._suspendBeforeObservers(self, observers, null, 'belongsToWillChange', function() {
+          callback.call(binding || self);
+        });
+      });
+    } finally {
+      this._suspendedAssociations = false;
+    }
+  },
+
+  becameInFlight: function() {
+  },
+
+  // FOR USE DURING COMMIT PROCESS
+
+  adapterDidUpdateAttribute: function(attributeName, value) {
+
+    // If a value is passed in, update the internal attributes and clear
+    // the attribute cache so it picks up the new value. Otherwise,
+    // collapse the current value into the internal attributes because
+    // the adapter has acknowledged it.
+    if (value !== undefined) {
+      get(this, 'data.attributes')[attributeName] = value;
+      this.notifyPropertyChange(attributeName);
+    } else {
+      value = get(this, attributeName);
+      get(this, 'data.attributes')[attributeName] = value;
+    }
+
+    this.updateRecordArraysLater();
+  },
+
+  adapterDidUpdateHasMany: function(name) {
+    var cachedValue = this.cacheFor(name),
+        hasMany = get(this, 'data').hasMany,
+        store = get(this, 'store');
+
+    var associations = get(this.constructor, 'associationsByName'),
+        association = associations.get(name),
+        idToClientId = store.idToClientId;
+
+    if (cachedValue) {
+      var key = name,
+          ids = hasMany[key] || [];
+
+      var clientIds;
+
+      clientIds = Ember.EnumerableUtils.map(ids, function(id) {
+        return store.clientIdForId(association.type, id);
+      });
+
+      set(cachedValue, 'content', Ember.A(clientIds));
+      set(cachedValue, 'isLoaded', true);
+    }
+
+    this.updateRecordArraysLater();
+  },
+
+  adapterDidInvalidate: function(errors) {
+    this.send('becameInvalid', errors);
+  },
+
+  adapterDidError: function() {
+    this.send('becameError');
+  },
 
   /**
     @private
@@ -3178,6 +3775,7 @@ var storeAlias = function(methodName) {
 DS.Model.reopenClass({
   isLoaded: storeAlias('recordIsLoaded'),
   find: storeAlias('find'),
+  all: storeAlias('all'),
   filter: storeAlias('filter'),
 
   _create: DS.Model.create,
@@ -3200,28 +3798,29 @@ DS.Model.reopenClass({
     var map = Ember.Map.create();
 
     this.eachComputedProperty(function(name, meta) {
-      if (meta.isAttribute) { map.set(name, meta); }
+      if (meta.isAttribute) {
+        Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.toString(), name !== 'id');
+
+        meta.name = name;
+        map.set(name, meta);
+      }
     });
 
     return map;
-  }).cacheable(),
+  })
+});
 
-  processAttributeKeys: function() {
-    if (this.processedAttributeKeys) { return; }
-
-    var namingConvention = this.proto().namingConvention;
-
-    this.eachComputedProperty(function(name, meta) {
-      if (meta.isAttribute && !meta.options.key) {
-        meta.options.key = namingConvention.keyToJSONKey(name, this);
-      }
-    }, this);
+DS.Model.reopen({
+  eachAttribute: function(callback, binding) {
+    get(this.constructor, 'attributes').forEach(function(name, meta) {
+      callback.call(binding, name, meta);
+    }, binding);
   }
 });
 
 function getAttr(record, options, key) {
-  var data = get(record, 'data');
-  var value = get(data, key);
+  var attributes = get(record, 'data').attributes;
+  var value = attributes[key];
 
   if (value === undefined) {
     value = options.defaultValue;
@@ -3231,85 +3830,1835 @@ function getAttr(record, options, key) {
 }
 
 DS.attr = function(type, options) {
-  var transform = DS.attr.transforms[type];
-  Ember.assert("Could not find model attribute of type " + type, !!transform);
-
-  var transformFrom = transform.from;
-  var transformTo = transform.to;
-
   options = options || {};
 
   var meta = {
     type: type,
     isAttribute: true,
-    options: options,
-
-    // this will ensure that the key always takes naming
-    // conventions into consideration.
-    key: function(recordType) {
-      recordType.processAttributeKeys();
-      return options.key;
-    }
+    options: options
   };
 
-  return Ember.computed(function(key, value) {
+  return Ember.computed(function(key, value, oldValue) {
     var data;
 
-    key = meta.key(this.constructor);
-
-    if (arguments.length === 2) {
-      value = transformTo(value);
-
-      if (value !== getAttr(this, options, key)) {
-        this.setProperty(key, value);
-      }
+    if (arguments.length > 1) {
+      // TODO: If there is a cached oldValue, use it [tomhuda]
+      oldValue = get(this, 'data.attributes')[key];
+      Ember.assert("You may not set `id` as an attribute on your model. Please remove any lines that look like: `id: DS.attr('<type>')` from " + this.toString(), key !== 'id');
+      this.setProperty(key, value, oldValue);
     } else {
       value = getAttr(this, options, key);
     }
 
-    return transformFrom(value);
+    return value;
   // `data` is never set directly. However, it may be
   // invalidated from the state manager's setData
   // event.
-  }).property('data').cacheable().meta(meta);
+  }).property('data').meta(meta);
 };
 
-DS.attr.transforms = {
+
+})();
+
+
+
+(function() {
+
+})();
+
+
+
+(function() {
+var get = Ember.get, set = Ember.set,
+    none = Ember.none;
+
+DS.belongsTo = function(type, options) {
+  Ember.assert("The first argument DS.belongsTo must be a model type or string, like DS.belongsTo(App.Person)", !!type && (typeof type === 'string' || DS.Model.detect(type)));
+
+  options = options || {};
+
+  var meta = { type: type, isAssociation: true, options: options, kind: 'belongsTo' };
+
+  return Ember.computed(function(key, value) {
+    if (arguments.length === 2) {
+      return value === undefined ? null : value;
+    }
+
+    var data = get(this, 'data').belongsTo,
+        store = get(this, 'store'), id;
+
+    if (typeof type === 'string') {
+      type = get(this, type, false) || get(Ember.lookup, type);
+    }
+
+    id = data[key];
+    return id ? store.find(type, id) : null;
+  }).property('data').meta(meta);
+};
+
+/**
+  These observers observe all `belongsTo` relationships on the record. See
+  `associations/ext` to see how these observers get their dependencies.
+
+  The observers use `removeFromContent` and `addToContent` to avoid
+  going through the public Enumerable API that would try to set the
+  inverse (again) and trigger an infinite loop.
+*/
+
+DS.Model.reopen({
+  /** @private */
+  belongsToWillChange: Ember.beforeObserver(function(record, key) {
+    if (get(record, 'isLoaded')) {
+      var oldParent = get(record, key);
+
+      var childId = get(record, 'clientId'),
+          store = get(record, 'store');
+
+      var change = DS.OneToManyChange.forChildAndParent(childId, store, { belongsToName: key });
+
+      if (change.oldParent === undefined) {
+        change.oldParent = oldParent ? get(oldParent, 'clientId') : null;
+      }
+    }
+  }),
+
+  /** @private */
+  belongsToDidChange: Ember.immediateObserver(function(record, key) {
+    if (get(record, 'isLoaded')) {
+      var change = get(record, 'store').relationshipChangeFor(get(record, 'clientId'), key),
+          newParent = get(record, key);
+
+      change.newParent = newParent ? get(newParent, 'clientId') : null;
+      change.sync();
+    }
+  })
+});
+
+})();
+
+
+
+(function() {
+var get = Ember.get, set = Ember.set;
+var hasAssociation = function(type, options) {
+  options = options || {};
+
+  var meta = { type: type, isAssociation: true, options: options, kind: 'hasMany' };
+
+  return Ember.computed(function(key, value) {
+    var data = get(this, 'data').hasMany,
+        store = get(this, 'store'),
+        ids, association;
+
+    if (typeof type === 'string') {
+      type = get(this, type, false) || get(Ember.lookup, type);
+    }
+
+    ids = data[key];
+    association = store.findMany(type, ids || [], this, meta);
+    set(association, 'owner', this);
+    set(association, 'name', key);
+
+    return association;
+  }).property().meta(meta);
+};
+
+DS.hasMany = function(type, options) {
+  Ember.assert("The type passed to DS.hasMany must be defined", !!type);
+  return hasAssociation(type, options);
+};
+
+})();
+
+
+
+(function() {
+var get = Ember.get, set = Ember.set;
+
+/**
+  @private
+
+  This file defines several extensions to the base `DS.Model` class that
+  add support for one-to-many relationships.
+*/
+
+DS.Model.reopen({
+  // This Ember.js hook allows an object to be notified when a property
+  // is defined.
+  //
+  // In this case, we use it to be notified when an Ember Data user defines a
+  // belongs-to relationship. In that case, we need to set up observers for
+  // each one, allowing us to track relationship changes and automatically
+  // reflect changes in the inverse has-many array.
+  //
+  // This hook passes the class being set up, as well as the key and value
+  // being defined. So, for example, when the user does this:
+  //
+  //   DS.Model.extend({
+  //     parent: DS.belongsTo(App.User)
+  //   });
+  //
+  // This hook would be called with "parent" as the key and the computed
+  // property returned by `DS.belongsTo` as the value.
+  didDefineProperty: function(proto, key, value) {
+    // Check if the value being set is a computed property.
+    if (value instanceof Ember.Descriptor) {
+
+      // If it is, get the metadata for the association. This is
+      // populated by the `DS.belongsTo` helper when it is creating
+      // the computed property.
+      var meta = value.meta();
+
+      if (meta.isAssociation && meta.kind === 'belongsTo') {
+        Ember.addObserver(proto, key, null, 'belongsToDidChange');
+        Ember.addBeforeObserver(proto, key, null, 'belongsToWillChange');
+      }
+    }
+  }
+});
+
+/**
+  These DS.Model extensions add class methods that provide relationship
+  introspection abilities about relationships.
+
+  A note about the computed properties contained here:
+
+  **These properties are effectively sealed once called for the first time.**
+  To avoid repeatedly doing expensive iteration over a model's fields, these
+  values are computed once and then cached for the remainder of the runtime of
+  your application.
+
+  If your application needs to modify a class after its initial definition
+  (for example, using `reopen()` to add additional attributes), make sure you
+  do it before using your model with the store, which uses these properties
+  extensively.
+*/
+
+DS.Model.reopenClass({
+  /**
+    For a given relationship name, returns the model type of the relationship.
+
+    For example, if you define a model like this:
+
+        App.Post = DS.Model.extend({
+          comments: DS.hasMany(App.Comment)
+        });
+
+    Calling `App.Post.typeForAssociation('comments')` will return `App.Comment`.
+
+    @param {String} name the name of the association
+    @return {subclass of DS.Model} the type of the association, or undefined
+  */
+  typeForAssociation: function(name) {
+    var association = get(this, 'associationsByName').get(name);
+    return association && association.type;
+  },
+
+  /**
+    The model's associations as a map, keyed on the type of the
+    association. The value of each entry is an array containing a descriptor
+    for each association with that type, describing the name of the association
+    as well as the type.
+
+    For example, given the following model definition:
+
+        App.Blog = DS.Model.extend({
+          users: DS.hasMany(App.User),
+          owner: DS.belongsTo(App.User),
+
+          posts: DS.hasMany(App.Post)
+        });
+
+    This computed property would return a map describing these
+    associations, like this:
+
+        var associations = Ember.get(App.Blog, 'associations');
+        associatons.get(App.User);
+        //=> [ { name: 'users', kind: 'hasMany' },
+        //     { name: 'owner', kind: 'belongsTo' } ]
+        associations.get(App.Post);
+        //=> [ { name: 'posts', kind: 'hasMany' } ]
+
+    @type Ember.Map
+    @readOnly
+  */
+  associations: Ember.computed(function() {
+    var map = new Ember.MapWithDefault({
+      defaultValue: function() { return []; }
+    });
+
+    // Loop through each computed property on the class
+    this.eachComputedProperty(function(name, meta) {
+
+      // If the computed property is an association, add
+      // it to the map.
+      if (meta.isAssociation) {
+        if (typeof meta.type === 'string') {
+          meta.type = Ember.get(Ember.lookup, meta.type);
+        }
+
+        var associationsForType = map.get(meta.type);
+
+        associationsForType.push({ name: name, kind: meta.kind });
+      }
+    });
+
+    return map;
+  }),
+
+  /**
+    A hash containing lists of the model's associations, grouped
+    by the association kind. For example, given a model with this
+    definition:
+
+        App.Blog = DS.Model.extend({
+          users: DS.hasMany(App.User),
+          owner: DS.belongsTo(App.User),
+
+          posts: DS.hasMany(App.Post)
+        });
+
+    This property would contain the following:
+
+       var associationNames = Ember.get(App.Blog, 'associationNames');
+       associationNames.hasMany;
+       //=> ['users', 'posts']
+       associationNames.belongsTo;
+       //=> ['owner']
+
+    @type Object
+    @readOnly
+  */
+  associationNames: Ember.computed(function() {
+    var names = { hasMany: [], belongsTo: [] };
+
+    this.eachComputedProperty(function(name, meta) {
+      if (meta.isAssociation) {
+        names[meta.kind].push(name);
+      }
+    });
+
+    return names;
+  }),
+
+  /**
+    A map whose keys are the associations of a model and whose values are
+    association descriptors.
+
+    For example, given a model with this
+    definition:
+
+        App.Blog = DS.Model.extend({
+          users: DS.hasMany(App.User),
+          owner: DS.belongsTo(App.User),
+
+          posts: DS.hasMany(App.Post)
+        });
+
+    This property would contain the following:
+
+       var associationsByName = Ember.get(App.Blog, 'associationsByName');
+       associationsByName.get('users');
+       //=> { key: 'users', kind: 'hasMany', type: App.User }
+       associationsByName.get('owner');
+       //=> { key: 'owner', kind: 'belongsTo', type: App.User }
+
+    @type Ember.Map
+    @readOnly
+  */
+  associationsByName: Ember.computed(function() {
+    var map = Ember.Map.create(), type;
+
+    this.eachComputedProperty(function(name, meta) {
+      if (meta.isAssociation) {
+        meta.key = name;
+        type = meta.type;
+
+        if (typeof type === 'string') {
+          type = get(this, type, false) || get(Ember.lookup, type);
+          meta.type = type;
+        }
+
+        map.set(name, meta);
+      }
+    });
+
+    return map;
+  }),
+
+  /**
+    A map whose keys are the fields of the model and whose values are strings
+    describing the kind of the field. A model's fields are the union of all of its
+    attributes and relationships.
+
+    For example:
+
+        App.Blog = DS.Model.extend({
+          users: DS.hasMany(App.User),
+          owner: DS.belongsTo(App.User),
+
+          posts: DS.hasMany(App.Post),
+
+          title: DS.attr('string')
+        });
+
+        var fields = Ember.get(App.Blog, 'fields');
+        fields.forEach(function(field, kind) {
+          console.log(field, kind);
+        });
+
+        // prints:
+        // users, hasMany
+        // owner, belongsTo
+        // posts, hasMany
+        // title, attribute
+
+    @type Ember.Map
+    @readOnly
+  */
+  fields: Ember.computed(function() {
+    var map = Ember.Map.create(), type;
+
+    this.eachComputedProperty(function(name, meta) {
+      if (meta.isAssociation) {
+        map.set(name, meta.kind);
+      } else if (meta.isAttribute) {
+        map.set(name, 'attribute');
+      }
+    });
+
+    return map;
+  }),
+
+  /**
+    Given a callback, iterates over each of the associations in the model,
+    invoking the callback with the name of each association and its association
+    descriptor.
+
+    @param {Function} callback the callback to invoke
+    @param {any} binding the value to which the callback's `this` should be bound
+  */
+  eachAssociation: function(callback, binding) {
+    get(this, 'associationsByName').forEach(function(name, association) {
+      callback.call(binding, name, association);
+    });
+  }
+});
+
+DS.Model.reopen({
+  /**
+    Given a callback, iterates over each of the associations in the model,
+    invoking the callback with the name of each association and its association
+    descriptor.
+
+    @param {Function} callback the callback to invoke
+    @param {any} binding the value to which the callback's `this` should be bound
+  */
+  eachAssociation: function(callback, binding) {
+    this.constructor.eachAssociation(callback, binding);
+  }
+});
+
+/**
+  @private
+
+  Helper method to look up the name of the inverse of an association.
+
+  In a has-many relationship, there are always two sides: the `belongsTo` side
+  and the `hasMany` side. When one side changes, the other side should be updated
+  automatically.
+
+  Given a model, the model of the inverse, and the kind of the association, this
+  helper returns the name of the association on the inverse.
+
+  For example, imagine the following two associated models:
+
+      App.Post = DS.Model.extend({
+        comments: DS.hasMany('App.Comment')
+      });
+
+      App.Comment = DS.Model.extend({
+        post: DS.belongsTo('App.Post')
+      });
+
+  If the `post` property of a `Comment` was modified, Ember Data would invoke
+  this helper like this:
+
+      DS._inverseNameFor(App.Comment, App.Post, 'hasMany');
+      //=> 'comments'
+
+  Ember Data uses the name of the association returned to reflect the changed
+  relationship on the other side.
+*/
+DS._inverseNameFor = function(modelType, inverseModelType, inverseAssociationKind) {
+  var associationMap = get(modelType, 'associations'),
+      possibleAssociations = associationMap.get(inverseModelType),
+      possible, actual, oldValue;
+
+  if (!possibleAssociations) { return; }
+
+  for (var i = 0, l = possibleAssociations.length; i < l; i++) {
+    possible = possibleAssociations[i];
+
+    if (possible.kind === inverseAssociationKind) {
+      actual = possible;
+      break;
+    }
+  }
+
+  if (actual) { return actual.name; }
+};
+
+/**
+  @private
+
+  Given a model and an association name, returns the model type of
+  the named association.
+
+      App.Post = DS.Model.extend({
+        comments: DS.hasMany('App.Comment')
+      });
+
+      DS._inverseTypeFor(App.Post, 'comments');
+      //=> App.Comment
+  @param {DS.Model class} modelType
+  @param {String} associationName
+  @return {DS.Model class}
+*/
+DS._inverseTypeFor = function(modelType, associationName) {
+  var associations = get(modelType, 'associationsByName'),
+      association = associations.get(associationName);
+
+  if (association) { return association.type; }
+};
+
+})();
+
+
+
+(function() {
+var get = Ember.get, set = Ember.set;
+
+DS.OneToManyChange = function(options) {
+  this.oldParent = options.oldParent;
+  this.child = options.child;
+  this.belongsToName = options.belongsToName;
+  this.store = options.store;
+  this.committed = {};
+  this.awaiting = 0;
+};
+
+/** @private */
+DS.OneToManyChange.create = function(options) {
+  return new DS.OneToManyChange(options);
+};
+
+/** @private */
+DS.OneToManyChange.forChildAndParent = function(childClientId, store, options) {
+  // Get the type of the child based on the child's client ID
+  var childType = store.typeForClientId(childClientId), key;
+
+  // If the name of the belongsTo side of the relationship is specified,
+  // use that
+  // If the type of the parent is specified, look it up on the child's type
+  // definition.
+  if (options.parentType) {
+    key = inverseBelongsToName(options.parentType, childType, options.hasManyName);
+  } else if (options.belongsToName) {
+    key = options.belongsToName;
+  } else {
+    Ember.assert("You must pass either a parentType or belongsToName option to OneToManyChange.forChildAndParent", false);
+  }
+
+  var change = store.relationshipChangeFor(childClientId, key);
+
+  if (!change) {
+    change = DS.OneToManyChange.create({
+      child: childClientId,
+      store: store
+    });
+
+    store.addRelationshipChangeFor(childClientId, key, change);
+  }
+
+  change.belongsToName = key;
+
+  return change;
+};
+
+DS.OneToManyChange.prototype = {
+  /**
+    Get the child type and ID, if available.
+
+    @returns {Array} an array of type and ID
+  */
+  getChildTypeAndId: function() {
+    return this.getTypeAndIdFor(this.child);
+  },
+
+  /**
+    Get the old parent type and ID, if available.
+
+    @returns {Array} an array of type and ID
+  */
+  getOldParentTypeAndId: function() {
+    return this.getTypeAndIdFor(this.oldParent);
+  },
+
+  /**
+    Get the new parent type and ID, if available.
+
+    @returns {Array} an array of type and ID
+  */
+  getNewParentTypeAndId: function() {
+    return this.getTypeAndIdFor(this.newParent);
+  },
+
+  /**
+    Get the name of the relationship on the hasMany side.
+
+    @returns {String}
+  */
+  getHasManyName: function() {
+    var name = this.hasManyName, store = this.store, parent;
+
+    if (!name) {
+      parent = this.oldParent || this.newParent;
+      if (!parent) { return; }
+
+      var childType = store.typeForClientId(this.child);
+      var inverseType = DS._inverseTypeFor(childType, this.belongsToName);
+      name = inverseHasManyName(inverseType, childType, this.belongsToName);
+      this.hasManyName = name;
+    }
+
+    return name;
+  },
+
+  /**
+    Get the name of the relationship on the belongsTo side.
+
+    @returns {String}
+  */
+  getBelongsToName: function() {
+    var name = this.belongsToName, store = this.store, parent;
+
+    if (!name) {
+      parent = this.oldParent || this.newParent;
+      if (!parent) { return; }
+
+      var childType = store.typeForClientId(this.child);
+      var parentType = store.typeForClientId(parent);
+      name = DS._inverseNameFor(childType, parentType, 'belongsTo', this.hasManyName);
+
+      this.belongsToName = name;
+    }
+
+    return name;
+  },
+
+  /** @private */
+  getTypeAndIdFor: function(clientId) {
+    if (clientId) {
+      var store = this.store;
+
+      return [
+        store.typeForClientId(clientId),
+        store.idForClientId(clientId)
+      ];
+    }
+  },
+
+  /** @private */
+  destroy: function() {
+    var childClientId = this.child,
+        belongsToName = this.getBelongsToName(),
+        hasManyName = this.getHasManyName(),
+        store = this.store,
+        child, oldParent, newParent, lastParent, transaction;
+
+    store.removeRelationshipChangeFor(childClientId, belongsToName);
+
+    if (transaction = this.transaction) {
+      transaction.relationshipBecameClean(this);
+    }
+  },
+
+  /** @private */
+  getByClientId: function(clientId) {
+    var store = this.store;
+
+    // return null or undefined if the original clientId was null or undefined
+    if (!clientId) { return clientId; }
+
+    if (store.recordIsMaterialized(clientId)) {
+      return store.findByClientId(null, clientId);
+    }
+  },
+
+  /** @private */
+  getChild: function() {
+    return this.getByClientId(this.child);
+  },
+
+  /** @private */
+  getOldParent: function() {
+    return this.getByClientId(this.oldParent);
+  },
+
+  /** @private */
+  getNewParent: function() {
+    return this.getByClientId(this.newParent);
+  },
+
+  /** @private */
+  getLastParent: function() {
+    return this.getByClientId(this.lastParent);
+  },
+
+  /**
+    @private
+
+    Make sure that all three parts of the relationship change are part of
+    the same transaction. If any of the three records is clean and in the
+    default transaction, and the rest are in a different transaction, move
+    them all into that transaction.
+  */
+  ensureSameTransaction: function(child, oldParent, newParent, hasManyName, belongsToName) {
+    var transactions = Ember.A();
+
+    if (child)     { transactions.pushObject(get(child, 'transaction')); }
+    if (oldParent) { transactions.pushObject(get(oldParent, 'transaction')); }
+    if (newParent) { transactions.pushObject(get(newParent, 'transaction')); }
+
+    var transaction = transactions.reduce(function(prev, t) {
+      if (!get(t, 'isDefault')) {
+        if (prev === null) { return t; }
+        Ember.assert("All records in a changed relationship must be in the same transaction. You tried to change the relationship between records when one is in " + t + " and the other is in " + prev, t === prev);
+      }
+
+      return prev;
+    }, null);
+
+    if (transaction) {
+      transaction.add(child);
+      if (oldParent) { transaction.add(oldParent); }
+      if (newParent) { transaction.add(newParent); }
+    } else {
+      transaction = transactions.objectAt(0);
+    }
+
+    this.transaction = transaction;
+    return transaction;
+  },
+
+  /** @private */
+  sync: function() {
+    var oldParentClientId = this.oldParent,
+        newParentClientId = this.newParent,
+        hasManyName = this.getHasManyName(),
+        belongsToName = this.getBelongsToName(),
+        child = this.getChild(),
+        oldParent, newParent;
+
+    //Ember.assert("You specified a hasMany (" + hasManyName + ") on " + (!belongsToName && (newParent || oldParent || this.lastParent).constructor) + " but did not specify an inverse belongsTo on " + child.constructor, belongsToName);
+
+    // This code path is reached if a child record was added to a new ManyArray
+    // without being removed from its old ManyArray. Below, this method will
+    // ensure (via `removeObject`) that the record is no longer in the old
+    // ManyArray.
+    if (oldParentClientId === undefined) {
+      // Since the child was added to a ManyArray, we know it was materialized.
+      oldParent = get(child, belongsToName);
+
+      if (oldParent) {
+        this.oldParent = get(oldParent, 'clientId');
+      } else {
+        this.oldParent = null;
+      }
+    } else {
+      oldParent = this.getOldParent();
+    }
+
+    // Coalesce changes from A to B and back to A.
+    if (oldParentClientId === newParentClientId) {
+      // If we have gone from oldParent to newParent and back to oldParent,
+      // there must be a materialized child.
+
+      // If our lastParent clientId is not null, there will always be a
+      // materialized lastParent.
+      var lastParent = this.getLastParent();
+      if (lastParent) {
+        lastParent.suspendAssociationObservers(function() {
+          get(lastParent, hasManyName).removeObject(child);
+        });
+      }
+
+      // Don't do anything if the belongsTo is going from null back to null
+      if (oldParent) {
+        get(oldParent, hasManyName).addObject(child);
+      }
+
+      set(child, belongsToName, oldParent);
+
+      this.destroy();
+      return;
+    }
+
+    //Ember.assert("You specified a belongsTo (" + belongsToName + ") on " + child.constructor + " but did not specify an inverse hasMany on " + (!hasManyName && (newParent || oldParent || this.lastParentRecord).constructor), hasManyName);
+
+    newParent = this.getNewParent();
+    var transaction = this.ensureSameTransaction(child, oldParent, newParent, hasManyName, belongsToName);
+
+    transaction.relationshipBecameDirty(this);
+
+    // Next, make sure that all three side of the association reflect the
+    // state of the OneToManyChange, while making sure to avoid an
+    // infinite loop.
+
+
+    var dirtySet = new Ember.OrderedSet();
+
+    // If there is an `oldParent` and the `oldParent` is different to
+    // the `newParent`, use the idempotent `removeObject` to ensure
+    // that the record is no longer in its ManyArray. The `removeObject`
+    // method only has an effect if:
+    //
+    // 1. The change happened from the belongsTo side
+    // 2. The record was moved to a new parent without explicitly
+    //    removing it from the old parent first.
+    if (oldParent && oldParent !== newParent) {
+      get(oldParent, hasManyName).removeObject(child);
+
+      // TODO: This implementation causes a race condition in key-value
+      // stores. The fix involves buffering changes that happen while
+      // a record is loading. A similar fix is required for other parts
+      // of ember-data, and should be done as new infrastructure, not
+      // a one-off hack. [tomhuda]
+      if (get(oldParent, 'isLoaded')) {
+        this.store.recordHasManyDidChange(dirtySet, oldParent, this);
+      }
+    }
+
+    // If there is a `newParent`, use the idempotent `addObject`
+    // to ensure that the record is in its ManyArray. The `addObject`
+    // method only has an effect if the change happened from the
+    // belongsTo side.
+    if (newParent) {
+      get(newParent, hasManyName).addObject(child);
+
+      if (get(newParent, 'isLoaded')) {
+        this.store.recordHasManyDidChange(dirtySet, newParent, this);
+      }
+    }
+
+    if (child) {
+      // Only set the belongsTo on the child if it is not already the
+      // newParent. This happens if the change happened from the
+      // ManyArray side.
+      if (get(child, belongsToName) !== newParent) {
+        set(child, belongsToName, newParent);
+      }
+
+      this.store.recordBelongsToDidChange(dirtySet, child, this);
+    }
+
+    dirtySet.forEach(function(record) {
+      record.adapterDidDirty();
+    });
+
+    // If this change is later reversed (A->B followed by B->A),
+    // we will need to remove the child from this parent. Save
+    // it off as `lastParent` so we can do that.
+    this.lastParent = newParentClientId;
+  },
+
+  /** @private */
+  adapterDidUpdate: function() {
+    if (this.awaiting > 0) { return; }
+    var belongsToName = this.getBelongsToName();
+    var hasManyName = this.getHasManyName();
+    var oldParent, newParent, child;
+
+    this.destroy();
+  },
+
+  wait: function() {
+    this.awaiting++;
+  },
+
+  done: function() {
+    this.awaiting--;
+
+    if (this.awaiting === 0) {
+      this.adapterDidUpdate();
+    }
+  }
+};
+
+function inverseBelongsToName(parentType, childType, hasManyName) {
+  // Get the options passed to the parent's DS.hasMany()
+  var options = parentType.metaForProperty(hasManyName).options;
+  var belongsToName;
+
+  if (belongsToName = options.inverse) {
+    return belongsToName;
+  }
+
+  return DS._inverseNameFor(childType, parentType, 'belongsTo');
+}
+
+function inverseHasManyName(parentType, childType, belongsToName) {
+  var options = childType.metaForProperty(belongsToName).options;
+  var hasManyName;
+
+  if (hasManyName = options.inverse) {
+    return hasManyName;
+  }
+
+  return DS._inverseNameFor(parentType, childType, 'hasMany');
+}
+
+})();
+
+
+
+(function() {
+
+})();
+
+
+
+(function() {
+var set = Ember.set;
+
+/**
+  This code registers an injection for Ember.Application.
+
+  If an Ember.js developer defines a subclass of DS.Store on their application,
+  this code will automatically instantiate it and make it available on the
+  router.
+
+  Additionally, after an application's controllers have been injected, they will
+  each have the store made available to them.
+
+  For example, imagine an Ember.js application with the following classes:
+
+  App.Store = DS.Store.extend({
+    adapter: 'App.MyCustomAdapter'
+  });
+
+  App.PostsController = Ember.ArrayController.extend({
+    // ...
+  });
+
+  When the application is initialized, `App.Store` will automatically be
+  instantiated, and the instance of `App.PostsController` will have its `store`
+  property set to that instance.
+
+  Note that this code will only be run if the `ember-application` package is
+  loaded. If Ember Data is being used in an environment other than a
+  typical application (e.g., node.js where only `ember-runtime` is available),
+  this code will be ignored.
+*/
+
+Ember.onLoad('Ember.Application', function(Application) {
+  Application.registerInjection({
+    name: "store",
+    before: "controllers",
+
+    // If a store subclass is defined, like App.Store,
+    // instantiate it and inject it into the router.
+    injection: function(app, stateManager, property) {
+      if (!stateManager) { return; }
+      if (property === 'Store') {
+        set(stateManager, 'store', app[property].create());
+      }
+    }
+  });
+
+  Application.registerInjection({
+    name: "giveStoreToControllers",
+    after: ['store','controllers'],
+
+    // For each controller, set its `store` property
+    // to the DS.Store instance we created above.
+    injection: function(app, stateManager, property) {
+      if (!stateManager) { return; }
+      if (/^[A-Z].*Controller$/.test(property)) {
+        var controllerName = property.charAt(0).toLowerCase() + property.substr(1);
+        var store = stateManager.get('store');
+        var controller = stateManager.get(controllerName);
+        if(!controller) { return; }
+
+        controller.set('store', store);
+      }
+    }
+  });
+});
+
+})();
+
+
+
+(function() {
+var get = Ember.get, set = Ember.set;
+
+/**
+  The serializer is responsible for converting the data returned from the
+  adapter into the semantics expected by records in Ember Data. It is also
+  responsible for converting a record into the form expected by the adapter
+  when saving changes that have been made locally.
+
+  Typically, your application's `DS.Adapter` is responsible for both creating
+  a serializer as well as calling the appropriate methods when it needs to
+  materialize data or serialize a record.
+
+  ## Serialization
+
+  These methods are responsible for taking a record and
+  producing a JSON object.
+
+  These methods are designed in layers, like a delicious 7-layer
+  cake (but with fewer layers).
+
+  The main entry point for serialization is the `serialize`
+  method, which takes the record and options.
+
+  The `serialize` method is responsible for:
+
+  * turning the record's attributes (`DS.attr`) into
+    attributes on the JSON object.
+  * optionally adding the record's ID onto the hash
+  * adding relationships (`DS.hasMany` and `DS.belongsTo`)
+    to the JSON object.
+
+  Depending on the backend, the serializer can choose
+  whether to include the `hasMany` or `belongsTo`
+  relationships on the JSON hash.
+
+  For very custom serialization, you can implement your
+  own `serialize` method. In general, however, you will want
+  to override the hooks described below.
+
+  ### Adding the ID
+
+  The default `serialize` will optionally call your serializer's
+  `addId` method with the JSON hash it is creating, the
+  record's type, and the record's ID. The `serialize` method
+  will not call `addId` if the record's ID is undefined.
+
+  Your adapter must specifically request ID inclusion by
+  passing `{ includeId: true }` as an option to `serialize`.
+
+  NOTE: You may not want to include the ID when updating an
+  existing record, because your server will likely disallow
+  changing an ID after it is created, and the PUT request
+  itself will include the record's identification.
+
+  By default, `addId` will:
+
+  1. Get the primary key name for the record by calling
+     the serializer's `primaryKey` with the record's type.
+     Unless you override the `primaryKey` method, this
+     will be `'id'`.
+  2. Assign the record's ID to the primary key in the
+     JSON hash being built.
+
+  If your backend expects a JSON object with the primary
+  key at the root, you can just override the `primaryKey`
+  method on your serializer subclass.
+
+  Otherwise, you can override the `addId` method for
+  more specialized handling.
+
+  ### Adding Attributes
+
+  By default, the serializer's `serialize` method will call
+  `addAttributes` with the JSON object it is creating
+  and the record to serialize.
+
+  The `addAttributes` method will then call `addAttribute`
+  in turn, with the JSON object, the record to serialize,
+  the attribute's name and its type.
+
+  Finally, the `addAttribute` method will serialize the
+  attribute:
+
+  1. It will call `keyForAttributeName` to determine
+     the key to use in the JSON hash.
+  2. It will get the value from the record.
+  3. It will call `serializeValue` with the attribute's
+     value and attribute type to convert it into a
+     JSON-compatible value. For example, it will convert a
+     Date into a String.
+
+  If your backend expects a JSON object with attributes as
+  keys at the root, you can just override the `serializeValue`
+  and `keyForAttributeName` methods in your serializer
+  subclass and let the base class do the heavy lifting.
+
+  If you need something more specialized, you can probably
+  override `addAttribute` and let the default `addAttributes`
+  handle the nitty gritty.
+
+  ### Adding Relationships
+
+  By default, `serialize` will call your serializer's
+  `addRelationships` method with the JSON object that is
+  being built and the record being serialized. The default
+  implementation of this method is to loop over all of the
+  relationships defined on your record type and:
+
+  * If the relationship is a `DS.hasMany` relationship,
+    call `addHasMany` with the JSON object, the record
+    and a description of the relationship.
+  * If the relationship is a `DS.belongsTo` relationship,
+    call `addBelongsTo` with the JSON object, the record
+    and a description of the relationship.
+
+  The relationship description has the following keys:
+
+  * `type`: the class of the associated information (the
+    first parameter to `DS.hasMany` or `DS.belongsTo`)
+  * `kind`: either `hasMany` or `belongsTo`
+
+  The relationship description may get additional
+  information in the future if more capabilities or
+  relationship types are added. However, it will
+  remain backwards-compatible, so the mere existence
+  of new features should not break existing adapters.
+*/
+DS.Serializer = Ember.Object.extend({
+  init: function() {
+    this.mappings = Ember.Map.create();
+  },
+
+  //.......................
+  //. SERIALIZATION HOOKS
+  //.......................
+
+  /**
+    The main entry point for serializing a record. While you can consider this
+    a hook that can be overridden in your serializer, you will have to manually
+    handle serialization. For most cases, there are more granular hooks that you
+    can override.
+
+    If overriding this method, these are the responsibilities that you will need
+    to implement yourself:
+
+    * If the option hash contains `includeId`, add the record's ID to the serialized form.
+      By default, `serialize` calls `addId` if appropriate.
+    * Add the record's attributes to the serialized form. By default, `serialize` calls
+      `addAttributes`.
+    * Add the record's relationships to the serialized form. By default, `serialize` calls
+      `addRelationships`.
+
+    @param {DS.Model} record the record to serialize
+    @param {Object} [options] a hash of options
+    @returns {any} the serialized form of the record
+  */
+  serialize: function(record, options) {
+    options = options || {};
+
+    var serialized = this.createSerializedForm(), id;
+
+    if (options.includeId) {
+      if (id = get(record, 'id')) {
+        this._addId(serialized, record.constructor, id);
+      }
+    }
+
+    this.addAttributes(serialized, record);
+    this.addRelationships(serialized, record);
+
+    return serialized;
+  },
+
+  /**
+    @private
+
+    Given an attribute type and value, convert the value into the
+    serialized form using the transform registered for that type.
+
+    @param {any} value the value to convert to the serialized form
+    @param {String} attributeType the registered type (e.g. `string`
+      or `boolean`)
+    @returns {any} the serialized form of the value
+  */
+  serializeValue: function(value, attributeType) {
+    var transform = this.transforms ? this.transforms[attributeType] : null;
+
+    Ember.assert("You tried to use an attribute type (" + attributeType + ") that has not been registered", transform);
+    return transform.serialize(value);
+  },
+
+  /**
+    A hook you can use to normalize IDs before adding them to the
+    serialized representation.
+
+    Because the store coerces all IDs to strings for consistency,
+    this is the opportunity for the serializer to, for example,
+    convert numerical IDs back into number form.
+
+    @param {String} id the id from the record
+    @returns {any} the serialized representation of the id
+  */
+  serializeId: function(id) {
+    if (isNaN(id)) { return id; }
+    return +id;
+  },
+
+  /**
+    A hook you can use to change how attributes are added to the serialized
+    representation of a record.
+
+    By default, `addAttributes` simply loops over all of the attributes of the
+    passed record, maps the attribute name to the key for the serialized form,
+    and invokes any registered transforms on the value. It then invokes the
+    more granular `addAttribute` with the key and transformed value.
+
+    Since you can override `keyForAttributeName`, `addAttribute`, and register
+    custom tranforms, you should rarely need to override this hook.
+
+    @param {any} data the serialized representation that is being built
+    @param {DS.Model} record the record to serialize
+  */
+  addAttributes: function(data, record) {
+    record.eachAttribute(function(name, attribute) {
+      this._addAttribute(data, record, name, attribute.type);
+    }, this);
+  },
+
+  /**
+    A hook you can use to customize how the key/value pair is added to
+    the serialized data.
+
+    @param {any} serialized the serialized form being built
+    @param {String} key the key to add to the serialized data
+    @param {any} value the value to add to the serialized data
+  */
+  addAttribute: Ember.K,
+
+  /**
+    A hook you can use to customize how the record's id is added to
+    the serialized data.
+
+    The `addId` hook is called with:
+
+    * the serialized representation being built
+    * the resolved primary key (taking configurations and the
+      `primaryKey` hook into consideration)
+    * the serialized id (after calling the `serializeId` hook)
+
+    @param {any} data the serialized representation that is being built
+    @param {String} key the resolved primary key
+    @param {id} id the serialized id
+  */
+  addId: Ember.K,
+
+  /**
+    A hook you can use to change how relationships are added to the serialized
+    representation of a record.
+
+    By default, `addAttributes` loops over all of the relationships of the
+    passed record, maps the relationship names to the key for the serialized form,
+    and then invokes the public `addBelongsTo` and `addHasMany` hooks.
+
+    Since you can override `keyForBelongsTo`, `keyForHasMany`, `addBelongsTo`,
+    `addHasMany`, and register mappings, you should rarely need to override this
+    hook.
+
+    @param {any} data the serialized representation that is being built
+    @param {DS.Model} record the record to serialize
+  */
+  addRelationships: function(data, record) {
+    record.eachAssociation(function(name, relationship) {
+      if (relationship.kind === 'belongsTo') {
+        this._addBelongsTo(data, record, name, relationship);
+      } else if (relationship.kind === 'hasMany') {
+        this._addHasMany(data, record, name, relationship);
+      }
+    }, this);
+  },
+
+  /**
+    A hook you can use to add a `belongsTo` relationship to the
+    serialized representation.
+
+    The specifics of this hook are very adapter-specific, so there
+    is no default implementation. You can see `DS.RESTSerializer`
+    for an example of an implementation of the `addBelongsTo` hook.
+
+    The `belongsTo` relationship object has the following properties:
+
+    * **type** a subclass of DS.Model that is the type of the
+      relationship. This is the first parameter to DS.belongsTo
+    * **options** the options passed to the call to DS.belongsTo
+    * **kind** always `belongsTo`
+
+    Additional properties may be added in the future.
+
+    @param {any} data the serialized representation that is being built
+    @param {DS.Model} record the record to serialize
+    @param {String} key the key for the serialized object
+    @param {Object} relationship an object representing the relationship
+  */
+  addBelongsTo: Ember.K,
+
+  /**
+    A hook you can use to add a `hasMany` relationship to the
+    serialized representation.
+
+    The specifics of this hook are very adapter-specific, so there
+    is no default implementation. You may not need to implement this,
+    for example, if your backend only expects associations on the
+    child of a one to many relationship.
+
+    The `hasMany` relationship object has the following properties:
+
+    * **type** a subclass of DS.Model that is the type of the
+      relationship. This is the first parameter to DS.hasMany
+    * **options** the options passed to the call to DS.hasMany
+    * **kind** always `hasMany`
+
+    Additional properties may be added in the future.
+
+    @param {any} data the serialized representation that is being built
+    @param {DS.Model} record the record to serialize
+    @param {String} key the key for the serialized object
+    @param {Object} relationship an object representing the relationship
+  */
+  addHasMany: Ember.K,
+
+  /**
+    NAMING CONVENTIONS
+
+    The most commonly overridden APIs of the serializer are
+    the naming convention methods:
+
+    * `keyForAttributeName`: converts a camelized attribute name
+      into a key in the adapter-provided data hash. For example,
+      if the model's attribute name was `firstName`, and the
+      server used underscored names, you would return `first_name`.
+    * `primaryKey`: returns the key that should be used to
+      extract the id from the adapter-provided data hash. It is
+      also used when serializing a record.
+  */
+
+  /**
+    A hook you can use in your serializer subclass to customize
+    how an unmapped attribute name is converted into a key.
+
+    By default, this method returns the `name` parameter.
+
+    For example, if the attribute names in your JSON are underscored,
+    you will want to convert them into JavaScript conventional
+    camelcase:
+
+    ```javascript
+    App.MySerializer = DS.Serializer.extend({
+      // ...
+
+      keyForAttributeName: function(type, name) {
+        return name.camelize();
+      }
+    });
+    ```
+
+    @param {DS.Model subclass} type the type of the record with
+      the attribute name `name`
+    @param {String} name the attribute name to convert into a key
+
+    @returns {String} the key
+  */
+  keyForAttributeName: function(type, name) {
+    return name;
+  },
+
+  /**
+    A hook you can use in your serializer to specify a conventional
+    primary key.
+
+    By default, this method will return the string `id`.
+
+    In general, you should not override this hook to specify a special
+    primary key for an individual type; use `configure` instead.
+
+    For example, if your primary key is always `__id__`:
+
+    ```javascript
+    App.MySerializer = DS.Serializer.extend({
+      // ...
+      primaryKey: function(type) {
+        return '__id__';
+      }
+    });
+    ```
+
+    In another example, if the primary key always includes the
+    underscored version of the type before the string `id`:
+
+    ```javascript
+    App.MySerializer = DS.Serializer.extend({
+      // ...
+      primaryKey: function(type) {
+        // If the type is `BlogPost`, this will return
+        // `blog_post_id`.
+        var typeString = type.toString.split(".")[1].underscore();
+        return typeString + "_id";
+      }
+    });
+    ```
+
+    @param {DS.Model subclass} type
+    @returns {String} the primary key for the type
+  */
+  primaryKey: function(type) {
+    return "id";
+  },
+
+  /**
+    A hook you can use in your serializer subclass to customize
+    how an unmapped `belongsTo` association is converted into
+    a key.
+
+    By default, this method calls `keyForAttributeName`, so if
+    your naming convention is uniform across attributes and
+    associations, you can use the default here and override
+    just `keyForAttributeName` as needed.
+
+    For example, if the `belongsTo` names in your JSON always
+    begin with `BT_` (e.g. `BT_posts`), you can strip out the
+    `BT_` prefix:"
+
+    ```javascript
+    App.MySerializer = DS.Serializer.extend({
+      // ...
+      keyForBelongsTo: function(type, name) {
+        return name.match(/^BT_(.*)$/)[1].camelize();
+      }
+    });
+    ```
+
+    @param {DS.Model subclass} type the type of the record with
+      the `belongsTo` association.
+    @param {String} name the association name to convert into a key
+
+    @returns {String} the key
+  */
+  keyForBelongsTo: function(type, name) {
+    return this.keyForAttributeName(type, name);
+  },
+
+  /**
+    A hook you can use in your serializer subclass to customize
+    how an unmapped `hasMany` association is converted into
+    a key.
+
+    By default, this method calls `keyForAttributeName`, so if
+    your naming convention is uniform across attributes and
+    associations, you can use the default here and override
+    just `keyForAttributeName` as needed.
+
+    For example, if the `hasMany` names in your JSON always
+    begin with the "table name" for the current type (e.g.
+    `post_comments`), you can strip out the prefix:"
+
+    ```javascript
+    App.MySerializer = DS.Serializer.extend({
+      // ...
+      keyForHasMany: function(type, name) {
+        // if your App.BlogPost has many App.BlogComment, the key from
+        // the server would look like: `blog_post_blog_comments`
+        //
+        // 1. Convert the type into a string and underscore the
+        //    second part (App.BlogPost -> blog_post)
+        // 2. Extract the part after `blog_post_` (`blog_comments`)
+        // 3. Underscore it, to become `blogComments`
+        var typeString = type.toString().split(".")[1].underscore();
+        return name.match(new RegExp("^" + typeString + "_(.*)$"))[1].camelize();
+      }
+    });
+    ```
+
+    @param {DS.Model subclass} type the type of the record with
+      the `belongsTo` association.
+    @param {String} name the association name to convert into a key
+
+    @returns {String} the key
+  */
+  keyForHasMany: function(type, name) {
+    return this.keyForAttributeName(type, name);
+  },
+  //.........................
+  //. MATERIALIZATION HOOKS
+  //.........................
+
+  materialize: function(record, serialized) {
+    if (Ember.none(get(record, 'id'))) {
+      record.materializeId(this.extractId(record.constructor, serialized));
+    }
+
+    this.materializeAttributes(record, serialized);
+    this.materializeRelationships(record, serialized);
+  },
+
+  deserializeValue: function(value, attributeType) {
+    var transform = this.transforms ? this.transforms[attributeType] : null;
+
+    Ember.assert("You tried to use a attribute type (" + attributeType + ") that has not been registered", transform);
+    return transform.deserialize(value);
+  },
+
+  materializeAttributes: function(record, serialized) {
+    record.eachAttribute(function(name, attribute) {
+      this.materializeAttribute(record, serialized, name, attribute.type);
+    }, this);
+  },
+
+  materializeAttribute: function(record, serialized, attributeName, attributeType) {
+    var value = this.extractAttribute(record.constructor, serialized, attributeName);
+    value = this.deserializeValue(value, attributeType);
+
+    record.materializeAttribute(attributeName, value);
+  },
+
+  materializeRelationships: function(record, hash) {
+    record.eachAssociation(function(name, relationship) {
+      if (relationship.kind === 'hasMany') {
+        this.materializeHasMany(name, record, hash, relationship);
+      } else if (relationship.kind === 'belongsTo') {
+        this.materializeBelongsTo(name, record, hash, relationship);
+      }
+    }, this);
+  },
+
+  materializeHasMany: function(name, record, hash, relationship) {
+    var key = this._keyForHasMany(record.constructor, relationship.key);
+    record.materializeHasMany(name, this.extractHasMany(record.constructor, hash, key));
+  },
+
+  materializeBelongsTo: function(name, record, hash, relationship) {
+    var key = this._keyForBelongsTo(record.constructor, relationship.key);
+    record.materializeBelongsTo(name, this.extractBelongsTo(record.constructor, hash, key));
+  },
+
+  _extractEmbeddedRelationship: function(type, hash, name, relationshipType) {
+    var key = this['_keyFor' + relationshipType](type, name),
+        mappings = this.mappingForType(type),
+        mapping = mappings && mappings[name];
+
+    if (mapping && mapping.embedded === 'load') {
+      return this['extractEmbedded' + relationshipType](type, hash, key);
+    }
+  },
+
+  _extractEmbeddedBelongsTo: function(type, hash, name) {
+    return this._extractEmbeddedRelationship(type, hash, name, 'BelongsTo');
+  },
+
+  _extractEmbeddedHasMany: function(type, hash, name) {
+    return this._extractEmbeddedRelationship(type, hash, name, 'HasMany');
+  },
+
+  extractEmbeddedBelongsTo: function(type, hash, key) {
+    return this.extractBelongsTo(type, hash, key);
+  },
+
+  extractEmbeddedHasMany: function(type, hash, key) {
+    return this.extractHasMany(type, hash, key);
+  },
+
+  /**
+    @private
+
+    This method is called to get the primary key for a given
+    type.
+
+    If a primary key configuration exists for this type, this
+    method will return the configured value. Otherwise, it will
+    call the public `primaryKey` hook.
+
+    @param {DS.Model subclass} type
+    @returns {String} the primary key for the type
+  */
+  _primaryKey: function(type) {
+    var mapping = this.mappingForType(type),
+        primaryKey = mapping && mapping.primaryKey;
+
+    if (primaryKey) {
+      return primaryKey;
+    } else {
+      return this.primaryKey(type);
+    }
+  },
+
+  /**
+    @private
+
+    This method looks up the key for the attribute name and transforms the
+    attribute's value using registered transforms.
+
+    Specifically:
+
+    1. Look up the key for the attribute name. If available, this will use
+       any registered mappings. Otherwise, it will invoke the public
+       `keyForAttributeName` hook.
+    2. Get the value from the record using the `attributeName`.
+    3. Transform the value using registered transforms for the `attributeType`.
+    4. Invoke the public `addAttribute` hook with the hash, key, and
+       transformed value.
+
+    @param {any} data the serialized representation being built
+    @param {DS.Model} record the record to serialize
+    @param {String} attributeName the name of the attribute on the record
+    @param {String} attributeType the type of the attribute (e.g. `string`
+      or `boolean`)
+  */
+  _addAttribute: function(data, record, attributeName, attributeType) {
+    var key = this._keyForAttributeName(record.constructor, attributeName);
+    var value = get(record, attributeName);
+
+    this.addAttribute(data, key, this.serializeValue(value, attributeType));
+  },
+
+  /**
+    @private
+
+    This method looks up the primary key for the `type` and invokes
+    `serializeId` on the `id`.
+
+    It then invokes the public `addId` hook with the primary key and
+    the serialized id.
+
+    @param {any} data the serialized representation that is being built
+    @param {Ember.Model subclass} type
+    @param {any} id the materialized id from the record
+  */
+  _addId: function(hash, type, id) {
+    var primaryKey = this._primaryKey(type);
+
+    this.addId(hash, primaryKey, this.serializeId(id));
+  },
+
+  /**
+    @private
+
+    This method is called to get a key used in the data from
+    an attribute name. It first checks for any mappings before
+    calling the public hook `keyForAttributeName`.
+
+    @param {DS.Model subclass} type the type of the record with
+      the attribute name `name`
+    @param {String} name the attribute name to convert into a key
+
+    @returns {String} the key
+  */
+  _keyForAttributeName: function(type, name) {
+    return this._keyFromMappingOrHook('keyForAttributeName', type, name);
+  },
+
+  /**
+    @private
+
+    This method is called to get a key used in the data from
+    a belongsTo association. It first checks for any mappings before
+    calling the public hook `keyForBelongsTo`.
+
+    @param {DS.Model subclass} type the type of the record with
+      the `belongsTo` association.
+    @param {String} name the association name to convert into a key
+
+    @returns {String} the key
+  */
+  _keyForBelongsTo: function(type, name) {
+    return this._keyFromMappingOrHook('keyForBelongsTo', type, name);
+  },
+
+  /**
+    @private
+
+    This method is called to get a key used in the data from
+    a hasMany association. It first checks for any mappings before
+    calling the public hook `keyForHasMany`.
+
+    @param {DS.Model subclass} type the type of the record with
+      the `hasMany` association.
+    @param {String} name the association name to convert into a key
+
+    @returns {String} the key
+  */
+  _keyForHasMany: function(type, name) {
+    return this._keyFromMappingOrHook('keyForHasMany', type, name);
+  },
+  /**
+    @private
+
+    This method converts the relationship name to a key for serialization,
+    and then invokes the public `addBelongsTo` hook.
+
+    @param {any} data the serialized representation that is being built
+    @param {DS.Model} record the record to serialize
+    @param {String} name the relationship name
+    @param {Object} relationship an object representing the relationship
+  */
+  _addBelongsTo: function(data, record, name, relationship) {
+    var key = this._keyForBelongsTo(record.constructor, name);
+    this.addBelongsTo(data, record, key, relationship);
+  },
+
+  /**
+    @private
+
+    This method converts the relationship name to a key for serialization,
+    and then invokes the public `addHasMany` hook.
+
+    @param {any} data the serialized representation that is being built
+    @param {DS.Model} record the record to serialize
+    @param {String} name the relationship name
+    @param {Object} relationship an object representing the relationship
+  */
+  _addHasMany: function(data, record, name, relationship) {
+    var key = this._keyForHasMany(record.constructor, name);
+    this.addHasMany(data, record, key, relationship);
+  },
+
+  /**
+    @private
+
+    An internal method that handles checking whether a mapping
+    exists for a particular attribute or association name before
+    calling the public hooks.
+
+    If a mapping is found, and the mapping has a key defined,
+    use that instead of invoking the hook.
+
+    @param {String} publicMethod the public hook to invoke if
+      a mapping is not found (e.g. `keyForAttributeName`)
+    @param {DS.Model subclass} type the type of the record with
+      the attribute or association name.
+    @param {String} name the attribute or association name to
+      convert into a key
+  */
+  _keyFromMappingOrHook: function(publicMethod, type, name) {
+    var mapping = this.mappingForType(type),
+        mappingOptions = mapping && mapping[name],
+        key = mappingOptions && mappingOptions.key;
+
+    if (key) {
+      return key;
+    } else {
+      return this[publicMethod](type, name);
+    }
+  },
+
+  /**
+    TRANSFORMS
+  */
+
+  registerTransform: function(type, transform) {
+    this.transforms[type] = transform;
+  },
+
+  /**
+    MAPPING CONVENIENCE
+  */
+
+  map: function(type, mappings) {
+    this.mappings.set(type, mappings);
+  },
+
+  mappingForType: function(type) {
+    this._reifyMappings();
+    return this.mappings.get(type);
+  },
+
+  _reifyMappings: function() {
+    if (this._didReifyMappings) { return; }
+
+    var mappings = this.mappings,
+        reifiedMappings = Ember.Map.create();
+
+    mappings.forEach(function(key, mapping) {
+      if (typeof key === 'string') {
+        var type = Ember.get(Ember.lookup, key);
+        Ember.assert("Could not find model at path" + key, type);
+
+        reifiedMappings.set(type, mapping);
+      } else {
+        reifiedMappings.set(key, mapping);
+      }
+    });
+
+    this.mappings = reifiedMappings;
+
+    this._didReifyMappings = true;
+  }
+});
+
+
+})();
+
+
+
+(function() {
+/**
+  DS.Transforms is a hash of transforms used by DS.Serializer.
+*/
+DS.JSONTransforms = {
   string: {
-    from: function(serialized) {
+    deserialize: function(serialized) {
       return Ember.none(serialized) ? null : String(serialized);
     },
 
-    to: function(deserialized) {
+    serialize: function(deserialized) {
       return Ember.none(deserialized) ? null : String(deserialized);
     }
   },
 
   number: {
-    from: function(serialized) {
+    deserialize: function(serialized) {
       return Ember.none(serialized) ? null : Number(serialized);
     },
 
-    to: function(deserialized) {
+    serialize: function(deserialized) {
       return Ember.none(deserialized) ? null : Number(deserialized);
     }
   },
 
+  // Handles the following boolean inputs:
+  // "TrUe", "t", "f", "FALSE", 0, (non-zero), or boolean true/false
   'boolean': {
-    from: function(serialized) {
-      return Boolean(serialized);
+    deserialize: function(serialized) {
+      var type = typeof serialized;
+
+      if (type === "boolean") {
+        return serialized;
+      } else if (type === "string") {
+        return serialized.match(/^true$|^t$|^1$/i) !== null;
+      } else if (type === "number") {
+        return serialized === 1;
+      } else {
+        return false;
+      }
     },
 
-    to: function(deserialized) {
+    serialize: function(deserialized) {
       return Boolean(deserialized);
     }
   },
 
   date: {
-    from: function(serialized) {
+    deserialize: function(serialized) {
       var type = typeof serialized;
 
       if (type === "string" || type === "number") {
+        // this is a fix for Safari 5.1.5 on Mac which does not accept timestamps as yyyy-mm-dd
+        if (type === "string" && serialized.search(/^\d{4}-\d{2}-\d{2}$/) !== -1){
+          serialized += "T00:00:00Z";
+        }
+
         return new Date(serialized);
       } else if (serialized === null || serialized === undefined) {
         // if the value is not present in the data,
@@ -3320,7 +5669,7 @@ DS.attr.transforms = {
       }
     },
 
-    to: function(date) {
+    serialize: function(date) {
       if (date instanceof Date) {
         var days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
@@ -3353,186 +5702,81 @@ DS.attr.transforms = {
   }
 };
 
-
-})();
-
-
-
-(function() {
-
-})();
-
-
-
-(function() {
-var get = Ember.get, set = Ember.set,
-    none = Ember.none;
-
-var embeddedFindRecord = function(store, type, data, key, one) {
-  var association = get(data, key);
-  return none(association) ? undefined : store.load(type, association).id;
-};
-
-var referencedFindRecord = function(store, type, data, key, one) {
-  return get(data, key);
-};
-
-var hasAssociation = function(type, options, one) {
-  options = options || {};
-
-  var embedded = options.embedded,
-      findRecord = embedded ? embeddedFindRecord : referencedFindRecord;
-
-  var meta = { type: type, isAssociation: true, options: options, kind: 'belongsTo' };
-
-  return Ember.computed(function(key, value) {
-    var data = get(this, 'data'), ids, id, association,
-        store = get(this, 'store');
-
-    if (typeof type === 'string') {
-      type = get(this, type, false) || get(window, type);
-    }
-
-    if (arguments.length === 2) {
-      key = options.key || get(this, 'namingConvention').foreignKey(key);
-      this.send('setAssociation', { key: key, value: Ember.none(value) ? null : get(value, 'clientId') });
-      //data.setAssociation(key, get(value, 'clientId'));
-      // put the client id in `key` in the data hash
-      return value;
-    } else {
-      // Embedded belongsTo associations should not look for
-      // a foreign key.
-      if (embedded) {
-        key = options.key || get(this, 'namingConvention').keyToJSONKey(key);
-
-      // Non-embedded associations should look for a foreign key.
-      // For example, instead of person, we might look for person_id
-      } else {
-        key = options.key || get(this, 'namingConvention').foreignKey(key);
-      }
-      id = findRecord(store, type, data, key, true);
-      association = id ? store.find(type, id) : null;
-    }
-
-    return association;
-  }).property('data').cacheable().meta(meta);
-};
-
-DS.belongsTo = function(type, options) {
-  Ember.assert("The type passed to DS.belongsTo must be defined", !!type);
-  return hasAssociation(type, options);
-};
-
 })();
 
 
 
 (function() {
 var get = Ember.get, set = Ember.set;
-var embeddedFindRecord = function(store, type, data, key) {
-  var association = get(data, key);
-  return association ? store.loadMany(type, association).ids : [];
-};
 
-var referencedFindRecord = function(store, type, data, key, one) {
-  return get(data, key);
-};
+DS.JSONSerializer = DS.Serializer.extend({
+  init: function() {
+    this._super();
 
-var hasAssociation = function(type, options) {
-  options = options || {};
-
-  var embedded = options.embedded,
-      findRecord = embedded ? embeddedFindRecord : referencedFindRecord;
-
-  var meta = { type: type, isAssociation: true, options: options, kind: 'hasMany' };
-
-  return Ember.computed(function(key, value) {
-    var data = get(this, 'data'),
-        store = get(this, 'store'),
-        ids, id, association;
-
-    if (typeof type === 'string') {
-      type = get(this, type, false) || get(window, type);
+    if (!get(this, 'transforms')) {
+      this.set('transforms', DS.JSONTransforms);
     }
-
-    key = options.key || get(this, 'namingConvention').keyToJSONKey(key);
-    ids = findRecord(store, type, data, key);
-    association = store.findMany(type, ids || []);
-    set(association, 'parentRecord', this);
-
-    return association;
-  }).property().cacheable().meta(meta);
-};
-
-DS.hasMany = function(type, options) {
-  Ember.assert("The type passed to DS.hasMany must be defined", !!type);
-  return hasAssociation(type, options);
-};
-
-})();
-
-
-
-(function() {
-var get = Ember.get;
-
-DS.Model.reopenClass({
-  typeForAssociation: function(name) {
-    var association = get(this, 'associationsByName').get(name);
-    return association && association.type;
   },
 
-  associations: Ember.computed(function() {
-    var map = Ember.Map.create();
+  addId: function(data, key, id) {
+    data[key] = id;
+  },
 
-    this.eachComputedProperty(function(name, meta) {
-      if (meta.isAssociation) {
-        var type = meta.type,
-            typeList = map.get(type);
+  /**
+    A hook you can use to customize how the key/value pair is added to
+    the serialized data.
 
-        if (typeof type === 'string') {
-          type = get(this, type, false) || get(window, type);
-          meta.type = type;
-        }
+    @param {any} hash the JSON hash being built
+    @param {String} key the key to add to the serialized data
+    @param {any} value the value to add to the serialized data
+  */
+  addAttribute: function(hash, key, value) {
+    hash[key] = value;
+  },
 
-        if (!typeList) {
-          typeList = [];
-          map.set(type, typeList);
-        }
+  /**
+    @private
 
-        typeList.push({ name: name, kind: meta.kind });
-      }
-    });
+    Creates an empty hash that will be filled in by the hooks called from the
+    `serialize()` method.
 
-    return map;
-  }).cacheable(),
+    @return {Object}
+  */
+  createSerializedForm: function() {
+    return {};
+  },
 
-  associationsByName: Ember.computed(function() {
-    var map = Ember.Map.create(), type;
+  extractAttribute: function(type, hash, attributeName) {
+    var key = this._keyForAttributeName(type, attributeName);
+    return hash[key];
+  },
 
-    this.eachComputedProperty(function(name, meta) {
-      if (meta.isAssociation) {
-        meta.key = name;
-        type = meta.type;
+  extractId: function(type, hash) {
+    var primaryKey = this._primaryKey(type);
 
-        if (typeof type === 'string') {
-          type = get(this, type, false) || get(window, type);
-          meta.type = type;
-        }
+    // Ensure that we coerce IDs to strings so that record
+    // IDs remain consistent between application runs; especially
+    // if the ID is serialized and later deserialized from the URL,
+    // when type information will have been lost.
+    return hash[primaryKey]+'';
+  },
 
-        map.set(name, meta);
-      }
-    });
+  extractHasMany: function(type, hash, key) {
+    return hash[key];
+  },
 
-    return map;
-  }).cacheable()
+  extractBelongsTo: function(type, hash, key) {
+    return hash[key];
+  },
+
+  replaceEmbeddedBelongsTo: function(type, hash, name, id) {
+    hash[this._keyForBelongsTo(type, name)] = id;
+  },
+
+  replaceEmbeddedHasMany: function(type, hash, name, ids) {
+    hash[this._keyForHasMany(type, name)] = ids;
+  }
 });
-
-})();
-
-
-
-(function() {
 
 })();
 
@@ -3581,7 +5825,98 @@ DS.Model.reopenClass({
    For more information about the adapter API, please see `README.md`.
 */
 
-DS.Adapter = Ember.Object.extend({
+var get = Ember.get, set = Ember.set;
+
+DS.Adapter = Ember.Object.extend(DS._Mappable, {
+
+  init: function() {
+    var serializer = get(this, 'serializer');
+
+    if (Ember.Object.detect(serializer)) {
+      serializer = serializer.create();
+      set(this, 'serializer', serializer);
+    }
+
+    this._attributesMap = this.createInstanceMapFor('attributes');
+
+    this._outstandingOperations = new Ember.MapWithDefault({
+      defaultValue: function() { return 0; }
+    });
+
+    this._dependencies = new Ember.MapWithDefault({
+      defaultValue: function() { return new Ember.OrderedSet(); }
+    });
+
+    this.registerSerializerTransforms(this.constructor, serializer, {});
+    this.registerSerializerMappings(serializer);
+  },
+
+  dirtyRecordsForAttributeChange: function(dirtySet, record, attributeName, newValue, oldValue) {
+    // TODO: Custom equality checking [tomhuda]
+    if (newValue !== oldValue) {
+      dirtySet.add(record);
+    }
+  },
+
+  dirtyRecordsForBelongsToChange: function(dirtySet, child) {
+    dirtySet.add(child);
+  },
+
+  dirtyRecordsForHasManyChange: function(dirtySet, parent) {
+    dirtySet.add(parent);
+  },
+
+  /**
+    @private
+
+    This method recursively climbs the superclass hierarchy and
+    registers any class-registered transforms on the adapter's
+    serializer.
+
+    Once it registers a transform for a given type, it ignores
+    subsequent transforms for the same attribute type.
+
+    @param {Class} klass the DS.Adapter subclass to extract the
+      transforms from
+    @param {DS.Serializer} serializer the serializer to register
+      the transforms onto
+    @param {Object} seen a hash of attributes already seen
+  */
+  registerSerializerTransforms: function(klass, serializer, seen) {
+    var transforms = klass._registeredTransforms, superclass, prop;
+
+    for (prop in transforms) {
+      if (!transforms.hasOwnProperty(prop) || prop in seen) { continue; }
+      seen[prop] = true;
+
+      serializer.registerTransform(prop, transforms[prop]);
+    }
+
+    if (superclass = klass.superclass) {
+      this.registerSerializerTransforms(superclass, serializer, seen);
+    }
+  },
+
+  /**
+    @private
+
+    This method recursively climbs the superclass hierarchy and
+    registers any class-registered mappings on the adapter's
+    serializer.
+
+    @param {Class} klass the DS.Adapter subclass to extract the
+      transforms from
+    @param {DS.Serializer} serializer the serializer to register the
+      mappings onto
+  */
+  registerSerializerMappings: function(serializer) {
+    var mappings = this._attributesMap;
+
+    mappings.forEach(function(type, mapping) {
+      serializer.map(type, mapping);
+    }, this);
+  },
+
   /**
     The `find()` method is invoked when the store is asked for a record that
     has not previously been loaded. In response to `find()` being called, you
@@ -3596,7 +5931,7 @@ DS.Adapter = Ember.Object.extend({
         url = url.fmt(id);
 
         jQuery.getJSON(url, function(data) {
-            // data is a Hash of key/value pairs. If your server returns a
+            // data is a hash of key/value pairs. If your server returns a
             // root, simply do something like:
             // store.load(type, id, data.person)
             store.load(type, id, data);
@@ -3604,6 +5939,12 @@ DS.Adapter = Ember.Object.extend({
       }
   */
   find: null,
+
+  serializer: DS.JSONSerializer,
+
+  registerTransform: function(attributeType, transform) {
+    get(this, 'serializer').registerTransform(attributeType, transform);
+  },
 
   /**
     If the globally unique IDs for your records should be generated on the client,
@@ -3626,17 +5967,92 @@ DS.Adapter = Ember.Object.extend({
   */
   generateIdForRecord: null,
 
+  materialize: function(record, data) {
+    get(this, 'serializer').materialize(record, data);
+  },
+
+  serialize: function(record, options) {
+    return get(this, 'serializer').serialize(record, options);
+  },
+
+  extractId: function(type, data) {
+    return get(this, 'serializer').extractId(type, data);
+  },
+
+  extractEmbeddedData: function(store, type, data) {
+    var serializer = get(this, 'serializer');
+
+    type.eachAssociation(function(name, association) {
+      var dataListToLoad, dataToLoad, typeToLoad;
+
+      if (association.kind === 'hasMany') {
+        this._extractEmbeddedHasMany(store, serializer, type, data, association);
+      } else if (association.kind === 'belongsTo') {
+        this._extractEmbeddedBelongsTo(store, serializer, type, data, association);
+      }
+    }, this);
+  },
+
+  _extractEmbeddedHasMany: function(store, serializer, type, data, association) {
+    var dataListToLoad = serializer._extractEmbeddedHasMany(type, data, association.key),
+        typeToLoad = association.type;
+
+    if (dataListToLoad) {
+      var ids = [];
+
+      for (var i=0, l=dataListToLoad.length; i<l; i++) {
+        var dataToLoad = dataListToLoad[i];
+        ids.push(store.adapterForType(typeToLoad).extractId(typeToLoad, dataToLoad));
+      }
+      serializer.replaceEmbeddedHasMany(type, data, association.key, ids);
+      store.loadMany(association.type, dataListToLoad);
+    }
+  },
+
+  _extractEmbeddedBelongsTo: function(store, serializer, type, data, association) {
+    var dataToLoad = serializer._extractEmbeddedBelongsTo(type, data, association.key),
+        typeToLoad = association.type;
+
+    if (dataToLoad) {
+      var id = store.adapterForType(typeToLoad).extractId(typeToLoad, dataToLoad);
+      serializer.replaceEmbeddedBelongsTo(type, data, association.key, id);
+      store.load(association.type, dataToLoad);
+    }
+  },
+
+  groupByType: function(enumerable) {
+    var map = Ember.MapWithDefault.create({
+      defaultValue: function() { return Ember.OrderedSet.create(); }
+    });
+
+    enumerable.forEach(function(item) {
+      map.get(item.constructor).add(item);
+    });
+
+    return map;
+  },
+
+  processRelationship: function(relationship) {
+    // TODO: Track changes to relationships made after a
+    // materialization request but before the adapter
+    // responds. [tomhuda]
+  },
+
   commit: function(store, commitDetails) {
-    commitDetails.updated.eachType(function(type, array) {
-      this.updateRecords(store, type, array.slice());
+    this.save(store, commitDetails);
+  },
+
+  save: function(store, commitDetails) {
+    this.groupByType(commitDetails.created).forEach(function(type, set) {
+      this.createRecords(store, type, set.copy());
     }, this);
 
-    commitDetails.created.eachType(function(type, array) {
-      this.createRecords(store, type, array.slice());
+    this.groupByType(commitDetails.updated).forEach(function(type, set) {
+      this.updateRecords(store, type, set.copy());
     }, this);
 
-    commitDetails.deleted.eachType(function(type, array) {
-      this.deleteRecords(store, type, array.slice());
+    this.groupByType(commitDetails.deleted).forEach(function(type, set) {
+      this.deleteRecords(store, type, set.copy());
     }, this);
   },
 
@@ -3665,38 +6081,32 @@ DS.Adapter = Ember.Object.extend({
   }
 });
 
-})();
+DS.Adapter.reopenClass({
+  registerTransform: function(attributeType, transform) {
+    var registeredTransforms = this._registeredTransforms || {};
 
+    registeredTransforms[attributeType] = transform;
 
+    this._registeredTransforms = registeredTransforms;
+  },
 
-(function() {
-var set = Ember.set;
+  map: DS._Mappable.generateMapFunctionFor('attributes', function(key, newValue, map) {
+    var existingValue = map.get(key);
 
-Ember.onLoad('application', function(app) {
-  app.registerInjection({
-    name: "store",
-    before: "controllers",
-
-    injection: function(app, stateManager, property) {
-      if (property === 'Store') {
-        set(stateManager, 'store', app[property].create());
-      }
+    for (var prop in newValue) {
+      if (!newValue.hasOwnProperty(prop)) { continue; }
+      existingValue[prop] = newValue[prop];
     }
-  });
+  }),
 
-  app.registerInjection({
-    name: "giveStoreToControllers",
-
-    injection: function(app, stateManager, property) {
-      if (property.match(/Controller$/)) {
-        var controllerName = property.charAt(0).toLowerCase() + property.substr(1);
-        var store = stateManager.get('store');
-        var controller = stateManager.get(controllerName);
-
-        controller.set('store', store);
-      }
+  resolveMapConflict: function(oldValue, newValue, mappingsKey) {
+    for (var prop in oldValue) {
+      if (!oldValue.hasOwnProperty(prop)) { continue; }
+      newValue[prop] = oldValue[prop];
     }
-  });
+
+    return newValue;
+  }
 });
 
 })();
@@ -3730,7 +6140,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
     Implement this method in order to provide provide json for CRUD methods
   */
   mockJSON: function(type, record) {
-    return record.toJSON({associations: true});
+    return this.serialize(record, { includeId: true });
   },
 
   /*
@@ -3766,7 +6176,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
         return ids.indexOf(item.id) !== -1;
       });
     }
-  
+
     if (fixtures) {
       this.simulateRemoteCall(function() {
         store.loadMany(type, fixtures);
@@ -3781,12 +6191,13 @@ DS.FixtureAdapter = DS.Adapter.extend({
 
     this.simulateRemoteCall(function() {
       store.loadMany(type, fixtures);
+      store.didUpdateAll(type);
     }, store, type);
   },
 
   findQuery: function(store, type, query, array) {
     var fixtures = this.fixturesForType(type);
-    
+
     Ember.assert("Unable to find fixtures for model type "+type.toString(), !!fixtures);
 
     fixtures = this.queryFixtures(fixtures, query);
@@ -3804,7 +6215,7 @@ DS.FixtureAdapter = DS.Adapter.extend({
     fixture.id = this.generateIdForRecord(store, record);
 
     this.simulateRemoteCall(function() {
-      store.didCreateRecord(record, fixture);
+      store.didSaveRecord(record, fixture);
     }, store, type, record);
   },
 
@@ -3812,13 +6223,13 @@ DS.FixtureAdapter = DS.Adapter.extend({
     var fixture = this.mockJSON(type, record);
 
     this.simulateRemoteCall(function() {
-      store.didUpdateRecord(record, fixture);
+      store.didSaveRecord(record, fixture);
     }, store, type, record);
   },
 
   deleteRecord: function(store, type, record) {
     this.simulateRemoteCall(function() {
-      store.didDeleteRecord(record);
+      store.didSaveRecord(record);
     }, store, type, record);
   },
 
@@ -3841,33 +6252,81 @@ DS.fixtureAdapter = DS.FixtureAdapter.create();
 
 
 (function() {
+var get = Ember.get;
+
+DS.RESTSerializer = DS.JSONSerializer.extend({
+  keyForBelongsTo: function(type, name) {
+    return this.keyForAttributeName(type, name) + "_id";
+  },
+
+  keyForAttributeName: function(type, name) {
+    return Ember.String.decamelize(name);
+  },
+
+  addBelongsTo: function(hash, record, key, relationship) {
+    var id = get(record, relationship.key+'.id');
+
+    if (!Ember.none(id)) { hash[key] = id; }
+  }
+});
+
+})();
+
+
+
+(function() {
 /*global jQuery*/
 
 var get = Ember.get, set = Ember.set;
 
 DS.RESTAdapter = DS.Adapter.extend({
   bulkCommit: false,
-	
+
+  serializer: DS.RESTSerializer,
+
   createRecord: function(store, type, record) {
     var root = this.rootForType(type);
 
     var data = {};
-    data[root] = record.toJSON();
+    data[root] = this.serialize(record, { includeId: true });
 
     this.ajax(this.buildURL(root), "POST", {
       data: data,
       context: this,
       success: function(json) {
         this.didCreateRecord(store, type, record, json);
+      },
+      error: function(xhr) {
+        this.didError(store, type, record, xhr);
       }
     });
+  },
+
+  dirtyRecordsForHasManyChange: Ember.K,
+
+  didSaveRecord: function(store, record, hash) {
+    record.eachAssociation(function(name, meta) {
+      if (meta.kind === 'belongsTo') {
+        store.didUpdateRelationship(record, name);
+      }
+    });
+
+    store.didSaveRecord(record, hash);
+  },
+
+  didSaveRecords: function(store, records, array) {
+    var i = 0;
+
+    records.forEach(function(record) {
+      this.didSaveRecord(store, record, array && array[i++]);
+    }, this);
   },
 
   didCreateRecord: function(store, type, record, json) {
     var root = this.rootForType(type);
 
     this.sideload(store, type, json, root);
-    store.didCreateRecord(record, json[root]);
+    this.didSaveRecord(store, record, json[root]);
   },
 
   createRecords: function(store, type, records) {
@@ -3879,9 +6338,10 @@ DS.RESTAdapter = DS.Adapter.extend({
         plural = this.pluralize(root);
 
     var data = {};
-    data[plural] = records.map(function(record) {
-      return record.toJSON();
-    });
+    data[plural] = [];
+    records.forEach(function(record) {
+      data[plural].push(this.serialize(record, { includeId: true }));
+    }, this);
 
     this.ajax(this.buildURL(root), "POST", {
       data: data,
@@ -3896,7 +6356,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     var root = this.pluralize(this.rootForType(type));
 
     this.sideload(store, type, json, root);
-    store.didCreateRecords(type, records, json[root]);
+    this.didSaveRecords(store, records, json[root]);
   },
 
   updateRecord: function(store, type, record) {
@@ -3904,13 +6364,16 @@ DS.RESTAdapter = DS.Adapter.extend({
     var root = this.rootForType(type);
 
     var data = {};
-    data[root] = record.toJSON();
+    data[root] = this.serialize(record);
 
     this.ajax(this.buildURL(root, id), "PUT", {
       data: data,
       context: this,
       success: function(json) {
         this.didUpdateRecord(store, type, record, json);
+      },
+      error: function(xhr) {
+        this.didError(store, type, record, xhr);
       }
     });
   },
@@ -3919,7 +6382,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     var root = this.rootForType(type);
 
     this.sideload(store, type, json, root);
-    store.didUpdateRecord(record, json && json[root]);
+    this.didSaveRecord(store, record, json && json[root]);
   },
 
   updateRecords: function(store, type, records) {
@@ -3931,9 +6394,10 @@ DS.RESTAdapter = DS.Adapter.extend({
         plural = this.pluralize(root);
 
     var data = {};
-    data[plural] = records.map(function(record) {
-      return record.toJSON();
-    });
+    data[plural] = [];
+    records.forEach(function(record) {
+      data[plural].push(this.serialize(record, { includeId: true }));
+    }, this);
 
     this.ajax(this.buildURL(root, "bulk"), "PUT", {
       data: data,
@@ -3948,7 +6412,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     var root = this.pluralize(this.rootForType(type));
 
     this.sideload(store, type, json, root);
-    store.didUpdateRecords(records, json[root]);
+    this.didSaveRecords(store, records, json[root]);
   },
 
   deleteRecord: function(store, type, record) {
@@ -3965,7 +6429,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
   didDeleteRecord: function(store, type, record, json) {
     if (json) { this.sideload(store, type, json); }
-    store.didDeleteRecord(record);
+    this.didSaveRecord(store, record);
   },
 
   deleteRecords: function(store, type, records) {
@@ -3974,11 +6438,13 @@ DS.RESTAdapter = DS.Adapter.extend({
     }
 
     var root = this.rootForType(type),
-        plural = this.pluralize(root);
+        plural = this.pluralize(root),
+        serializer = get(this, 'serializer');
 
     var data = {};
-    data[plural] = records.map(function(record) {
-      return get(record, 'id');
+    data[plural] = [];
+    records.forEach(function(record) {
+      data[plural].push(serializer.serializeId( get(record, 'id') ));
     });
 
     this.ajax(this.buildURL(root, 'bulk'), "DELETE", {
@@ -3992,7 +6458,7 @@ DS.RESTAdapter = DS.Adapter.extend({
 
   didDeleteRecords: function(store, type, records, json) {
     if (json) { this.sideload(store, type, json); }
-    store.didDeleteRecords(records);
+    this.didSaveRecords(store, records);
   },
 
   find: function(store, type, id) {
@@ -4000,45 +6466,102 @@ DS.RESTAdapter = DS.Adapter.extend({
 
     this.ajax(this.buildURL(root, id), "GET", {
       success: function(json) {
-        this.sideload(store, type, json, root);
-        store.load(type, json[root]);
+        this.didFindRecord(store, type, json, id);
       }
     });
   },
 
-  findMany: function(store, type, ids) {
-    var root = this.rootForType(type), plural = this.pluralize(root);
+  didFindRecord: function(store, type, json, id) {
+    var root = this.rootForType(type);
+
+    this.sideload(store, type, json, root);
+    store.load(type, id, json[root]);
+  },
+
+  findAll: function(store, type, since) {
+    var root = this.rootForType(type);
 
     this.ajax(this.buildURL(root), "GET", {
-      data: { ids: ids },
+      data: this.sinceQuery(since),
       success: function(json) {
-        this.sideload(store, type, json, plural);
-        store.loadMany(type, json[plural]);
+        this.didFindAll(store, type, json);
       }
     });
   },
 
-  findAll: function(store, type) {
-    var root = this.rootForType(type), plural = this.pluralize(root);
+  didFindAll: function(store, type, json) {
+    var root = this.pluralize(this.rootForType(type)),
+        since = this.extractSince(json);
 
-    this.ajax(this.buildURL(root), "GET", {
-      success: function(json) {
-        this.sideload(store, type, json, plural);
-        store.loadMany(type, json[plural]);
-      }
-    });
+    this.sideload(store, type, json, root);
+    store.loadMany(type, json[root]);
+
+    // this registers the id with the store, so it will be passed
+    // into the next call to `findAll`
+    if (since) { store.sinceForType(type, since); }
+
+    store.didUpdateAll(type);
   },
 
   findQuery: function(store, type, query, recordArray) {
-    var root = this.rootForType(type), plural = this.pluralize(root);
+    var root = this.rootForType(type);
 
     this.ajax(this.buildURL(root), "GET", {
       data: query,
       success: function(json) {
-        this.sideload(store, type, json, plural);
-        recordArray.load(json[plural]);
+        this.didFindQuery(store, type, json, recordArray);
       }
     });
+  },
+
+  didFindQuery: function(store, type, json, recordArray) {
+    var root = this.pluralize(this.rootForType(type));
+
+    this.sideload(store, type, json, root);
+    recordArray.load(json[root]);
+  },
+
+  findMany: function(store, type, ids) {
+    var root = this.rootForType(type);
+    ids = this.serializeIds(ids);
+
+    this.ajax(this.buildURL(root), "GET", {
+      data: {ids: ids},
+      success: function(json) {
+        this.didFindMany(store, type, json);
+      }
+    });
+  },
+
+  /**
+    @private
+
+    This method serializes a list of IDs using `serializeId`
+
+    @returns {Array} an array of serialized IDs
+  */
+  serializeIds: function(ids) {
+    var serializer = get(this, 'serializer');
+
+    return Ember.EnumerableUtils.map(ids, function(id) {
+      return serializer.serializeId(id);
+    });
+  },
+
+  didFindMany: function(store, type, json) {
+    var root = this.pluralize(this.rootForType(type));
+
+    this.sideload(store, type, json, root);
+    store.loadMany(type, json[root]);
+  },
+
+  didError: function(store, type, record, xhr) {
+    if (xhr.status === 422) {
+      var data = JSON.parse(xhr.responseText);
+      store.recordWasInvalid(record, data['errors']);
+    } else {
+      store.recordWasError(record);
+    }
   },
 
   // HELPERS
@@ -4082,6 +6605,7 @@ DS.RESTAdapter = DS.Adapter.extend({
     for (var prop in json) {
       if (!json.hasOwnProperty(prop)) { continue; }
       if (prop === root) { continue; }
+      if (prop === get(this, 'meta')) { continue; }
 
       sideloadedType = type.typeForAssociation(prop);
 
@@ -4126,8 +6650,10 @@ DS.RESTAdapter = DS.Adapter.extend({
     }
   },
 
+  url: "",
+
   buildURL: function(record, suffix) {
-    var url = [""];
+    var url = [this.url];
 
     Ember.assert("Namespace URL (" + this.namespace + ") must not start with slash", !this.namespace || this.namespace.toString().charAt(0) !== "/");
     Ember.assert("Record URL (" + record + ") must not start with slash", !record || record.toString().charAt(0) !== "/");
@@ -4143,9 +6669,33 @@ DS.RESTAdapter = DS.Adapter.extend({
     }
 
     return url.join("/");
+  },
+
+  meta: 'meta',
+  since: 'since',
+
+  sinceQuery: function(since) {
+    var query = {};
+    query[get(this, 'since')] = since;
+    return since ? query : null;
+  },
+
+  extractSince: function(json) {
+    var meta = this.extractMeta(json);
+    return meta[get(this, 'since')] || null;
+  },
+
+  extractMeta: function(json) {
+    return json[get(this, 'meta')] || {};
   }
 });
 
+
+})();
+
+
+
+(function() {
 
 })();
 

--- a/assets/javascripts/vendor/ember.js
+++ b/assets/javascripts/vendor/ember.js
@@ -1,5 +1,5 @@
-// Version: v1.0.pre-151-gb993a76
-// Last commit: b993a76 (2012-09-18 21:53:28 -0700)
+// Version: v1.0.0-pre.2-103-g9fc4d5d
+// Last commit: 9fc4d5d (2012-12-09 11:22:46 -0800)
 
 
 (function() {
@@ -32,18 +32,19 @@ if (!('MANDATORY_SETTER' in Ember.ENV)) {
 
 /**
   Define an assertion that will throw an exception if the condition is not
-  met.  Ember build tools will remove any calls to Ember.assert() when
+  met. Ember build tools will remove any calls to `Ember.assert()` when
   doing a production build. Example:
 
-      // Test for truthiness
-      Ember.assert('Must pass a valid object', obj);
-      // Fail unconditionally
-      Ember.assert('This code path should never be run')
+  ```javascript
+  // Test for truthiness
+  Ember.assert('Must pass a valid object', obj);
+  // Fail unconditionally
+  Ember.assert('This code path should never be run')
+  ```
 
   @method assert
-  @param {String} desc A description of the assertion.  This will become
+  @param {String} desc A description of the assertion. This will become
     the text of the Error thrown if the assertion fails.
-
   @param {Boolean} test Must be truthy for the assertion to pass. If
     falsy, an exception will be thrown.
 */
@@ -54,7 +55,7 @@ Ember.assert = function(desc, test) {
 
 /**
   Display a warning with the provided message. Ember build tools will
-  remove any calls to Ember.warn() when doing a production build.
+  remove any calls to `Ember.warn()` when doing a production build.
 
   @method warn
   @param {String} message A warning to display.
@@ -71,7 +72,7 @@ Ember.warn = function(message, test) {
 /**
   Display a deprecation warning with the provided message and a stack trace
   (Chrome and Firefox only). Ember build tools will remove any calls to
-  Ember.deprecate() when doing a production build.
+  `Ember.deprecate()` when doing a production build.
 
   @method deprecate
   @param {String} message A description of the deprecation.
@@ -118,7 +119,7 @@ Ember.deprecate = function(message, test) {
   Display a deprecation warning with the provided message and a stack trace
   (Chrome and Firefox only) when the wrapped method is called.
 
-  Ember build tools will not remove calls to Ember.deprecateFunc(), though
+  Ember build tools will not remove calls to `Ember.deprecateFunc()`, though
   no warnings will be shown in production.
 
   @method deprecateFunc
@@ -132,18 +133,51 @@ Ember.deprecateFunc = function(message, func) {
   };
 };
 
-
-window.ember_assert         = Ember.deprecateFunc("ember_assert is deprecated. Please use Ember.assert instead.",               Ember.assert);
-window.ember_warn           = Ember.deprecateFunc("ember_warn is deprecated. Please use Ember.warn instead.",                   Ember.warn);
-window.ember_deprecate      = Ember.deprecateFunc("ember_deprecate is deprecated. Please use Ember.deprecate instead.",         Ember.deprecate);
-window.ember_deprecateFunc  = Ember.deprecateFunc("ember_deprecateFunc is deprecated. Please use Ember.deprecateFunc instead.", Ember.deprecateFunc);
+if ('undefined' !== typeof window) {
+  window.ember_assert         = Ember.deprecateFunc("ember_assert is deprecated. Please use Ember.assert instead.",               Ember.assert);
+  window.ember_warn           = Ember.deprecateFunc("ember_warn is deprecated. Please use Ember.warn instead.",                   Ember.warn);
+  window.ember_deprecate      = Ember.deprecateFunc("ember_deprecate is deprecated. Please use Ember.deprecate instead.",         Ember.deprecate);
+  window.ember_deprecateFunc  = Ember.deprecateFunc("ember_deprecateFunc is deprecated. Please use Ember.deprecateFunc instead.", Ember.deprecateFunc);
+}
 
 })();
 
-// Version: v1.0.pre-151-gb993a76
-// Last commit: b993a76 (2012-09-18 21:53:28 -0700)
+// Version: v1.0.0-pre.2-103-g9fc4d5d
+// Last commit: 9fc4d5d (2012-12-09 11:22:46 -0800)
 
 
+(function() {
+var define, requireModule;
+
+(function() {
+  var registry = {}, seen = {};
+
+  define = function(name, deps, callback) {
+    registry[name] = { deps: deps, callback: callback };
+  };
+
+  requireModule = function(name) {
+    if (seen[name]) { return seen[name]; }
+    seen[name] = {};
+
+    var mod = registry[name],
+        deps = mod.deps,
+        callback = mod.callback,
+        reified = [],
+        exports;
+
+    for (var i=0, l=deps.length; i<l; i++) {
+      if (deps[i] === 'exports') {
+        reified.push(exports = {});
+      } else {
+        reified.push(requireModule(deps[i]));
+      }
+    }
+
+    var value = callback.apply(this, reified);
+    return seen[name] = exports || value;
+  };
+})();
 (function() {
 /*globals Em:true ENV */
 
@@ -153,24 +187,23 @@ window.ember_deprecateFunc  = Ember.deprecateFunc("ember_deprecateFunc is deprec
 */
 
 /**
-  All Ember methods and functions are defined inside of this namespace.
-  You generally should not add new properties to this namespace as it may be
+  All Ember methods and functions are defined inside of this namespace. You
+  generally should not add new properties to this namespace as it may be
   overwritten by future versions of Ember.
 
-  You can also use the shorthand "Em" instead of "Ember".
+  You can also use the shorthand `Em` instead of `Ember`.
 
-  Ember-Runtime is a framework that provides core functions for
-  Ember including cross-platform functions, support for property
-  observing and objects. Its focus is on small size and performance. You can
-  use this in place of or along-side other cross-platform libraries such as
-  jQuery.
+  Ember-Runtime is a framework that provides core functions for Ember including
+  cross-platform functions, support for property observing and objects. Its
+  focus is on small size and performance. You can use this in place of or
+  along-side other cross-platform libraries such as jQuery.
 
   The core Runtime framework is based on the jQuery API with a number of
   performance optimizations.
 
   @class Ember
   @static
-  @version 1.0.pre
+  @version 1.0.0-pre.2
 */
 
 if ('undefined' === typeof Ember) {
@@ -179,10 +212,13 @@ if ('undefined' === typeof Ember) {
   Ember = {};
 }
 
+// Default imports, exports and lookup to the global object;
+var imports = Ember.imports = Ember.imports || this;
+var exports = Ember.exports = Ember.exports || this;
+var lookup  = Ember.lookup  = Ember.lookup  || this;
+
 // aliases needed to keep minifiers from removing the global context
-if ('undefined' !== typeof window) {
-  window.Em = window.Ember = Em = Ember;
-}
+exports.Em = exports.Ember = Em = Ember;
 
 // Make sure these are set whether Ember was already defined or not
 
@@ -194,13 +230,13 @@ Ember.toString = function() { return "Ember"; };
 /**
   @property VERSION
   @type String
-  @default '1.0.pre'
+  @default '1.0.0-pre.2'
   @final
 */
-Ember.VERSION = '1.0.pre';
+Ember.VERSION = '1.0.0-pre.2';
 
 /**
-  Standard environmental variables.  You can define these in a global `ENV`
+  Standard environmental variables. You can define these in a global `ENV`
   variable before loading Ember to control various configuration
   settings.
 
@@ -216,20 +252,24 @@ Ember.config = Ember.config || {};
 //
 
 /**
-  Determines whether Ember should enhances some built-in object
-  prototypes to provide a more friendly API.  If enabled, a few methods
-  will be added to Function, String, and Array.  Object.prototype will not be
-  enhanced, which is the one that causes most troubles for people.
+  Determines whether Ember should enhances some built-in object prototypes to
+  provide a more friendly API. If enabled, a few methods will be added to
+  `Function`, `String`, and `Array`. `Object.prototype` will not be enhanced,
+  which is the one that causes most trouble for people.
 
   In general we recommend leaving this option set to true since it rarely
-  conflicts with other code.  If you need to turn it off however, you can
-  define an ENV.EXTEND_PROTOTYPES config to disable it.
+  conflicts with other code. If you need to turn it off however, you can
+  define an `ENV.EXTEND_PROTOTYPES` config to disable it.
 
   @property EXTEND_PROTOTYPES
   @type Boolean
   @default true
 */
-Ember.EXTEND_PROTOTYPES = (Ember.ENV.EXTEND_PROTOTYPES !== false);
+Ember.EXTEND_PROTOTYPES = Ember.ENV.EXTEND_PROTOTYPES;
+
+if (typeof Ember.EXTEND_PROTOTYPES === 'undefined') {
+  Ember.EXTEND_PROTOTYPES = true;
+}
 
 /**
   Determines whether Ember logs a full stack trace during deprecation warnings
@@ -249,62 +289,8 @@ Ember.LOG_STACKTRACE_ON_DEPRECATION = (Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION !
 */
 Ember.SHIM_ES5 = (Ember.ENV.SHIM_ES5 === false) ? false : Ember.EXTEND_PROTOTYPES;
 
-
 /**
-  Determines whether computed properties are cacheable by default.
-  This option will be removed for the 1.1 release.
-
-  When caching is enabled by default, you can use `volatile()` to disable
-  caching on individual computed properties.
-
-  @property CP_DEFAULT_CACHEABLE
-  @type Boolean
-  @default true
-*/
-Ember.CP_DEFAULT_CACHEABLE = (Ember.ENV.CP_DEFAULT_CACHEABLE !== false);
-
-/**
-  Determines whether views render their templates using themselves
-  as the context, or whether it is inherited from the parent. This option
-  will be removed in the 1.1 release.
-
-  If you need to update your application to use the new context rules, simply
-  prefix property access with `view.`:
-
-  Before:
-
-  ``` handlebars
-  {{#each App.photosController}}
-    Photo Title: {{title}}
-    {{#view App.InfoView contentBinding="this"}}
-      {{content.date}}
-      {{content.cameraType}}
-      {{otherViewProperty}}
-    {{/view}}
-  {{/each}}
-  ```
-
-  After:
-
-  ``` handlebars
-  {{#each App.photosController}}
-    Photo Title: {{title}}
-    {{#view App.InfoView}}
-      {{date}}
-      {{cameraType}}
-      {{view.otherViewProperty}}
-    {{/view}}
-  {{/each}}
-  ```
-
-  @property VIEW_PRESERVES_CONTEXT
-  @type Boolean
-  @default true
-*/
-Ember.VIEW_PRESERVES_CONTEXT = (Ember.ENV.VIEW_PRESERVES_CONTEXT !== false);
-
-/**
-  Empty function.  Useful for some operations.
+  Empty function. Useful for some operations.
 
   @method K
   @private
@@ -324,26 +310,35 @@ if ('undefined' === typeof Ember.deprecateFunc) {
 
 // These are deprecated but still supported
 
-if ('undefined' === typeof ember_assert) { window.ember_assert = Ember.K; }
-if ('undefined' === typeof ember_warn) { window.ember_warn = Ember.K; }
-if ('undefined' === typeof ember_deprecate) { window.ember_deprecate = Ember.K; }
+if ('undefined' === typeof ember_assert) { exports.ember_assert = Ember.K; }
+if ('undefined' === typeof ember_warn) { exports.ember_warn = Ember.K; }
+if ('undefined' === typeof ember_deprecate) { exports.ember_deprecate = Ember.K; }
 if ('undefined' === typeof ember_deprecateFunc) {
-  window.ember_deprecateFunc = function(_, func) { return func; };
+  exports.ember_deprecateFunc = function(_, func) { return func; };
 }
 
+/**
+  Previously we used `Ember.$.uuid`, however `$.uuid` has been removed from
+  jQuery master. We'll just bootstrap our own uuid now.
+
+  @property uuid
+  @type Number
+  @private
+*/
+Ember.uuid = 0;
 
 // ..........................................................
 // LOGGER
 //
 
 /**
-  Inside Ember-Metal, simply uses the window.console object.
+  Inside Ember-Metal, simply uses the `imports.console` object.
   Override this to provide more robust logging functionality.
 
   @class Logger
   @namespace Ember
 */
-Ember.Logger = window.console || { log: Ember.K, warn: Ember.K, error: Ember.K, info: Ember.K, debug: Ember.K };
+Ember.Logger = imports.console || { log: Ember.K, warn: Ember.K, error: Ember.K, info: Ember.K, debug: Ember.K };
 
 
 // ..........................................................
@@ -351,8 +346,9 @@ Ember.Logger = window.console || { log: Ember.K, warn: Ember.K, error: Ember.K, 
 //
 
 /**
-  A function may be assigned to `Ember.onerror` to be called when Ember internals encounter an error.
-  This is useful for specialized error handling and reporting code.
+  A function may be assigned to `Ember.onerror` to be called when Ember
+  internals encounter an error. This is useful for specialized error handling
+  and reporting code.
 
   @event onerror
   @for Ember
@@ -383,6 +379,182 @@ Ember.handleErrors = function(func, context) {
     return func.apply(context || this);
   }
 };
+
+Ember.merge = function(original, updates) {
+  for (var prop in updates) {
+    if (!updates.hasOwnProperty(prop)) { continue; }
+    original[prop] = updates[prop];
+  }
+};
+
+})();
+
+
+
+(function() {
+/**
+  The purpose of the Ember Instrumentation module is
+  to provide efficient, general-purpose instrumentation
+  for Ember.
+
+  Subscribe to a listener by using `Ember.subscribe`:
+
+  ```javascript
+  Ember.subscribe("render", {
+    before: function(name, timestamp, payload) {
+
+    },
+
+    after: function(name, timestamp, payload) {
+
+    }
+  });
+  ```
+
+  If you return a value from the `before` callback, that same
+  value will be passed as a fourth parameter to the `after`
+  callback.
+
+  Instrument a block of code by using `Ember.instrument`:
+
+  ```javascript
+  Ember.instrument("render.handlebars", payload, function() {
+    // rendering logic
+  }, binding);
+  ```
+
+  Event names passed to `Ember.instrument` are namespaced
+  by periods, from more general to more specific. Subscribers
+  can listen for events by whatever level of granularity they
+  are interested in.
+
+  In the above example, the event is `render.handlebars`,
+  and the subscriber listened for all events beginning with
+  `render`. It would receive callbacks for events named
+  `render`, `render.handlebars`, `render.container`, or
+  even `render.handlebars.layout`.
+
+  @class Instrumentation
+  @namespace Ember
+  @static
+*/
+Ember.Instrumentation = {};
+
+var subscribers = [], cache = {};
+
+var populateListeners = function(name) {
+  var listeners = [], subscriber;
+
+  for (var i=0, l=subscribers.length; i<l; i++) {
+    subscriber = subscribers[i];
+    if (subscriber.regex.test(name)) {
+      listeners.push(subscriber.object);
+    }
+  }
+
+  cache[name] = listeners;
+  return listeners;
+};
+
+var time = (function() {
+	var perf = 'undefined' !== typeof window ? window.performance || {} : {};
+	var fn = perf.now || perf.mozNow || perf.webkitNow || perf.msNow || perf.oNow;
+	// fn.bind will be available in all the browsers that support the advanced window.performance... ;-)
+	return fn ? fn.bind(perf) : function() { return +new Date(); };
+})();
+
+
+Ember.Instrumentation.instrument = function(name, payload, callback, binding) {
+  var listeners = cache[name], timeName, ret;
+
+  if (Ember.STRUCTURED_PROFILE) {
+    timeName = name + ": " + payload.object;
+    console.time(timeName);
+  }
+
+  if (!listeners) {
+    listeners = populateListeners(name);
+  }
+
+  if (listeners.length === 0) {
+    ret = callback.call(binding);
+    if (Ember.STRUCTURED_PROFILE) { console.timeEnd(timeName); }
+    return ret;
+  }
+
+  var beforeValues = [], listener, i, l;
+
+  try {
+    for (i=0, l=listeners.length; i<l; i++) {
+      listener = listeners[i];
+      beforeValues[i] = listener.before(name, time(), payload);
+    }
+
+    ret = callback.call(binding);
+  } catch(e) {
+    payload = payload || {};
+    payload.exception = e;
+  } finally {
+    for (i=0, l=listeners.length; i<l; i++) {
+      listener = listeners[i];
+      listener.after(name, time(), payload, beforeValues[i]);
+    }
+
+    if (Ember.STRUCTURED_PROFILE) {
+      console.timeEnd(timeName);
+    }
+  }
+
+  return ret;
+};
+
+Ember.Instrumentation.subscribe = function(pattern, object) {
+  var paths = pattern.split("."), path, regex = [];
+
+  for (var i=0, l=paths.length; i<l; i++) {
+    path = paths[i];
+    if (path === "*") {
+      regex.push("[^\\.]*");
+    } else {
+      regex.push(path);
+    }
+  }
+
+  regex = regex.join("\\.");
+  regex = regex + "(\\..*)?";
+
+  var subscriber = {
+    pattern: pattern,
+    regex: new RegExp("^" + regex + "$"),
+    object: object
+  };
+
+  subscribers.push(subscriber);
+  cache = {};
+
+  return subscriber;
+};
+
+Ember.Instrumentation.unsubscribe = function(subscriber) {
+  var index;
+
+  for (var i=0, l=subscribers.length; i<l; i++) {
+    if (subscribers[i] === subscriber) {
+      index = i;
+    }
+  }
+
+  subscribers.splice(index, 1);
+  cache = {};
+};
+
+Ember.Instrumentation.reset = function() {
+  subscribers = [];
+  cache = {};
+};
+
+Ember.instrument = Ember.Instrumentation.instrument;
+Ember.subscribe = Ember.Instrumentation.subscribe;
 
 })();
 
@@ -487,9 +659,23 @@ var utils = Ember.EnumerableUtils = {
     });
   },
 
+  addObject: function(array, item) {
+    var index = utils.indexOf(array, item);
+    if (index === -1) { array.push(item); }
+  },
+
   removeObject: function(array, item) {
     var index = utils.indexOf(array, item);
     if (index !== -1) { array.splice(index, 1); }
+  },
+
+  replace: function(array, idx, amt, objects) {
+    if (array.replace) {
+      return array.replace(idx, amt, objects);
+    } else {
+      var args = Array.prototype.concat.apply([idx, amt], objects);
+      return array.splice.apply(array, args);
+    }
   }
 };
 
@@ -529,7 +715,8 @@ var platform = Ember.platform = {};
 
 
 /**
-  Identical to Object.create().  Implements if not available natively.
+  Identical to `Object.create()`. Implements if not available natively.
+
   @method create
   @for Ember
 */
@@ -630,7 +817,7 @@ if (defineProperty) {
 */
 
 /**
-  Identical to Object.defineProperty().  Implements as much functionality
+  Identical to `Object.defineProperty()`. Implements as much functionality
   as possible if not available natively.
 
   @method defineProperty
@@ -710,20 +897,18 @@ var GUID_DESC = {
   @private
 
   Generates a new guid, optionally saving the guid to the object that you
-  pass in.  You will rarely need to use this method.  Instead you should
-  call Ember.guidFor(obj), which return an existing guid if available.
+  pass in. You will rarely need to use this method. Instead you should
+  call `Ember.guidFor(obj)`, which return an existing guid if available.
 
   @method generateGuid
   @for Ember
-  @param {Object} [obj] Object the guid will be used for.  If passed in, the guid will
+  @param {Object} [obj] Object the guid will be used for. If passed in, the guid will
     be saved on the object and reused whenever you pass the same object
     again.
 
     If no object is passed, just generate a new guid.
-
-  @param {String} [prefix] Prefix to place in front of the guid.  Useful when you want to
+  @param {String} [prefix] Prefix to place in front of the guid. Useful when you want to
     separate the guid into separate namespaces.
-
   @return {String} the guid
 */
 Ember.generateGuid = function generateGuid(obj, prefix) {
@@ -739,9 +924,10 @@ Ember.generateGuid = function generateGuid(obj, prefix) {
 /**
   @private
 
-  Returns a unique id for the object.  If the object does not yet have
-  a guid, one will be assigned to it.  You can call this on any object,
-  Ember.Object-based or not, but be aware that it will add a _guid property.
+  Returns a unique id for the object. If the object does not yet have a guid,
+  one will be assigned to it. You can call this on any object,
+  `Ember.Object`-based or not, but be aware that it will add a `_guid`
+  property.
 
   You can also use this method on DOM Element objects.
 
@@ -836,14 +1022,18 @@ if (isDefinePropertySimulated) {
   // jQuery.extend() by having a property that fails
   // hasOwnProperty check.
   Meta.prototype.__preventPlainObject__ = true;
+
+  // Without non-enumerable properties, meta objects will be output in JSON
+  // unless explicitly suppressed
+  Meta.prototype.toJSON = function () { };
 }
 
 /**
-  Retrieves the meta hash for an object.  If 'writable' is true ensures the
+  Retrieves the meta hash for an object. If `writable` is true ensures the
   hash is writable for this object as well.
 
   The meta object contains information about computed property descriptors as
-  well as any watched properties and other information.  You generally will
+  well as any watched properties and other information. You generally will
   not access this information directly but instead work with higher level
   methods that manipulate this hash indirectly.
 
@@ -852,10 +1042,8 @@ if (isDefinePropertySimulated) {
   @private
 
   @param {Object} obj The object to retrieve meta for
-
-  @param {Boolean} [writable=true] Pass false if you do not intend to modify
+  @param {Boolean} [writable=true] Pass `false` if you do not intend to modify
     the meta hash, allowing the method to avoid making an unnecessary copy.
-
   @return {Hash}
 */
 Ember.meta = function meta(obj, writable) {
@@ -915,7 +1103,7 @@ Ember.setMeta = function setMeta(obj, property, value) {
 
   This method allows extensions to deeply clone a series of nested hashes or
   other complex objects. For instance, the event system might pass
-  ['listeners', 'foo:change', 'ember157'] to `prepareMetaPath`, which will
+  `['listeners', 'foo:change', 'ember157']` to `prepareMetaPath`, which will
   walk down the keys provided.
 
   For each key, if the key does not exist, it is created. If it already
@@ -960,7 +1148,7 @@ Ember.metaPath = function metaPath(obj, path, writable) {
   @private
 
   Wraps the passed function so that `this._super` will point to the superFunc
-  when the function is invoked.  This is the primitive we use to implement
+  when the function is invoked. This is the primitive we use to implement
   calls to super.
 
   @method wrap
@@ -994,12 +1182,14 @@ Ember.wrap = function(func, superFunc) {
     - the object is a native Array
     - the object is an Object, and has a length property
 
-  Unlike Ember.typeOf this method returns true even if the passed object is
-  not formally array but appears to be array-like (i.e. implements Ember.Array)
+  Unlike `Ember.typeOf` this method returns true even if the passed object is
+  not formally array but appears to be array-like (i.e. implements `Ember.Array`)
 
-      Ember.isArray(); // false
-      Ember.isArray([]); // true
-      Ember.isArray( Ember.ArrayProxy.create({ content: [] }) ); // true
+  ```javascript
+  Ember.isArray();                                            // false
+  Ember.isArray([]);                                          // true
+  Ember.isArray( Ember.ArrayProxy.create({ content: [] }) );  // true
+  ```
 
   @method isArray
   @for Ember
@@ -1015,18 +1205,20 @@ Ember.isArray = function(obj) {
 };
 
 /**
-  Forces the passed object to be part of an array.  If the object is already
-  an array or array-like, returns the object.  Otherwise adds the object to
-  an array.  If obj is null or undefined, returns an empty array.
+  Forces the passed object to be part of an array. If the object is already
+  an array or array-like, returns the object. Otherwise adds the object to
+  an array. If obj is `null` or `undefined`, returns an empty array.
 
-      Ember.makeArray();          => []
-      Ember.makeArray(null);      => []
-      Ember.makeArray(undefined); => []
-      Ember.makeArray('lindsay'); => ['lindsay']
-      Ember.makeArray([1,2,42]);  => [1,2,42]
+  ```javascript
+  Ember.makeArray();                           // []
+  Ember.makeArray(null);                       // []
+  Ember.makeArray(undefined);                  // []
+  Ember.makeArray('lindsay');                  // ['lindsay']
+  Ember.makeArray([1,2,42]);                   // [1,2,42]
 
-      var controller = Ember.ArrayProxy.create({ content: [] });
-      Ember.makeArray(controller) === controller;   => true
+  var controller = Ember.ArrayProxy.create({ content: [] });
+  Ember.makeArray(controller) === controller;  // true
+  ```
 
   @method makeArray
   @for Ember
@@ -1087,12 +1279,12 @@ Ember.tryInvoke = function(obj, methodName, args) {
   keys. Because it is commonly used in low-level bookkeeping, Map is
   implemented as a pure JavaScript object for performance.
 
-  This implementation follows the current iteration of the ES6 proposal
-  for maps (http://wiki.ecmascript.org/doku.php?id=harmony:simple_maps_and_sets),
-  with two exceptions. First, because we need our implementation to be
-  pleasant on older browsers, we do not use the `delete` name (using
-  `remove` instead). Second, as we do not have the luxury of in-VM
-  iteration, we implement a forEach method for iteration.
+  This implementation follows the current iteration of the ES6 proposal for
+  maps (http://wiki.ecmascript.org/doku.php?id=harmony:simple_maps_and_sets),
+  with two exceptions. First, because we need our implementation to be pleasant
+  on older browsers, we do not use the `delete` name (using `remove` instead).
+  Second, as we do not have the luxury of in-VM iteration, we implement a
+  forEach method for iteration.
 
   Map is mocked out to look like an Ember object, so you can do
   `Ember.Map.create()` for symmetry with other Ember classes.
@@ -1121,7 +1313,7 @@ var copyMap = function(original, newObject) {
 };
 
 /**
-  This class is used internally by Ember.js and Ember Data.
+  This class is used internally by Ember and Ember Data.
   Please do not use it at this time. We plan to clean it up
   and add many tests soon.
 
@@ -1248,9 +1440,8 @@ OrderedSet.prototype = {
 
   Internally, a Map has two data structures:
 
-    `keys`: an OrderedSet of all of the existing keys
-    `values`: a JavaScript Object indexed by the
-      Ember.guidFor(key)
+  1. `keys`: an OrderedSet of all of the existing keys
+  2. `values`: a JavaScript Object indexed by the `Ember.guidFor(key)`
 
   When a key/value pair is added for the first time, we
   add the key to the `keys` OrderedSet, and create or
@@ -1281,7 +1472,7 @@ Map.prototype = {
 
     @method get
     @param {anything} key
-    @return {anything} the value associated with the key, or undefined
+    @return {anything} the value associated with the key, or `undefined`
   */
   get: function(key) {
     var values = this.values,
@@ -1395,7 +1586,8 @@ var MapWithDefault = Ember.MapWithDefault = function(options) {
   @static
   @param [options]
     @param {anything} [options.defaultValue]
-  @return {Ember.MapWithDefault|Ember.Map} If options are passed, returns Ember.MapWithDefault otherwise returns Ember.Map
+  @return {Ember.MapWithDefault|Ember.Map} If options are passed, returns 
+    `Ember.MapWithDefault` otherwise returns `Ember.Map`
 */
 MapWithDefault.create = function(options) {
   if (options) {
@@ -1462,28 +1654,28 @@ var FIRST_KEY = /^([^\.\*]+)/;
 // object.
 
 /**
-  Gets the value of a property on an object.  If the property is computed,
-  the function will be invoked.  If the property is not defined but the
-  object implements the unknownProperty() method then that will be invoked.
+  Gets the value of a property on an object. If the property is computed,
+  the function will be invoked. If the property is not defined but the
+  object implements the `unknownProperty` method then that will be invoked.
 
   If you plan to run on IE8 and older browsers then you should use this
   method anytime you want to retrieve a property on an object that you don't
-  know for sure is private.  (My convention only properties beginning with
-  an underscore '_' are considered private.)
+  know for sure is private. (Properties beginning with an underscore '_' 
+  are considered private.)
 
   On all newer browsers, you only need to use this method to retrieve
   properties if the property might not be defined on the object and you want
-  to respect the unknownProperty() handler.  Otherwise you can ignore this
+  to respect the `unknownProperty` handler. Otherwise you can ignore this
   method.
 
-  Note that if the obj itself is null, this method will simply return
-  undefined.
+  Note that if the obj itself is `null`, this method will simply return
+  `undefined`.
 
   @method get
   @for Ember
   @param {Object} obj The object to retrieve from.
   @param {String} keyName The property key to retrieve
-  @return {Object} the property value or null.
+  @return {Object} the property value or `null`.
 */
 get = function get(obj, keyName) {
   // Helpers that operate with 'this' within an #each
@@ -1523,18 +1715,18 @@ get = function get(obj, keyName) {
 
 /**
   Sets the value of a property on an object, respecting computed properties
-  and notifying observers and other listeners of the change.  If the
-  property is not defined but the object implements the unknownProperty()
+  and notifying observers and other listeners of the change. If the
+  property is not defined but the object implements the `unknownProperty`
   method then that will be invoked as well.
 
   If you plan to run on IE8 and older browsers then you should use this
   method anytime you want to set a property on an object that you don't
-  know for sure is private.  (My convention only properties beginning with
-  an underscore '_' are considered private.)
+  know for sure is private. (Properties beginning with an underscore '_' 
+  are considered private.)
 
   On all newer browsers, you only need to use this method to set
   properties if the property might not be defined on the object and you want
-  to respect the unknownProperty() handler.  Otherwise you can ignore this
+  to respect the `unknownProperty` handler. Otherwise you can ignore this
   method.
 
   @method set
@@ -1563,8 +1755,7 @@ set = function set(obj, keyName, value, tolerant) {
       isUnknown, currentValue;
   if (desc) {
     desc.set(obj, keyName, value);
-  }
-  else {
+  } else {
     isUnknown = 'object' === typeof obj && !(keyName in obj);
 
     // setUnknownProperty is called if `obj` is an object,
@@ -1599,6 +1790,15 @@ set = function set(obj, keyName, value, tolerant) {
   return value;
 };
 
+// Currently used only by Ember Data tests
+if (Ember.config.overrideAccessors) {
+  Ember.get = get;
+  Ember.set = set;
+  Ember.config.overrideAccessors();
+  get = Ember.get;
+  set = Ember.set;
+}
+
 function firstKey(path) {
   return path.match(FIRST_KEY)[0];
 }
@@ -1609,10 +1809,10 @@ function normalizeTuple(target, path) {
       isGlobal = !hasThis && IS_GLOBAL_PATH.test(path),
       key;
 
-  if (!target || isGlobal) target = window;
+  if (!target || isGlobal) target = Ember.lookup;
   if (hasThis) path = path.slice(5);
 
-  if (target === window) {
+  if (target === Ember.lookup) {
     key = firstKey(path);
     target = get(target, key);
     path   = path.slice(key.length+1);
@@ -1630,7 +1830,7 @@ function getPath(root, path) {
   // If there is no root and path is a key name, return that
   // property from the global object.
   // E.g. get('Ember') -> Ember
-  if (root === null && path.indexOf('.') === -1) { return get(window, path); }
+  if (root === null && path.indexOf('.') === -1) { return get(Ember.lookup, path); }
 
   // detect complicated paths and normalize them
   hasThis  = HAS_THIS.test(path);
@@ -1682,13 +1882,13 @@ function setPath(root, path, value, tolerant) {
   @private
 
   Normalizes a target/path pair to reflect that actual target/path that should
-  be observed, etc.  This takes into account passing in global property
+  be observed, etc. This takes into account passing in global property
   paths (i.e. a path beginning with a captial letter not defined on the
   target) and * separators.
 
   @method normalizeTuple
   @for Ember
-  @param {Object} target The current target.  May be null.
+  @param {Object} target The current target. May be `null`.
   @param {String} path A path on the target or a global property path.
   @return {Array} a temporary array with the normalized target/path pair.
 */
@@ -1711,8 +1911,8 @@ Ember.set = set;
 Ember.setPath = Ember.deprecateFunc('setPath is deprecated since set now supports paths', Ember.set);
 
 /**
-  Error-tolerant form of Ember.set. Will not blow up if any part of the
-  chain is undefined, null, or destroyed.
+  Error-tolerant form of `Ember.set`. Will not blow up if any part of the
+  chain is `undefined`, `null`, or destroyed.
 
   This is primarily used when syncing bindings, which may try to update after
   an object has been destroyed.
@@ -1729,8 +1929,8 @@ Ember.trySet = function(root, path, value) {
 Ember.trySetPath = Ember.deprecateFunc('trySetPath has been renamed to trySet', Ember.trySet);
 
 /**
-  Returns true if the provided path is global (e.g., "MyApp.fooController.bar")
-  instead of local ("foo.bar.baz").
+  Returns true if the provided path is global (e.g., `MyApp.fooController.bar`)
+  instead of local (`foo.bar.baz`).
 
   @method isGlobalPath
   @for Ember
@@ -1742,13 +1942,6 @@ Ember.isGlobalPath = function(path) {
   return IS_GLOBAL.test(path);
 };
 
-
-
-if (Ember.config.overrideAccessors) {
-  Ember.config.overrideAccessors();
-  get = Ember.get;
-  set = Ember.set;
-}
 
 })();
 
@@ -1774,7 +1967,7 @@ var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
 
 /**
   Objects of this type can implement an interface to responds requests to
-  get and set.  The default implementation handles simple properties.
+  get and set. The default implementation handles simple properties.
 
   You generally won't need to create or subclass this directly.
 
@@ -1792,42 +1985,44 @@ var Descriptor = Ember.Descriptor = function() {};
 /**
   @private
 
-  NOTE: This is a low-level method used by other parts of the API.  You almost
-  never want to call this method directly.  Instead you should use Ember.mixin()
-  to define new properties.
+  NOTE: This is a low-level method used by other parts of the API. You almost
+  never want to call this method directly. Instead you should use
+  `Ember.mixin()` to define new properties.
 
-  Defines a property on an object.  This method works much like the ES5
-  Object.defineProperty() method except that it can also accept computed
+  Defines a property on an object. This method works much like the ES5
+  `Object.defineProperty()` method except that it can also accept computed
   properties and other special descriptors.
 
-  Normally this method takes only three parameters.  However if you pass an
-  instance of Ember.Descriptor as the third param then you can pass an optional
-  value as the fourth parameter.  This is often more efficient than creating
-  new descriptor hashes for each property.
+  Normally this method takes only three parameters. However if you pass an
+  instance of `Ember.Descriptor` as the third param then you can pass an
+  optional value as the fourth parameter. This is often more efficient than
+  creating new descriptor hashes for each property.
 
   ## Examples
 
-      // ES5 compatible mode
-      Ember.defineProperty(contact, 'firstName', {
-        writable: true,
-        configurable: false,
-        enumerable: true,
-        value: 'Charles'
-      });
+  ```javascript
+  // ES5 compatible mode
+  Ember.defineProperty(contact, 'firstName', {
+    writable: true,
+    configurable: false,
+    enumerable: true,
+    value: 'Charles'
+  });
 
-      // define a simple property
-      Ember.defineProperty(contact, 'lastName', undefined, 'Jolley');
+  // define a simple property
+  Ember.defineProperty(contact, 'lastName', undefined, 'Jolley');
 
-      // define a computed property
-      Ember.defineProperty(contact, 'fullName', Ember.computed(function() {
-        return this.firstName+' '+this.lastName;
-      }).property('firstName', 'lastName').cacheable());
+  // define a computed property
+  Ember.defineProperty(contact, 'fullName', Ember.computed(function() {
+    return this.firstName+' '+this.lastName;
+  }).property('firstName', 'lastName'));
+  ```
 
   @method defineProperty
   @for Ember
   @param {Object} obj the object to define this property on. This may be a prototype.
   @param {String} keyName the name of the property
-  @param {Ember.Descriptor} [desc] an instance of Ember.Descriptor (typically a
+  @param {Ember.Descriptor} [desc] an instance of `Ember.Descriptor` (typically a
     computed property) or an ES5 descriptor.
     You must provide this or `data` but not both.
   @param {anything} [data] something other than a descriptor, that will
@@ -1912,78 +2107,73 @@ Ember.defineProperty = function(obj, keyName, desc, data, meta) {
 
 var AFTER_OBSERVERS = ':change';
 var BEFORE_OBSERVERS = ':before';
+
 var guidFor = Ember.guidFor;
 
 var deferred = 0;
-var array_Slice = [].slice;
 
-var ObserverSet = function () {
-  this.targetSet = {};
-};
-ObserverSet.prototype.add = function (target, path) {
-  var targetSet = this.targetSet,
-    targetGuid = Ember.guidFor(target),
-    pathSet = targetSet[targetGuid];
-  if (!pathSet) {
-    targetSet[targetGuid] = pathSet = {};
+/*
+  this.observerSet = {
+    [senderGuid]: { // variable name: `keySet`
+      [keyName]: listIndex
+    }
+  },
+  this.observers = [
+    {
+      sender: obj,
+      keyName: keyName,
+      eventName: eventName,
+      listeners: [
+        [target, method, onceFlag, suspendedFlag]
+      ]
+    },
+    ...
+  ]
+*/
+function ObserverSet() {
+  this.clear();
+}
+
+ObserverSet.prototype.add = function(sender, keyName, eventName) {
+  var observerSet = this.observerSet,
+      observers = this.observers,
+      senderGuid = Ember.guidFor(sender),
+      keySet = observerSet[senderGuid],
+      index;
+
+  if (!keySet) {
+    observerSet[senderGuid] = keySet = {};
   }
-  if (pathSet[path]) {
-    return false;
-  } else {
-    return pathSet[path] = true;
-  }
-};
-ObserverSet.prototype.clear = function () {
-  this.targetSet = {};
-};
-
-var DeferredEventQueue = function() {
-  this.targetSet = {};
-  this.queue = [];
-};
-
-DeferredEventQueue.prototype.push = function(target, eventName, keyName) {
-  var targetSet = this.targetSet,
-    queue = this.queue,
-    targetGuid = Ember.guidFor(target),
-    eventNameSet = targetSet[targetGuid],
-    index;
-
-  if (!eventNameSet) {
-    targetSet[targetGuid] = eventNameSet = {};
-  }
-  index = eventNameSet[eventName];
+  index = keySet[keyName];
   if (index === undefined) {
-    eventNameSet[eventName] = queue.push(Ember.deferEvent(target, eventName, [target, keyName])) - 1;
-  } else {
-    queue[index] = Ember.deferEvent(target, eventName, [target, keyName]);
+    index = observers.push({
+      sender: sender,
+      keyName: keyName,
+      eventName: eventName,
+      listeners: []
+    }) - 1;
+    keySet[keyName] = index;
+  }
+  return observers[index].listeners;
+};
+
+ObserverSet.prototype.flush = function() {
+  var observers = this.observers, i, len, observer, sender;
+  this.clear();
+  for (i=0, len=observers.length; i < len; ++i) {
+    observer = observers[i];
+    sender = observer.sender;
+    if (sender.isDestroyed) { continue; }
+    Ember.sendEvent(sender, observer.eventName, [sender, observer.keyName], observer.listeners);
   }
 };
 
-DeferredEventQueue.prototype.flush = function() {
-  var queue = this.queue;
-  this.queue = [];
-  this.targetSet = {};
-  for (var i=0, len=queue.length; i < len; ++i) {
-    queue[i]();
-  }
+ObserverSet.prototype.clear = function() {
+  this.observerSet = {};
+  this.observers = [];
 };
 
-var queue = new DeferredEventQueue(), beforeObserverSet = new ObserverSet();
-
-function notifyObservers(obj, eventName, keyName, forceNotification) {
-  if (deferred && !forceNotification) {
-    queue.push(obj, eventName, keyName);
-  } else {
-    Ember.sendEvent(obj, eventName, [obj, keyName]);
-  }
-}
-
-function flushObserverQueue() {
-  beforeObserverSet.clear();
-
-  queue.flush();
-}
+var beforeObserverSet = new ObserverSet(), observerSet = new ObserverSet();
 
 /**
   @method beginPropertyChanges
@@ -1991,7 +2181,6 @@ function flushObserverQueue() {
 */
 Ember.beginPropertyChanges = function() {
   deferred++;
-  return this;
 };
 
 /**
@@ -1999,17 +2188,22 @@ Ember.beginPropertyChanges = function() {
 */
 Ember.endPropertyChanges = function() {
   deferred--;
-  if (deferred<=0) flushObserverQueue();
+  if (deferred<=0) {
+    beforeObserverSet.clear();
+    observerSet.flush();
+  }
 };
 
 /**
   Make a series of property changes together in an
   exception-safe way.
 
-      Ember.changeProperties(function() {
-        obj1.set('foo', mayBlowUpWhenSet);
-        obj2.set('bar', baz);
-      });
+  ```javascript
+  Ember.changeProperties(function() {
+    obj1.set('foo', mayBlowUpWhenSet);
+    obj2.set('bar', baz);
+  });
+  ```
 
   @method changeProperties
   @param {Function} callback
@@ -2136,28 +2330,30 @@ Ember.removeBeforeObserver = function(obj, path, target, method) {
   return this;
 };
 
-Ember.notifyObservers = function(obj, keyName) {
-  if (obj.isDestroying) { return; }
-
-  notifyObservers(obj, changeEvent(keyName), keyName);
-};
-
 Ember.notifyBeforeObservers = function(obj, keyName) {
   if (obj.isDestroying) { return; }
 
-  var guid, set, forceNotification = false;
-
+  var eventName = beforeEvent(keyName), listeners, listenersDiff;
   if (deferred) {
-    if (beforeObserverSet.add(obj, keyName)) {
-      forceNotification = true;
-    } else {
-      return;
-    }
+    listeners = beforeObserverSet.add(obj, keyName, eventName);
+    listenersDiff = Ember.listenersDiff(obj, eventName, listeners);
+    Ember.sendEvent(obj, eventName, [obj, keyName], listenersDiff);
+  } else {
+    Ember.sendEvent(obj, eventName, [obj, keyName]);
   }
-
-  notifyObservers(obj, beforeEvent(keyName), keyName, forceNotification);
 };
 
+Ember.notifyObservers = function(obj, keyName) {
+  if (obj.isDestroying) { return; }
+
+  var eventName = changeEvent(keyName), listeners;
+  if (deferred) {
+    listeners = observerSet.add(obj, keyName, eventName);
+    Ember.listenersUnion(obj, eventName, listeners);
+  } else {
+    Ember.sendEvent(obj, eventName, [obj, keyName]);
+  }
+};
 
 })();
 
@@ -2247,30 +2443,39 @@ function dependentKeysDidChange(obj, depKey, meta) {
 //
 
 function addChainWatcher(obj, keyName, node) {
-  if (!obj || ('object' !== typeof obj)) return; // nothing to do
-  var m = metaFor(obj);
-  var nodes = m.chainWatchers;
-  if (!nodes || nodes.__emberproto__ !== obj) {
-    nodes = m.chainWatchers = { __emberproto__: obj };
+  if (!obj || ('object' !== typeof obj)) { return; } // nothing to do
+
+  var m = metaFor(obj), nodes = m.chainWatchers;
+
+  if (!m.hasOwnProperty('chainWatchers')) {
+    nodes = m.chainWatchers = {};
   }
 
-  if (!nodes[keyName]) { nodes[keyName] = {}; }
-  nodes[keyName][guidFor(node)] = node;
+  if (!nodes[keyName]) { nodes[keyName] = []; }
+  nodes[keyName].push(node);
   Ember.watch(obj, keyName);
 }
 
 function removeChainWatcher(obj, keyName, node) {
   if (!obj || 'object' !== typeof obj) { return; } // nothing to do
-  var m = metaFor(obj, false),
-      nodes = m.chainWatchers;
-  if (!nodes || nodes.__emberproto__ !== obj) { return; } //nothing to do
-  if (nodes[keyName]) { delete nodes[keyName][guidFor(node)]; }
+
+  var m = metaFor(obj, false);
+  if (!m.hasOwnProperty('chainWatchers')) { return; } // nothing to do
+
+  var nodes = m.chainWatchers;
+
+  if (nodes[keyName]) {
+    nodes = nodes[keyName];
+    for (var i = 0, l = nodes.length; i < l; i++) {
+      if (nodes[i] === node) { nodes.splice(i, 1); }
+    }
+  }
   Ember.unwatch(obj, keyName);
 }
 
 var pendingQueue = [];
 
-// attempts to add the pendingQueue chains again.  If some of them end up
+// attempts to add the pendingQueue chains again. If some of them end up
 // back in the queue and reschedule is true, schedules a timeout to try
 // again.
 function flushPendingChains() {
@@ -2288,10 +2493,10 @@ function isProto(pvalue) {
   return metaFor(pvalue, false).proto === pvalue;
 }
 
-// A ChainNode watches a single key on an object.  If you provide a starting
-// value for the key then the node won't actually watch it.  For a root node
+// A ChainNode watches a single key on an object. If you provide a starting
+// value for the key then the node won't actually watch it. For a root node
 // pass null for parent and key and object for value.
-var ChainNode = function(parent, key, value, separator) {
+var ChainNode = function(parent, key, value) {
   var obj;
   this._parent = parent;
   this._key    = key;
@@ -2305,7 +2510,6 @@ var ChainNode = function(parent, key, value, separator) {
   this._watching = value===undefined;
 
   this._value  = value;
-  this._separator = separator || '.';
   this._paths = {};
   if (this._watching) {
     this._object = parent.value();
@@ -2342,7 +2546,7 @@ ChainNodePrototype.destroy = function() {
 
 // copies a top level object only
 ChainNodePrototype.copy = function(obj) {
-  var ret = new ChainNode(null, null, obj, this._separator),
+  var ret = new ChainNode(null, null, obj),
       paths = this._paths, path;
   for (path in paths) {
     if (paths[path] <= 0) { continue; } // this check will also catch non-number vals.
@@ -2354,7 +2558,7 @@ ChainNodePrototype.copy = function(obj) {
 // called on the root node of a chain to setup watchers on the specified
 // path.
 ChainNodePrototype.add = function(path) {
-  var obj, tuple, key, src, separator, paths;
+  var obj, tuple, key, src, paths;
 
   paths = this._paths;
   paths[path] = (paths[path] || 0) + 1;
@@ -2379,12 +2583,11 @@ ChainNodePrototype.add = function(path) {
   } else {
     src  = tuple[0];
     key  = path.slice(0, 0-(tuple[1].length+1));
-    separator = path.slice(key.length, key.length+1);
     path = tuple[1];
   }
 
   tuple.length = 0;
-  this.chain(key, path, src, separator);
+  this.chain(key, path, src);
 };
 
 // called on the root node of a chain to teardown watcher on the specified
@@ -2413,12 +2616,12 @@ ChainNodePrototype.remove = function(path) {
 
 ChainNodePrototype.count = 0;
 
-ChainNodePrototype.chain = function(key, path, src, separator) {
+ChainNodePrototype.chain = function(key, path, src) {
   var chains = this._chains, node;
   if (!chains) { chains = this._chains = {}; }
 
   node = chains[key];
-  if (!node) { node = chains[key] = new ChainNode(this, key, src, separator); }
+  if (!node) { node = chains[key] = new ChainNode(this, key, src); }
   node.count++; // count chains...
 
   // chain rest of path if there is one
@@ -2461,7 +2664,7 @@ ChainNodePrototype.willChange = function() {
 };
 
 ChainNodePrototype.chainWillChange = function(chain, path, depth) {
-  if (this._key) { path = this._key + this._separator + path; }
+  if (this._key) { path = this._key + '.' + path; }
 
   if (this._parent) {
     this._parent.chainWillChange(this, path, depth+1);
@@ -2473,7 +2676,7 @@ ChainNodePrototype.chainWillChange = function(chain, path, depth) {
 };
 
 ChainNodePrototype.chainDidChange = function(chain, path, depth) {
-  if (this._key) { path = this._key + this._separator + path; }
+  if (this._key) { path = this._key + '.' + path; }
   if (this._parent) {
     this._parent.chainDidChange(this, path, depth+1);
   } else {
@@ -2515,7 +2718,7 @@ ChainNodePrototype.didChange = function(suppressEvent) {
   if (this._parent) { this._parent.chainDidChange(this, this._key, 1); }
 };
 
-// get the chains for the current object.  If the current object has
+// get the chains for the current object. If the current object has
 // chains inherited from the proto they will be cloned and reconfigured for
 // the current object.
 function chainsFor(obj) {
@@ -2528,30 +2731,35 @@ function chainsFor(obj) {
   return ret;
 }
 
-function notifyChains(obj, m, keyName, methodName, arg) {
-  var nodes = m.chainWatchers;
+Ember.overrideChains = function(obj, keyName, m) {
+  chainsDidChange(obj, keyName, m, true);
+};
 
-  if (!nodes || nodes.__emberproto__ !== obj) { return; } // nothing to do
+function chainsWillChange(obj, keyName, m, arg) {
+  if (!m.hasOwnProperty('chainWatchers')) { return; } // nothing to do
+
+  var nodes = m.chainWatchers;
 
   nodes = nodes[keyName];
   if (!nodes) { return; }
 
-  for(var key in nodes) {
-    if (!nodes.hasOwnProperty(key)) { continue; }
-    nodes[key][methodName](arg);
+  for(var i = 0, l = nodes.length; i < l; i++) {
+    nodes[i].willChange(arg);
   }
 }
 
-Ember.overrideChains = function(obj, keyName, m) {
-  notifyChains(obj, m, keyName, 'didChange', true);
-};
+function chainsDidChange(obj, keyName, m, arg) {
+  if (!m.hasOwnProperty('chainWatchers')) { return; } // nothing to do
 
-function chainsWillChange(obj, keyName, m) {
-  notifyChains(obj, m, keyName, 'willChange');
-}
+  var nodes = m.chainWatchers;
 
-function chainsDidChange(obj, keyName, m) {
-  notifyChains(obj, m, keyName, 'didChange');
+  nodes = nodes[keyName];
+  if (!nodes) { return; }
+
+  // looping in reverse because the chainWatchers array can be modified inside didChange
+  for (var i = nodes.length - 1; i >= 0; i--) {
+    nodes[i].didChange(arg);
+  }
 }
 
 // ..........................................................
@@ -2561,11 +2769,11 @@ function chainsDidChange(obj, keyName, m) {
 /**
   @private
 
-  Starts watching a property on an object.  Whenever the property changes,
-  invokes Ember.propertyWillChange and Ember.propertyDidChange.  This is the
+  Starts watching a property on an object. Whenever the property changes,
+  invokes `Ember.propertyWillChange` and `Ember.propertyDidChange`. This is the
   primitive used by observers and dependent keys; usually you will never call
   this method directly but instead use higher level methods like
-  Ember.addObserver().
+  `Ember.addObserver()`
 
   @method watch
   @for Ember
@@ -2660,8 +2868,8 @@ Ember.unwatch = function(obj, keyName) {
 /**
   @private
 
-  Call on an object when you first beget it from another object.  This will
-  setup any chained watchers on the object instance as needed.  This method is
+  Call on an object when you first beget it from another object. This will
+  setup any chained watchers on the object instance as needed. This method is
   safe to call multiple times.
 
   @method rewatch
@@ -2815,7 +3023,7 @@ Ember.destroy = function (obj) {
 @module ember-metal
 */
 
-Ember.warn("Computed properties will soon be cacheable by default. To enable this in your app, set `ENV.CP_DEFAULT_CACHEABLE = true`.", Ember.CP_DEFAULT_CACHEABLE);
+Ember.warn("The CP_DEFAULT_CACHEABLE flag has been removed and computed properties are always cached by default. Use `volatile` if you don't want caching.", Ember.ENV.CP_DEFAULT_CACHEABLE !== false);
 
 
 var get = Ember.get,
@@ -2926,7 +3134,7 @@ function removeDependentKeys(desc, obj, keyName, meta) {
 */
 function ComputedProperty(func, opts) {
   this.func = func;
-  this._cacheable = (opts && opts.cacheable !== undefined) ? opts.cacheable : Ember.CP_DEFAULT_CACHEABLE;
+  this._cacheable = (opts && opts.cacheable !== undefined) ? opts.cacheable : true;
   this._dependentKeys = opts && opts.dependentKeys;
 }
 
@@ -2936,24 +3144,26 @@ ComputedProperty.prototype = new Ember.Descriptor();
 var ComputedPropertyPrototype = ComputedProperty.prototype;
 
 /**
-  Call on a computed property to set it into cacheable mode.  When in this
+  Call on a computed property to set it into cacheable mode. When in this
   mode the computed property will automatically cache the return value of
   your function until one of the dependent keys changes.
 
-      MyApp.president = Ember.Object.create({
-        fullName: function() {
-          return this.get('firstName') + ' ' + this.get('lastName');
+  ```javascript
+  MyApp.president = Ember.Object.create({
+    fullName: function() {
+      return this.get('firstName') + ' ' + this.get('lastName');
 
-          // After calculating the value of this function, Ember.js will
-          // return that value without re-executing this function until
-          // one of the dependent properties change.
-        }.property('firstName', 'lastName').cacheable()
-      });
+      // After calculating the value of this function, Ember will
+      // return that value without re-executing this function until
+      // one of the dependent properties change.
+    }.property('firstName', 'lastName')
+  });
+  ```
 
   Properties are cacheable by default.
 
   @method cacheable
-  @param {Boolean} aFlag optional set to false to disable caching
+  @param {Boolean} aFlag optional set to `false` to disable caching
   @chainable
 */
 ComputedPropertyPrototype.cacheable = function(aFlag) {
@@ -2962,14 +3172,16 @@ ComputedPropertyPrototype.cacheable = function(aFlag) {
 };
 
 /**
-  Call on a computed property to set it into non-cached mode.  When in this
+  Call on a computed property to set it into non-cached mode. When in this
   mode the computed property will not automatically cache the return value.
 
-      MyApp.outsideService = Ember.Object.create({
-        value: function() {
-          return OutsideService.getValue();
-        }.property().volatile()
-      });
+  ```javascript
+  MyApp.outsideService = Ember.Object.create({
+    value: function() {
+      return OutsideService.getValue();
+    }.property().volatile()
+  });
+  ```
 
   @method volatile
   @chainable
@@ -2979,17 +3191,19 @@ ComputedPropertyPrototype.volatile = function() {
 };
 
 /**
-  Sets the dependent keys on this computed property.  Pass any number of
+  Sets the dependent keys on this computed property. Pass any number of
   arguments containing key paths that this computed property depends on.
 
-      MyApp.president = Ember.Object.create({
-        fullName: Ember.computed(function() {
-          return this.get('firstName') + ' ' + this.get('lastName');
+  ```javascript
+  MyApp.president = Ember.Object.create({
+    fullName: Ember.computed(function() {
+      return this.get('firstName') + ' ' + this.get('lastName');
 
-          // Tell Ember.js that this computed property depends on firstName
-          // and lastName
-        }).property('firstName', 'lastName')
-      });
+      // Tell Ember that this computed property depends on firstName
+      // and lastName
+    }).property('firstName', 'lastName')
+  });
+  ```
 
   @method property
   @param {String} path* zero or more property paths
@@ -3012,10 +3226,12 @@ ComputedPropertyPrototype.property = function() {
 
   You can pass a hash of these values to a computed property like this:
 
-      person: function() {
-        var personId = this.get('personId');
-        return App.Person.create({ id: personId });
-      }.property().meta({ type: App.Person })
+  ```
+  person: function() {
+    var personId = this.get('personId');
+    return App.Person.create({ id: personId });
+  }.property().meta({ type: App.Person })
+  ```
 
   The hash that you pass to the `meta()` function will be saved on the
   computed property descriptor under the `_meta` key. Ember runtime
@@ -3090,38 +3306,56 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
 /* impl descriptor API */
 ComputedPropertyPrototype.set = function(obj, keyName, value) {
   var cacheable = this._cacheable,
+      func = this.func,
       meta = metaFor(obj, cacheable),
       watched = meta.watching[keyName],
       oldSuspended = this._suspended,
       hadCachedValue = false,
-      ret;
+      cache = meta.cache,
+      cachedValue, ret;
+
   this._suspended = obj;
 
-  if (cacheable && keyName in meta.cache) {
-    if (meta.cache[keyName] === value) {
+  try {
+    if (cacheable && cache.hasOwnProperty(keyName)) {
+      cachedValue = cache[keyName];
+      hadCachedValue = true;
+    }
+
+    // For backwards-compatibility with computed properties
+    // that check for arguments.length === 2 to determine if
+    // they are being get or set, only pass the old cached
+    // value if the computed property opts into a third
+    // argument.
+    if (func.length === 3) {
+      ret = func.call(obj, keyName, value, cachedValue);
+    } else if (func.length === 2) {
+      ret = func.call(obj, keyName, value);
+    } else {
+      Ember.defineProperty(obj, keyName, null, cachedValue);
+      Ember.set(obj, keyName, value);
       return;
     }
-    hadCachedValue = true;
-  }
 
-  if (watched) { Ember.propertyWillChange(obj, keyName); }
+    if (hadCachedValue && cachedValue === ret) { return; }
 
-  if (cacheable && hadCachedValue) {
-    delete meta.cache[keyName];
-  }
+    if (watched) { Ember.propertyWillChange(obj, keyName); }
 
-  ret = this.func.call(obj, keyName, value);
-
-  if (cacheable) {
-    if (!watched && !hadCachedValue) {
-      addDependentKeys(this, obj, keyName, meta);
+    if (hadCachedValue) {
+      delete cache[keyName];
     }
-    meta.cache[keyName] = ret;
+
+    if (cacheable) {
+      if (!watched && !hadCachedValue) {
+        addDependentKeys(this, obj, keyName, meta);
+      }
+      cache[keyName] = ret;
+    }
+
+    if (watched) { Ember.propertyDidChange(obj, keyName); }
+  } finally {
+    this._suspended = oldSuspended;
   }
-
-  if (watched) { Ember.propertyDidChange(obj, keyName); }
-
-  this._suspended = oldSuspended;
   return ret;
 };
 
@@ -3149,12 +3383,12 @@ ComputedPropertyPrototype.teardown = function(obj, keyName) {
 
 /**
   This helper returns a new property descriptor that wraps the passed
-  computed property function.  You can use this helper to define properties
-  with mixins or via Ember.defineProperty().
+  computed property function. You can use this helper to define properties
+  with mixins or via `Ember.defineProperty()`.
 
   The function you pass will be used to both get and set property values.
-  The function should accept two parameters, key and value.  If value is not
-  undefined you should set the value first.  In either case return the
+  The function should accept two parameters, key and value. If value is not
+  undefined you should set the value first. In either case return the
   current value of the property.
 
   @method computed
@@ -3189,7 +3423,7 @@ Ember.computed = function(func) {
   @for Ember
   @param {Object} obj the object whose property you want to check
   @param {String} key the name of the property whose cached value you want
-                      to return
+    to return
 */
 Ember.cacheFor = function cacheFor(obj, key) {
   var cache = metaFor(obj, false).cache;
@@ -3207,7 +3441,7 @@ Ember.cacheFor = function cacheFor(obj, key) {
 Ember.computed.not = function(dependentKey) {
   return Ember.computed(dependentKey, function(key) {
     return !get(this, dependentKey);
-  }).cacheable();
+  });
 };
 
 /**
@@ -3219,7 +3453,7 @@ Ember.computed.empty = function(dependentKey) {
   return Ember.computed(dependentKey, function(key) {
     var val = get(this, dependentKey);
     return val === undefined || val === null || val === '' || (Ember.isArray(val) && get(val, 'length') === 0);
-  }).cacheable();
+  });
 };
 
 /**
@@ -3230,7 +3464,7 @@ Ember.computed.empty = function(dependentKey) {
 Ember.computed.bool = function(dependentKey) {
   return Ember.computed(dependentKey, function(key) {
     return !!get(this, dependentKey);
-  }).cacheable();
+  });
 };
 
 })();
@@ -3243,10 +3477,9 @@ Ember.computed.bool = function(dependentKey) {
 */
 
 var o_create = Ember.create,
-    meta = Ember.meta,
+    metaFor = Ember.meta,
     metaPath = Ember.metaPath,
-    guidFor = Ember.guidFor,
-    a_slice = [].slice;
+    META_KEY = Ember.META_KEY;
 
 /*
   The event system uses a series of nested hashes to store listeners on an
@@ -3257,75 +3490,84 @@ var o_create = Ember.create,
 
       // Object's meta hash
       {
-        listeners: {               // variable name: `listenerSet`
-          "foo:changed": {         // variable name: `targetSet`
-            [targetGuid]: {        // variable name: `actionSet`
-              [methodGuid]: {      // variable name: `action`
-                target: [Object object],
-                method: [Function function]
-              }
-            }
-          }
+        listeners: {       // variable name: `listenerSet`
+          "foo:changed": [ // variable name: `actions`
+            [target, method, onceFlag, suspendedFlag]
+          ]
         }
       }
 
 */
 
-// Gets the set of all actions, keyed on the guid of each action's
-// method property.
-function actionSetFor(obj, eventName, target, writable) {
-  return metaPath(obj, ['listeners', eventName, guidFor(target)], writable);
+function indexOf(array, target, method) {
+  var index = -1;
+  for (var i = 0, l = array.length; i < l; i++) {
+    if (target === array[i][0] && method === array[i][1]) { index = i; break; }
+  }
+  return index;
 }
 
-// Gets the set of all targets, keyed on the guid of each action's
-// target property.
-function targetSetFor(obj, eventName) {
-  var listenerSet = meta(obj, false).listeners;
-  if (!listenerSet) { return false; }
+function actionsFor(obj, eventName) {
+  var meta = metaFor(obj, true),
+      actions;
 
-  return listenerSet[eventName] || false;
+  if (!meta.listeners) { meta.listeners = {}; }
+
+  if (!meta.hasOwnProperty('listeners')) {
+    // setup inherited copy of the listeners object
+    meta.listeners = o_create(meta.listeners);
+  }
+
+  actions = meta.listeners[eventName];
+
+  // if there are actions, but the eventName doesn't exist in our listeners, then copy them from the prototype
+  if (actions && !meta.listeners.hasOwnProperty(eventName)) {
+    actions = meta.listeners[eventName] = meta.listeners[eventName].slice();
+  } else if (!actions) {
+    actions = meta.listeners[eventName] = [];
+  }
+
+  return actions;
 }
 
-// TODO: This knowledge should really be a part of the
-// meta system.
-var SKIP_PROPERTIES = { __ember_source__: true };
+function actionsUnion(obj, eventName, otherActions) {
+  var meta = obj[META_KEY],
+      actions = meta && meta.listeners && meta.listeners[eventName];
 
-function iterateSet(obj, eventName, callback, params) {
-  var targetSet = targetSetFor(obj, eventName);
-  if (!targetSet) { return false; }
-  // Iterate through all elements of the target set
-  for(var targetGuid in targetSet) {
-    if (SKIP_PROPERTIES[targetGuid]) { continue; }
+  if (!actions) { return; }
+  for (var i = actions.length - 1; i >= 0; i--) {
+    var target = actions[i][0],
+        method = actions[i][1],
+        once = actions[i][2],
+        suspended = actions[i][3],
+        actionIndex = indexOf(otherActions, target, method);
 
-    var actionSet = targetSet[targetGuid];
-    if (actionSet) {
-      // Iterate through the elements of the action set
-      for(var methodGuid in actionSet) {
-        if (SKIP_PROPERTIES[methodGuid]) { continue; }
-
-        var action = actionSet[methodGuid];
-        if (action) {
-          if (callback(action, params, obj) === true) {
-            return true;
-          }
-        }
-      }
+    if (actionIndex === -1) {
+      otherActions.push([target, method, once, suspended]);
     }
   }
-  return false;
 }
 
-function invokeAction(action, params, sender) {
-  var method = action.method, target = action.target;
-  // If there is no target, the target is the object
-  // on which the event was fired.
-  if (!target) { target = sender; }
-  if ('string' === typeof method) { method = target[method]; }
-  if (params) {
-    method.apply(target, params);
-  } else {
-    method.apply(target);
+function actionsDiff(obj, eventName, otherActions) {
+  var meta = obj[META_KEY],
+      actions = meta && meta.listeners && meta.listeners[eventName],
+      diffActions = [];
+
+  if (!actions) { return; }
+  for (var i = actions.length - 1; i >= 0; i--) {
+    var target = actions[i][0],
+        method = actions[i][1],
+        once = actions[i][2],
+        suspended = actions[i][3],
+        actionIndex = indexOf(otherActions, target, method);
+
+    if (actionIndex !== -1) { continue; }
+
+    otherActions.push([target, method, once, suspended]);
+    diffActions.push([target, method, once, suspended]);
   }
+
+  return diffActions;
 }
 
 /**
@@ -3338,7 +3580,7 @@ function invokeAction(action, params, sender) {
   @param {Object|Function} targetOrMethod A target object or a function
   @param {Function|String} method A function or the name of a function to be called on `target`
 */
-function addListener(obj, eventName, target, method) {
+function addListener(obj, eventName, target, method, once) {
   Ember.assert("You must pass at least an object and event name to Ember.addListener", !!obj && !!eventName);
 
   if (!method && 'function' === typeof target) {
@@ -3346,12 +3588,12 @@ function addListener(obj, eventName, target, method) {
     target = null;
   }
 
-  var actionSet = actionSetFor(obj, eventName, target, true),
-      methodGuid = guidFor(method);
+  var actions = actionsFor(obj, eventName),
+      actionIndex = indexOf(actions, target, method);
 
-  if (!actionSet[methodGuid]) {
-    actionSet[methodGuid] = { target: target, method: method };
-  }
+  if (actionIndex !== -1) { return; }
+
+  actions.push([target, method, once, undefined]);
 
   if ('function' === typeof obj.didAddListener) {
     obj.didAddListener(eventName, target, method);
@@ -3378,15 +3620,30 @@ function removeListener(obj, eventName, target, method) {
     target = null;
   }
 
-  var actionSet = actionSetFor(obj, eventName, target, true),
-      methodGuid = guidFor(method);
+  function _removeListener(target, method, once) {
+    var actions = actionsFor(obj, eventName),
+        actionIndex = indexOf(actions, target, method);
 
-  // we can't simply delete this parameter, because if we do, we might
-  // re-expose the property from the prototype chain.
-  if (actionSet && actionSet[methodGuid]) { actionSet[methodGuid] = null; }
+    // action doesn't exist, give up silently
+    if (actionIndex === -1) { return; }
 
-  if ('function' === typeof obj.didRemoveListener) {
-    obj.didRemoveListener(eventName, target, method);
+    actions.splice(actionIndex, 1);
+
+    if ('function' === typeof obj.didRemoveListener) {
+      obj.didRemoveListener(eventName, target, method);
+    }
+  }
+
+  if (method) {
+    _removeListener(target, method);
+  } else {
+    var meta = obj[META_KEY],
+        actions = meta && meta.listeners && meta.listeners[eventName];
+
+    if (!actions) { return; }
+    for (var i = actions.length - 1; i >= 0; i--) {
+      _removeListener(actions[i][0], actions[i][1]);
+    }
   }
 }
 
@@ -3414,15 +3671,20 @@ function suspendListener(obj, eventName, target, method, callback) {
     target = null;
   }
 
-  var actionSet = actionSetFor(obj, eventName, target, true),
-      methodGuid = guidFor(method),
-      action = actionSet && actionSet[methodGuid];
+  var actions = actionsFor(obj, eventName),
+      actionIndex = indexOf(actions, target, method),
+      action;
 
-  actionSet[methodGuid] = null;
+  if (actionIndex !== -1) {
+    action = actions[actionIndex].slice(); // copy it, otherwise we're modifying a shared object
+    action[3] = true; // mark the action as suspended
+    actions[actionIndex] = action; // replace the shared object with our copy
+  }
+
   try {
     return callback.call(target);
   } finally {
-    actionSet[methodGuid] = action;
+    if (action) { action[3] = undefined; }
   }
 }
 
@@ -3450,27 +3712,27 @@ function suspendListeners(obj, eventNames, target, method, callback) {
     target = null;
   }
 
-  var oldActions = [],
-      actionSets = [],
-      eventName, actionSet, methodGuid, action, i, l;
+  var suspendedActions = [],
+      eventName, actions, action, i, l;
 
   for (i=0, l=eventNames.length; i<l; i++) {
     eventName = eventNames[i];
-    actionSet = actionSetFor(obj, eventName, target, true),
-    methodGuid = guidFor(method);
+    actions = actionsFor(obj, eventName);
+    var actionIndex = indexOf(actions, target, method);
 
-    oldActions.push(actionSet && actionSet[methodGuid]);
-    actionSets.push(actionSet);
-
-    actionSet[methodGuid] = null;
+    if (actionIndex !== -1) {
+      action = actions[actionIndex].slice();
+      action[3] = true;
+      actions[actionIndex] = action;
+      suspendedActions.push(action);
+    }
   }
 
   try {
     return callback.call(target);
   } finally {
-    for (i=0, l=oldActions.length; i<l; i++) {
-      eventName = eventNames[i];
-      actionSets[i][methodGuid] = oldActions[i];
+    for (i = 0, l = suspendedActions.length; i < l; i++) {
+      suspendedActions[i][3] = undefined;
     }
   }
 }
@@ -3485,13 +3747,11 @@ function suspendListeners(obj, eventNames, target, method, callback) {
   @param obj
 */
 function watchedEvents(obj) {
-  var listeners = meta(obj, false).listeners, ret = [];
+  var listeners = obj[META_KEY].listeners, ret = [];
 
   if (listeners) {
     for(var eventName in listeners) {
-      if (!SKIP_PROPERTIES[eventName] && listeners[eventName]) {
-        ret.push(eventName);
-      }
+      if (listeners[eventName]) { ret.push(eventName); }
     }
   }
   return ret;
@@ -3505,41 +3765,36 @@ function watchedEvents(obj) {
   @param {Array} params
   @return true
 */
-function sendEvent(obj, eventName, params) {
+function sendEvent(obj, eventName, params, actions) {
   // first give object a chance to handle it
   if (obj !== Ember && 'function' === typeof obj.sendEvent) {
     obj.sendEvent(eventName, params);
   }
 
-  iterateSet(obj, eventName, invokeAction, params);
+  if (!actions) {
+    var meta = obj[META_KEY];
+    actions = meta && meta.listeners && meta.listeners[eventName];
+  }
+
+  if (!actions) { return; }
+
+  for (var i = actions.length - 1; i >= 0; i--) { // looping in reverse for once listeners
+    if (!actions[i] || actions[i][3] === true) { continue; }
+
+    var target = actions[i][0],
+        method = actions[i][1],
+        once = actions[i][2];
+
+    if (once) { removeListener(obj, eventName, target, method); }
+    if (!target) { target = obj; }
+    if ('string' === typeof method) { method = target[method]; }
+    if (params) {
+      method.apply(target, params);
+    } else {
+      method.apply(target);
+    }
+  }
   return true;
-}
-
-/**
-  @private
-  @method deferEvent
-  @for Ember
-  @param obj
-  @param {String} eventName
-  @param {Array} params
-*/
-function deferEvent(obj, eventName, params) {
-  var actions = [];
-  iterateSet(obj, eventName, function (action) {
-    actions.push(action);
-  });
-
-  return function() {
-    if (obj.isDestroyed) { return; }
-
-    if (obj !== Ember && 'function' === typeof obj.sendEvent) {
-      obj.sendEvent(eventName, params);
-    }
-
-    for (var i=0, len=actions.length; i < len; ++i) {
-      invokeAction(actions[i], params, obj);
-    }
-  };
 }
 
 /**
@@ -3550,15 +3805,10 @@ function deferEvent(obj, eventName, params) {
   @param {String} eventName
 */
 function hasListeners(obj, eventName) {
-  if (iterateSet(obj, eventName, function() { return true; })) {
-    return true;
-  }
+  var meta = obj[META_KEY],
+      actions = meta && meta.listeners && meta.listeners[eventName];
 
-  // no listeners!  might as well clean this up so it is faster later.
-  var set = metaPath(obj, ['listeners'], true);
-  set[eventName] = null;
-
-  return false;
+  return !!(actions && actions.length);
 }
 
 /**
@@ -3570,9 +3820,17 @@ function hasListeners(obj, eventName) {
 */
 function listenersFor(obj, eventName) {
   var ret = [];
-  iterateSet(obj, eventName, function (action) {
-    ret.push([action.target, action.method]);
-  });
+  var meta = obj[META_KEY],
+      actions = meta && meta.listeners && meta.listeners[eventName];
+
+  if (!actions) { return ret; }
+
+  for (var i = 0, l = actions.length; i < l; i++) {
+    var target = actions[i][0],
+        method = actions[i][1];
+    ret.push([target, method]);
+  }
+
   return ret;
 }
 
@@ -3584,7 +3842,8 @@ Ember.sendEvent = sendEvent;
 Ember.hasListeners = hasListeners;
 Ember.watchedEvents = watchedEvents;
 Ember.listenersFor = listenersFor;
-Ember.deferEvent = deferEvent;
+Ember.listenersDiff = actionsDiff;
+Ember.listenersUnion = actionsUnion;
 
 })();
 
@@ -3702,7 +3961,7 @@ RunLoop.prototype = {
       while (this._queues && (queue = this._queues[queueName])) {
         this._queues[queueName] = null;
 
-        // the sync phase is to allow property changes to propagate.  don't
+        // the sync phase is to allow property changes to propagate. don't
         // invoke observers until that is finished.
         if (queueName === 'sync') {
           log = Ember.LOG_BINDINGS;
@@ -3734,7 +3993,7 @@ RunLoop.prototype = {
         delete this._queues[queueName];
 
         if (queue) {
-          // the sync phase is to allow property changes to propagate.  don't
+          // the sync phase is to allow property changes to propagate. don't
           // invoke observers until that is finished.
           if (queueName === 'sync') {
             log = Ember.LOG_BINDINGS;
@@ -3784,14 +4043,16 @@ Ember.RunLoop = RunLoop;
   deferred actions including bindings and views updates are flushed at the
   end.
 
-  Normally you should not need to invoke this method yourself.  However if
+  Normally you should not need to invoke this method yourself. However if
   you are implementing raw event handlers when interfacing with other
   libraries or plugins, you should probably wrap all of your code inside this
   call.
 
-      Ember.run(function(){
-        // code to be execute within a RunLoop 
-      });
+  ```javascript
+  Ember.run(function(){
+    // code to be execute within a RunLoop 
+  });
+  ```
 
   @class run
   @namespace Ember
@@ -3799,7 +4060,7 @@ Ember.RunLoop = RunLoop;
   @constructor
   @param {Object} [target] target of method to call
   @param {Function|String} method Method to invoke.
-    May be a function or a string.  If you pass a string
+    May be a function or a string. If you pass a string
     then it will be looked up on the passed target.
   @param {Object} [args*] Any additional arguments you wish to pass to the method.
   @return {Object} return value from invoking the passed function.
@@ -3819,13 +4080,15 @@ var run = Ember.run;
 
 
 /**
-  Begins a new RunLoop.  Any deferred actions invoked after the begin will
-  be buffered until you invoke a matching call to Ember.run.end().  This is
-  an lower-level way to use a RunLoop instead of using Ember.run().
+  Begins a new RunLoop. Any deferred actions invoked after the begin will
+  be buffered until you invoke a matching call to `Ember.run.end()`. This is
+  an lower-level way to use a RunLoop instead of using `Ember.run()`.
 
-      Ember.run.begin();
-      // code to be execute within a RunLoop 
-      Ember.run.end();
+  ```javascript
+  Ember.run.begin();
+  // code to be execute within a RunLoop 
+  Ember.run.end();
+  ```
 
   @method begin
   @return {void}
@@ -3835,13 +4098,15 @@ Ember.run.begin = function() {
 };
 
 /**
-  Ends a RunLoop.  This must be called sometime after you call Ember.run.begin()
-  to flush any deferred actions.  This is a lower-level way to use a RunLoop
-  instead of using Ember.run().
+  Ends a RunLoop. This must be called sometime after you call
+  `Ember.run.begin()` to flush any deferred actions. This is a lower-level way
+  to use a RunLoop instead of using `Ember.run()`.
 
-      Ember.run.begin();
-      // code to be execute within a RunLoop 
-      Ember.run.end();
+  ```javascript
+  Ember.run.begin();
+  // code to be execute within a RunLoop 
+  Ember.run.end();
+  ```
 
   @method end
   @return {void}
@@ -3857,9 +4122,9 @@ Ember.run.end = function() {
 };
 
 /**
-  Array of named queues.  This array determines the order in which queues
-  are flushed at the end of the RunLoop.  You can define your own queues by
-  simply adding the queue name to this array.  Normally you should not need
+  Array of named queues. This array determines the order in which queues
+  are flushed at the end of the RunLoop. You can define your own queues by
+  simply adding the queue name to this array. Normally you should not need
   to inspect or modify this property.
 
   @property queues
@@ -3870,38 +4135,38 @@ Ember.run.queues = ['sync', 'actions', 'destroy', 'timers'];
 
 /**
   Adds the passed target/method and any optional arguments to the named
-  queue to be executed at the end of the RunLoop.  If you have not already
+  queue to be executed at the end of the RunLoop. If you have not already
   started a RunLoop when calling this method one will be started for you
   automatically.
 
   At the end of a RunLoop, any methods scheduled in this way will be invoked.
   Methods will be invoked in an order matching the named queues defined in
-  the run.queues property.
+  the `run.queues` property.
 
-      Ember.run.schedule('timers', this, function(){
-        // this will be executed at the end of the RunLoop, when timers are run
-        console.log("scheduled on timers queue");
-      });
-      Ember.run.schedule('sync', this, function(){
-        // this will be executed at the end of the RunLoop, when bindings are synced
-        console.log("scheduled on sync queue");
-      });
-      // Note the functions will be run in order based on the run queues order. Output would be:
-      //   scheduled on sync queue
-      //   scheduled on timers queue
+  ```javascript
+  Ember.run.schedule('timers', this, function(){
+    // this will be executed at the end of the RunLoop, when timers are run
+    console.log("scheduled on timers queue");
+  });
+
+  Ember.run.schedule('sync', this, function(){
+    // this will be executed at the end of the RunLoop, when bindings are synced
+    console.log("scheduled on sync queue");
+  });
+
+  // Note the functions will be run in order based on the run queues order. Output would be:
+  //   scheduled on sync queue
+  //   scheduled on timers queue
+  ```
 
   @method schedule
   @param {String} queue The name of the queue to schedule against.
     Default queues are 'sync' and 'actions'
-
   @param {Object} [target] target object to use as the context when invoking a method.
-
-  @param {String|Function} method The method to invoke.  If you pass a string it
+  @param {String|Function} method The method to invoke. If you pass a string it
     will be resolved on the target object at the time the scheduled item is
     invoked allowing you to change the target function.
-
   @param {Object} [arguments*] Optional arguments to be passed to the queued method.
-
   @return {void}
 */
 Ember.run.schedule = function(queue, target, method) {
@@ -3939,10 +4204,9 @@ Ember.run.cancelTimers = function () {
 
 /**
   Begins a new RunLoop if necessary and schedules a timer to flush the
-  RunLoop at a later time.  This method is used by parts of Ember to
-  ensure the RunLoop always finishes.  You normally do not need to call this
-  method directly.  Instead use Ember.run().
-
+  RunLoop at a later time. This method is used by parts of Ember to
+  ensure the RunLoop always finishes. You normally do not need to call this
+  method directly. Instead use `Ember.run()`
 
   @method autorun
   @example
@@ -3964,14 +4228,16 @@ Ember.run.autorun = function() {
 };
 
 /**
-  Immediately flushes any events scheduled in the 'sync' queue.  Bindings
+  Immediately flushes any events scheduled in the 'sync' queue. Bindings
   use this queue so this method is a useful way to immediately force all
   bindings in the application to sync.
 
   You should call this method anytime you need any changed state to propagate
   throughout the app immediately without repainting the UI.
 
-      Ember.run.sync();
+  ```javascript
+  Ember.run.sync();
+  ```
 
   @method sync
   @return {void}
@@ -4010,30 +4276,28 @@ function invokeLaterTimers() {
 
 /**
   Invokes the passed target/method and optional arguments after a specified
-  period if time.  The last parameter of this method must always be a number
+  period if time. The last parameter of this method must always be a number
   of milliseconds.
 
   You should use this method whenever you need to run some action after a
-  period of time instead of using setTimeout().  This method will ensure that
+  period of time instead of using `setTimeout()`. This method will ensure that
   items that expire during the same script execution cycle all execute
   together, which is often more efficient than using a real setTimeout.
 
-      Ember.run.later(myContext, function(){
-        // code here will execute within a RunLoop in about 500ms with this == myContext
-      }, 500);
+  ```javascript
+  Ember.run.later(myContext, function(){
+    // code here will execute within a RunLoop in about 500ms with this == myContext
+  }, 500);
+  ```
 
   @method later
   @param {Object} [target] target of method to invoke
-
   @param {Function|String} method The method to invoke.
     If you pass a string it will be resolved on the
     target at the time the method is invoked.
-
   @param {Object} [args*] Optional arguments to pass to the timeout.
-
   @param {Number} wait
     Number of milliseconds to wait.
-
   @return {String} a string you can use to cancel the timer in
     {{#crossLink "Ember/run.cancel"}}{{/crossLink}} later.
 */
@@ -4095,30 +4359,28 @@ function scheduleOnce(queue, target, method, args) {
 }
 
 /**
-  Schedules an item to run one time during the current RunLoop.  Calling
+  Schedules an item to run one time during the current RunLoop. Calling
   this method with the same target/method combination will have no effect.
 
   Note that although you can pass optional arguments these will not be
-  considered when looking for duplicates.  New arguments will replace previous
+  considered when looking for duplicates. New arguments will replace previous
   calls.
 
-      Ember.run(function(){
-        var doFoo = function() { foo(); }
-        Ember.run.once(myContext, doFoo);
-        Ember.run.once(myContext, doFoo);
-        // doFoo will only be executed once at the end of the RunLoop
-      });
+  ```javascript
+  Ember.run(function(){
+    var doFoo = function() { foo(); }
+    Ember.run.once(myContext, doFoo);
+    Ember.run.once(myContext, doFoo);
+    // doFoo will only be executed once at the end of the RunLoop
+  });
+  ```
 
   @method once
   @param {Object} [target] target of method to invoke
-
   @param {Function|String} method The method to invoke.
     If you pass a string it will be resolved on the
     target at the time the method is invoked.
-
   @param {Object} [args*] Optional arguments to pass to the timeout.
-
-
   @return {Object} timer
 */
 Ember.run.once = function(target, method) {
@@ -4144,21 +4406,20 @@ function invokeNextTimers() {
 
 /**
   Schedules an item to run after control has been returned to the system.
-  This is often equivalent to calling setTimeout(function...,1).
+  This is often equivalent to calling `setTimeout(function() {}, 1)`.
 
-      Ember.run.next(myContext, function(){
-        // code to be executed in the next RunLoop, which will be scheduled after the current one
-      });
+  ```javascript
+  Ember.run.next(myContext, function(){
+    // code to be executed in the next RunLoop, which will be scheduled after the current one
+  });
+  ```
 
   @method next
   @param {Object} [target] target of method to invoke
-
   @param {Function|String} method The method to invoke.
     If you pass a string it will be resolved on the
     target at the time the method is invoked.
-
   @param {Object} [args*] Optional arguments to pass to the timeout.
-
   @return {Object} timer
 */
 Ember.run.next = function(target, method) {
@@ -4178,23 +4439,25 @@ Ember.run.next = function(target, method) {
 };
 
 /**
-  Cancels a scheduled item.  Must be a value returned by `Ember.run.later()`,
+  Cancels a scheduled item. Must be a value returned by `Ember.run.later()`,
   `Ember.run.once()`, or `Ember.run.next()`.
 
-      var runNext = Ember.run.next(myContext, function(){
-        // will not be executed
-      });
-      Ember.run.cancel(runNext);
+  ```javascript
+  var runNext = Ember.run.next(myContext, function(){
+    // will not be executed
+  });
+  Ember.run.cancel(runNext);
 
-      var runLater = Ember.run.later(myContext, function(){
-        // will not be executed
-      }, 500);
-      Ember.run.cancel(runLater);
+  var runLater = Ember.run.later(myContext, function(){
+    // will not be executed
+  }, 500);
+  Ember.run.cancel(runLater);
 
-      var runOnce = Ember.run.once(myContext, function(){
-        // will not be executed
-      });
-      Ember.run.cancel(runOnce);
+  var runOnce = Ember.run.once(myContext, function(){
+    // will not be executed
+  });
+  Ember.run.cancel(runOnce);
+  ```
 
   @method cancel
   @param {Object} timer Timer object to cancel
@@ -4241,7 +4504,7 @@ var get     = Ember.get,
 
 
 function getWithGlobals(obj, path) {
-  return get(isGlobalPath(path) ? window : obj, path);
+  return get(isGlobalPath(path) ? Ember.lookup : obj, path);
 }
 
 // ..........................................................
@@ -4278,17 +4541,17 @@ Binding.prototype = {
   //
 
   /**
-    This will set "from" property path to the specified value. It will not
+    This will set `from` property path to the specified value. It will not
     attempt to resolve this property path to an actual object until you
     connect the binding.
 
     The binding will search for the property path starting at the root object
-    you pass when you connect() the binding.  It follows the same rules as
+    you pass when you `connect()` the binding. It follows the same rules as
     `get()` - see that method for more information.
 
     @method from
     @param {String} propertyPath the property path to connect to
-    @return {Ember.Binding} receiver
+    @return {Ember.Binding} `this`
   */
   from: function(path) {
     this._from = path;
@@ -4296,17 +4559,17 @@ Binding.prototype = {
   },
 
   /**
-    This will set the "to" property path to the specified value. It will not
+    This will set the `to` property path to the specified value. It will not
     attempt to resolve this property path to an actual object until you
     connect the binding.
 
     The binding will search for the property path starting at the root object
-    you pass when you connect() the binding.  It follows the same rules as
+    you pass when you `connect()` the binding. It follows the same rules as
     `get()` - see that method for more information.
 
     @method to
     @param {String|Tuple} propertyPath A property path or tuple
-    @return {Ember.Binding} this
+    @return {Ember.Binding} `this`
   */
   to: function(path) {
     this._to = path;
@@ -4315,12 +4578,12 @@ Binding.prototype = {
 
   /**
     Configures the binding as one way. A one-way binding will relay changes
-    on the "from" side to the "to" side, but not the other way around. This
-    means that if you change the "to" side directly, the "from" side may have
+    on the `from` side to the `to` side, but not the other way around. This
+    means that if you change the `to` side directly, the `from` side may have
     a different value.
 
     @method oneWay
-    @return {Ember.Binding} receiver
+    @return {Ember.Binding} `this`
   */
   oneWay: function() {
     this._oneWay = true;
@@ -4343,7 +4606,7 @@ Binding.prototype = {
 
     @method connect
     @param {Object} obj The root object for this binding.
-    @return {Ember.Binding} this
+    @return {Ember.Binding} `this`
   */
   connect: function(obj) {
     Ember.assert('Must pass a valid object to Ember.Binding.connect()', !!obj);
@@ -4368,7 +4631,7 @@ Binding.prototype = {
 
     @method disconnect
     @param {Object} obj The root object you passed when connecting the binding.
-    @return {Ember.Binding} this
+    @return {Ember.Binding} `this`
   */
   disconnect: function(obj) {
     Ember.assert('Must pass a valid object to Ember.Binding.disconnect()', !!obj);
@@ -4452,7 +4715,7 @@ Binding.prototype = {
         Ember.Logger.log(' ', this.toString(), '<-', toValue, obj);
       }
       Ember._suspendObserver(obj, fromPath, this, this.fromDidChange, function () {
-        Ember.trySet(Ember.isGlobalPath(fromPath) ? window : obj, fromPath, toValue);
+        Ember.trySet(Ember.isGlobalPath(fromPath) ? Ember.lookup : obj, fromPath, toValue);
       });
     }
   }
@@ -4493,8 +4756,8 @@ mixinProperties(Binding, {
 
   /**
     Creates a new Binding instance and makes it apply in a single direction.
-    A one-way binding will relay changes on the "from" side object (supplied
-    as the `from` argument) the "to" side, but not the other way around.
+    A one-way binding will relay changes on the `from` side object (supplied
+    as the `from` argument) the `to` side, but not the other way around.
     This means that if you change the "to" side directly, the "from" side may have
     a different value.
 
@@ -4502,8 +4765,9 @@ mixinProperties(Binding, {
 
     @method oneWay
     @param {String} from from path.
-    @param {Boolean} [flag] (Optional) passing nothing here will make the binding oneWay.  You can
-      instead pass false to disable oneWay, making the binding two way again.
+    @param {Boolean} [flag] (Optional) passing nothing here will make the
+      binding `oneWay`. You can instead pass `false` to disable `oneWay`, making the
+      binding two way again.
   */
   oneWay: function(from, flag) {
     var C = this, binding = new C(null, from);
@@ -4513,18 +4777,23 @@ mixinProperties(Binding, {
 });
 
 /**
-  An Ember.Binding connects the properties of two objects so that whenever the
-  value of one property changes, the other property will be changed also.
+  An `Ember.Binding` connects the properties of two objects so that whenever
+  the value of one property changes, the other property will be changed also.
 
   ## Automatic Creation of Bindings with `/^*Binding/`-named Properties
+
   You do not usually create Binding objects directly but instead describe
-  bindings in your class or object definition using automatic binding detection.
+  bindings in your class or object definition using automatic binding
+  detection.
 
-  Properties ending in a `Binding` suffix will be converted to Ember.Binding instances.
-  The value of this property should be a string representing a path to another object or
-  a custom binding instanced created using Binding helpers (see "Customizing Your Bindings"):
+  Properties ending in a `Binding` suffix will be converted to `Ember.Binding`
+  instances. The value of this property should be a string representing a path
+  to another object or a custom binding instanced created using Binding helpers
+  (see "Customizing Your Bindings"):
 
-      valueBinding: "MyApp.someController.title"
+  ```
+  valueBinding: "MyApp.someController.title"
+  ```
 
   This will create a binding from `MyApp.someController.title` to the `value`
   property of your object instance automatically. Now the two values will be
@@ -4539,12 +4808,14 @@ mixinProperties(Binding, {
   has changed, but your object will not be changing the preference itself, you
   could do:
 
-      bigTitlesBinding: Ember.Binding.oneWay("MyApp.preferencesController.bigTitles")
+  ```
+  bigTitlesBinding: Ember.Binding.oneWay("MyApp.preferencesController.bigTitles")
+  ```
 
-  This way if the value of MyApp.preferencesController.bigTitles changes the
-  "bigTitles" property of your object will change also. However, if you
-  change the value of your "bigTitles" property, it will not update the
-  preferencesController.
+  This way if the value of `MyApp.preferencesController.bigTitles` changes the
+  `bigTitles` property of your object will change also. However, if you
+  change the value of your `bigTitles` property, it will not update the
+  `preferencesController`.
 
   One way bindings are almost twice as fast to setup and twice as fast to
   execute because the binding only has to worry about changes to one side.
@@ -4555,35 +4826,39 @@ mixinProperties(Binding, {
 
   ## Adding Bindings Manually
 
-  All of the examples above show you how to configure a custom binding, but
-  the result of these customizations will be a binding template, not a fully
-  active Binding instance. The binding will actually become active only when you
+  All of the examples above show you how to configure a custom binding, but the
+  result of these customizations will be a binding template, not a fully active
+  Binding instance. The binding will actually become active only when you
   instantiate the object the binding belongs to. It is useful however, to
   understand what actually happens when the binding is activated.
 
-  For a binding to function it must have at least a "from" property and a "to"
-  property. The from property path points to the object/key that you want to
-  bind from while the to path points to the object/key you want to bind to.
+  For a binding to function it must have at least a `from` property and a `to`
+  property. The `from` property path points to the object/key that you want to
+  bind from while the `to` path points to the object/key you want to bind to.
 
   When you define a custom binding, you are usually describing the property
-  you want to bind from (such as "MyApp.someController.value" in the examples
+  you want to bind from (such as `MyApp.someController.value` in the examples
   above). When your object is created, it will automatically assign the value
-  you want to bind "to" based on the name of your binding key. In the
+  you want to bind `to` based on the name of your binding key. In the
   examples above, during init, Ember objects will effectively call
   something like this on your binding:
 
-      binding = Ember.Binding.from(this.valueBinding).to("value");
+  ```javascript
+  binding = Ember.Binding.from(this.valueBinding).to("value");
+  ```
 
   This creates a new binding instance based on the template you provide, and
-  sets the to path to the "value" property of the new object. Now that the
-  binding is fully configured with a "from" and a "to", it simply needs to be
-  connected to become active. This is done through the connect() method:
+  sets the to path to the `value` property of the new object. Now that the
+  binding is fully configured with a `from` and a `to`, it simply needs to be
+  connected to become active. This is done through the `connect()` method:
 
-      binding.connect(this);
+  ```javascript
+  binding.connect(this);
+  ```
 
   Note that when you connect a binding you pass the object you want it to be
-  connected to.  This object will be used as the root for both the from and
-  to side of the binding when inspecting relative paths.  This allows the
+  connected to. This object will be used as the root for both the from and
+  to side of the binding when inspecting relative paths. This allows the
   binding to be automatically inherited by subclassed objects as well.
 
   Now that the binding is connected, it will observe both the from and to side
@@ -4591,20 +4866,23 @@ mixinProperties(Binding, {
 
   If you ever needed to do so (you almost never will, but it is useful to
   understand this anyway), you could manually create an active binding by
-  using the Ember.bind() helper method. (This is the same method used by
+  using the `Ember.bind()` helper method. (This is the same method used by
   to setup your bindings on objects):
 
-      Ember.bind(MyApp.anotherObject, "value", "MyApp.someController.value");
+  ```javascript
+  Ember.bind(MyApp.anotherObject, "value", "MyApp.someController.value");
+  ```
 
   Both of these code fragments have the same effect as doing the most friendly
   form of binding creation like so:
 
-      MyApp.anotherObject = Ember.Object.create({
-        valueBinding: "MyApp.someController.value",
+  ```javascript
+  MyApp.anotherObject = Ember.Object.create({
+    valueBinding: "MyApp.someController.value",
 
-        // OTHER CODE FOR THIS OBJECT...
-
-      });
+    // OTHER CODE FOR THIS OBJECT...
+  });
+  ```
 
   Ember's built in binding creation method makes it easy to automatically
   create bindings for you. You should always use the highest-level APIs
@@ -4618,19 +4896,16 @@ Ember.Binding = Binding;
 
 
 /**
-  Global helper method to create a new binding.  Just pass the root object
-  along with a to and from path to create and connect the binding.
+  Global helper method to create a new binding. Just pass the root object
+  along with a `to` and `from` path to create and connect the binding.
 
   @method bind
   @for Ember
   @param {Object} obj The root object of the transform.
-
   @param {String} to The path to the 'to' side of the binding.
     Must be relative to obj.
-
   @param {String} from The path to the 'from' side of the binding.
     Must be relative to obj or a global path.
-
   @return {Ember.Binding} binding instance
 */
 Ember.bind = function(obj, to, from) {
@@ -4641,13 +4916,10 @@ Ember.bind = function(obj, to, from) {
   @method oneWay
   @for Ember
   @param {Object} obj The root object of the transform.
-
   @param {String} to The path to the 'to' side of the binding.
     Must be relative to obj.
-
   @param {String} from The path to the 'from' side of the binding.
     Must be relative to obj or a global path.
-
   @return {Ember.Binding} binding instance
 */
 Ember.oneWay = function(obj, to, from) {
@@ -4691,8 +4963,8 @@ function initMixin(mixin, args) {
     mixin.mixins = a_map.call(args, function(x) {
       if (x instanceof Mixin) { return x; }
 
-      // Note: Manually setup a primitive mixin here.  This is the only
-      // way to actually get a primitive mixin.  This way normal creation
+      // Note: Manually setup a primitive mixin here. This is the only
+      // way to actually get a primitive mixin. This way normal creation
       // of mixins will give you combined mixins...
       var mixin = new Mixin();
       mixin.properties = x;
@@ -4709,11 +4981,20 @@ function isMethod(obj) {
 }
 
 function mergeMixins(mixins, m, descs, values, base) {
-  var len = mixins.length, idx, mixin, guid, props, value, key, ovalue, concats;
+  var len = mixins.length, idx, mixin, guid, props, value, key, ovalue, concats, meta;
 
   function removeKeys(keyName) {
     delete descs[keyName];
     delete values[keyName];
+  }
+
+  function cloneDescriptor(desc) {
+    var newDesc = new Ember.ComputedProperty();
+    newDesc._cacheable = desc._cacheable;
+    newDesc._dependentKeys = desc._dependentKeys;
+    newDesc.func = desc.func;
+
+    return newDesc;
   }
 
   for(idx=0; idx < len; idx++) {
@@ -4730,6 +5011,8 @@ function mergeMixins(mixins, m, descs, values, base) {
     }
 
     if (props) {
+      meta = Ember.meta(base);
+
       // reset before adding each new mixin to pickup concats from previous
       concats = values.concatenatedProperties || base.concatenatedProperties;
       if (props.concatenatedProperties) {
@@ -4741,6 +5024,21 @@ function mergeMixins(mixins, m, descs, values, base) {
         value = props[key];
         if (value instanceof Ember.Descriptor) {
           if (value === REQUIRED && descs[key]) { continue; }
+
+          // Wrap descriptor function to implement
+          // _super() if needed
+          if (value.func) {
+            ovalue = values[key] === undefined && descs[key];
+            if (!ovalue) { ovalue = meta.descs[key]; }
+            if (ovalue && ovalue.func) {
+              // Since multiple mixins may inherit from the
+              // same parent, we need to clone the computed
+              // property so that other mixins do not receive
+              // the wrapped version.
+              value = cloneDescriptor(value);
+              value.func = Ember.wrap(value.func, ovalue.func);
+            }
+          }
 
           descs[key]  = value;
           values[key] = undefined;
@@ -4758,7 +5056,15 @@ function mergeMixins(mixins, m, descs, values, base) {
             }
           } else if ((concats && a_indexOf.call(concats, key) >= 0) || key === 'concatenatedProperties') {
             var baseValue = values[key] || base[key];
-            value = baseValue ? baseValue.concat(value) : Ember.makeArray(value);
+            if (baseValue) {
+              if ('function' === typeof baseValue.concat) {
+                value = baseValue.concat(value);
+              } else {
+                value = Ember.makeArray(baseValue).concat(value);
+              }
+            } else {
+              value = Ember.makeArray(value);
+            }
           }
 
           descs[key] = undefined;
@@ -4951,22 +5257,24 @@ Ember.mixin = function(obj) {
   The `Ember.Mixin` class allows you to create mixins, whose properties can be
   added to other classes. For instance,
 
-      App.Editable = Ember.Mixin.create({
-        edit: function() {
-          console.log('starting to edit');
-          this.set('isEditing', true);
-        },
-        isEditing: false
-      });
+  ```javascript
+  App.Editable = Ember.Mixin.create({
+    edit: function() {
+      console.log('starting to edit');
+      this.set('isEditing', true);
+    },
+    isEditing: false
+  });
 
-      // Mix mixins into classes by passing them as the first arguments to
-      // .extend or .create.
-      App.CommentView = Ember.View.extend(App.Editable, {
-        template: Ember.Handlebars.compile('{{#if isEditing}}...{{else}}...{{/if}}')
-      });
+  // Mix mixins into classes by passing them as the first arguments to
+  // .extend or .create.
+  App.CommentView = Ember.View.extend(App.Editable, {
+    template: Ember.Handlebars.compile('{{#if isEditing}}...{{else}}...{{/if}}')
+  });
 
-      commentView = App.CommentView.create();
-      commentView.edit(); // => outputs 'starting to edit'
+  commentView = App.CommentView.create();
+  commentView.edit(); // outputs 'starting to edit'
+  ```
 
   Note that Mixins are created with `Ember.Mixin.create`, not
   `Ember.Mixin.extend`.
@@ -5119,7 +5427,7 @@ function processNames(paths, root, seen) {
 
     if (obj && obj.toString === classToString) {
       obj[NAME_KEY] = paths.join('.');
-    } else if (obj && get(obj, 'isNamespace')) {
+    } else if (obj && obj.isNamespace) {
       if (seen[guidFor(obj)]) { continue; }
       seen[guidFor(obj)] = true;
       processNames(paths, obj, seen);
@@ -5129,22 +5437,25 @@ function processNames(paths, root, seen) {
 }
 
 function findNamespaces() {
-  var Namespace = Ember.Namespace, obj, isNamespace;
+  var Namespace = Ember.Namespace, lookup = Ember.lookup, obj, isNamespace;
 
   if (Namespace.PROCESSED) { return; }
 
-  for (var prop in window) {
+  for (var prop in lookup) {
+    // These don't raise exceptions but can cause warnings
+    if (prop === "parent" || prop === "top" || prop === "frameElement") { continue; }
+
     //  get(window.globalStorage, 'isNamespace') would try to read the storage for domain isNamespace and cause exception in Firefox.
     // globalStorage is a storage obsoleted by the WhatWG storage specification. See https://developer.mozilla.org/en/DOM/Storage#globalStorage
-    if (prop === "globalStorage" && window.StorageList && window.globalStorage instanceof window.StorageList) { continue; }
+    if (prop === "globalStorage" && lookup.StorageList && lookup.globalStorage instanceof lookup.StorageList) { continue; }
     // Unfortunately, some versions of IE don't support window.hasOwnProperty
-    if (window.hasOwnProperty && !window.hasOwnProperty(prop)) { continue; }
+    if (lookup.hasOwnProperty && !lookup.hasOwnProperty(prop)) { continue; }
 
     // At times we are not allowed to access certain properties for security reasons.
     // There are also times where even if we can access them, we are not allowed to access their properties.
     try {
-      obj = window[prop];
-      isNamespace = obj && get(obj, 'isNamespace');
+      obj = Ember.lookup[prop];
+      isNamespace = obj && obj.isNamespace;
     } catch (e) {
       continue;
     }
@@ -5177,7 +5488,7 @@ classToString = function() {
   var Namespace = Ember.Namespace, namespace;
 
   // TODO: Namespace should really be in Metal
-  if (Namespace) {
+  if (Namespace && !Ember.BOOTED) {
     if (!this[NAME_KEY] && !classToString.processed) {
       if (!Namespace.PROCESSED) {
         findNamespaces();
@@ -5245,17 +5556,20 @@ Alias.prototype = new Ember.Descriptor();
 /**
   Makes a property or method available via an additional name.
 
-      App.PaintSample = Ember.Object.extend({
-        color: 'red',
-        colour: Ember.alias('color'),
-        name: function(){
-          return "Zed";
-        },
-        moniker: Ember.alias("name")
-      });
-      var paintSample = App.PaintSample.create()
-      paintSample.get('colour'); //=> 'red'
-      paintSample.moniker(); //=> 'Zed'
+  ```javascript
+  App.PaintSample = Ember.Object.extend({
+    color: 'red',
+    colour: Ember.alias('color'),
+    name: function(){
+      return "Zed";
+    },
+    moniker: Ember.alias("name")
+  });
+
+  var paintSample = App.PaintSample.create()
+  paintSample.get('colour');  // 'red'
+  paintSample.moniker();      // 'Zed'
+  ```
 
   @method alias
   @for Ember
@@ -5329,6 +5643,234 @@ Ember Metal
 })();
 
 (function() {
+define("rsvp",
+  ["exports"],
+  function(exports) {
+    "use strict";
+    var browserGlobal = (typeof window !== 'undefined') ? window : {};
+
+    var MutationObserver = browserGlobal.MutationObserver || browserGlobal.WebKitMutationObserver;
+    var async;
+
+    if (typeof process !== 'undefined' &&
+      {}.toString.call(process) === '[object process]') {
+      async = function(callback, binding) {
+        process.nextTick(function() {
+          callback.call(binding);
+        });
+      };
+    } else if (MutationObserver) {
+      var queue = [];
+
+      var observer = new MutationObserver(function() {
+        var toProcess = queue.slice();
+        queue = [];
+
+        toProcess.forEach(function(tuple) {
+          var callback = tuple[0], binding = tuple[1];
+          callback.call(binding);
+        });
+      });
+
+      var element = document.createElement('div');
+      observer.observe(element, { attributes: true });
+
+      async = function(callback, binding) {
+        queue.push([callback, binding]);
+        element.setAttribute('drainQueue', 'drainQueue');
+      };
+    } else {
+      async = function(callback, binding) {
+        setTimeout(function() {
+          callback.call(binding);
+        }, 1);
+      };
+    }
+
+
+    var Event = function(type, options) {
+      this.type = type;
+
+      for (var option in options) {
+        if (!options.hasOwnProperty(option)) { continue; }
+
+        this[option] = options[option];
+      }
+    };
+
+
+    var indexOf = function(callbacks, callback) {
+      for (var i=0, l=callbacks.length; i<l; i++) {
+        if (callbacks[i][0] === callback) { return i; }
+      }
+
+      return -1;
+    };
+
+    var callbacksFor = function(object) {
+      var callbacks = object._promiseCallbacks;
+
+      if (!callbacks) {
+        callbacks = object._promiseCallbacks = {};
+      }
+
+      return callbacks;
+    };
+
+    var EventTarget = {
+      mixin: function(object) {
+        object.on = this.on;
+        object.off = this.off;
+        object.trigger = this.trigger;
+        return object;
+      },
+
+      on: function(eventNames, callback, binding) {
+        var allCallbacks = callbacksFor(this), callbacks, eventName;
+        eventNames = eventNames.split(/\s+/);
+        binding = binding || this;
+
+        while (eventName = eventNames.shift()) {
+          callbacks = allCallbacks[eventName];
+
+          if (!callbacks) {
+            callbacks = allCallbacks[eventName] = [];
+          }
+
+          if (indexOf(callbacks, callback) === -1) {
+            callbacks.push([callback, binding]);
+          }
+        }
+      },
+
+      off: function(eventNames, callback) {
+        var allCallbacks = callbacksFor(this), callbacks, eventName, index;
+        eventNames = eventNames.split(/\s+/);
+
+        while (eventName = eventNames.shift()) {
+          if (!callback) {
+            allCallbacks[eventName] = [];
+            continue;
+          }
+
+          callbacks = allCallbacks[eventName];
+
+          index = indexOf(callbacks, callback);
+
+          if (index !== -1) { callbacks.splice(index, 1); }
+        }
+      },
+
+      trigger: function(eventName, options) {
+        var allCallbacks = callbacksFor(this),
+            callbacks, callbackTuple, callback, binding, event;
+
+        if (callbacks = allCallbacks[eventName]) {
+          for (var i=0, l=callbacks.length; i<l; i++) {
+            callbackTuple = callbacks[i];
+            callback = callbackTuple[0];
+            binding = callbackTuple[1];
+
+            if (typeof options !== 'object') {
+              options = { detail: options };
+            }
+
+            event = new Event(eventName, options);
+            callback.call(binding, event);
+          }
+        }
+      }
+    };
+
+
+    var Promise = function() {
+      this.on('promise:resolved', function(event) {
+        this.trigger('success', { detail: event.detail });
+      }, this);
+
+      this.on('promise:failed', function(event) {
+        this.trigger('error', { detail: event.detail });
+      }, this);
+    };
+
+
+    var noop = function() {};
+
+    var invokeCallback = function(type, promise, callback, event) {
+      var value, error;
+
+      if (callback) {
+        try {
+          value = callback(event.detail);
+        } catch(e) {
+          error = e;
+        }
+      } else {
+        value = event.detail;
+      }
+
+      if (value instanceof Promise) {
+        value.then(function(value) {
+          promise.resolve(value);
+        }, function(error) {
+          promise.reject(error);
+        });
+      } else if (callback && value) {
+        promise.resolve(value);
+      } else if (error) {
+        promise.reject(error);
+      } else {
+        promise[type](value);
+      }
+    };
+
+    Promise.prototype = {
+      then: function(done, fail) {
+        var thenPromise = new Promise();
+
+        this.on('promise:resolved', function(event) {
+          invokeCallback('resolve', thenPromise, done, event);
+        });
+
+        this.on('promise:failed', function(event) {
+          invokeCallback('reject', thenPromise, fail, event);
+        });
+
+        return thenPromise;
+      },
+
+      resolve: function(value) {
+        async(function() {
+          this.trigger('promise:resolved', { detail: value });
+          this.isResolved = value;
+        }, this);
+
+        this.resolve = noop;
+        this.reject = noop;
+      },
+
+      reject: function(value) {
+        async(function() {
+          this.trigger('promise:failed', { detail: value });
+          this.isRejected = value;
+        }, this);
+
+        this.resolve = noop;
+        this.reject = noop;
+      }
+    };
+
+    EventTarget.mixin(Promise.prototype);
+
+    exports.async = async;
+    exports.Event = Event;
+    exports.EventTarget = EventTarget;
+    exports.Promise = Promise;
+  });
+
+})();
+
+(function() {
 /*globals ENV */
 /**
 @module ember
@@ -5354,7 +5896,7 @@ var toString = Object.prototype.toString;
 
   Use this instead of the built-in `typeof` to get the type of an item.
   It will return the same result across all browsers and includes a bit
-  more detail.  Here is what will be returned:
+  more detail. Here is what will be returned:
 
       | Return Value  | Meaning                                              |
       |---------------|------------------------------------------------------|
@@ -5372,20 +5914,22 @@ var toString = Object.prototype.toString;
 
   Examples:
 
-      Ember.typeOf();                      => 'undefined'
-      Ember.typeOf(null);                  => 'null'
-      Ember.typeOf(undefined);             => 'undefined'
-      Ember.typeOf('michael');             => 'string'
-      Ember.typeOf(101);                   => 'number'
-      Ember.typeOf(true);                  => 'boolean'
-      Ember.typeOf(Ember.makeArray);       => 'function'
-      Ember.typeOf([1,2,90]);              => 'array'
-      Ember.typeOf(Ember.Object.extend()); => 'class'
-      Ember.typeOf(Ember.Object.create()); => 'instance'
-      Ember.typeOf(new Error('teamocil')); => 'error'
+  ```javascript
+  Ember.typeOf();                       // 'undefined'
+  Ember.typeOf(null);                   // 'null'
+  Ember.typeOf(undefined);              // 'undefined'
+  Ember.typeOf('michael');              // 'string'
+  Ember.typeOf(101);                    // 'number'
+  Ember.typeOf(true);                   // 'boolean'
+  Ember.typeOf(Ember.makeArray);        // 'function'
+  Ember.typeOf([1,2,90]);               // 'array'
+  Ember.typeOf(Ember.Object.extend());  // 'class'
+  Ember.typeOf(Ember.Object.create());  // 'instance'
+  Ember.typeOf(new Error('teamocil'));  // 'error'
 
-      // "normal" JavaScript object
-      Ember.typeOf({a: 'b'});              => 'object'
+  // "normal" JavaScript object
+  Ember.typeOf({a: 'b'});              // 'object'
+  ```
 
   @method typeOf
   @for Ember
@@ -5409,16 +5953,18 @@ Ember.typeOf = function(item) {
 };
 
 /**
-  Returns true if the passed value is null or undefined.  This avoids errors
+  Returns true if the passed value is null or undefined. This avoids errors
   from JSLint complaining about use of ==, which can be technically
   confusing.
 
-      Ember.none();             => true
-      Ember.none(null);         => true
-      Ember.none(undefined);    => true
-      Ember.none('');           => false
-      Ember.none([]);           => false
-      Ember.none(function(){}); => false
+  ```javascript
+  Ember.none();              // true
+  Ember.none(null);          // true
+  Ember.none(undefined);     // true
+  Ember.none('');            // false
+  Ember.none([]);            // false
+  Ember.none(function(){});  // false
+  ```
 
   @method none
   @for Ember
@@ -5430,18 +5976,21 @@ Ember.none = function(obj) {
 };
 
 /**
-  Verifies that a value is null or an empty string | array | function.
+  Verifies that a value is `null` or an empty string, empty array,
+  or empty function.
 
   Constrains the rules on `Ember.none` by returning false for empty
   string and empty arrays.
 
-      Ember.empty();               => true
-      Ember.empty(null);           => true
-      Ember.empty(undefined);      => true
-      Ember.empty('');             => true
-      Ember.empty([]);             => true
-      Ember.empty('tobias fünke'); => false
-      Ember.empty([0,1,2]);        => false
+  ```javascript
+  Ember.empty();                // true
+  Ember.empty(null);            // true
+  Ember.empty(undefined);       // true
+  Ember.empty('');              // true
+  Ember.empty([]);              // true
+  Ember.empty('Adam Hawkins');  // false
+  Ember.empty([0,1,2]);         // false
+  ```
 
   @method empty
   @for Ember
@@ -5460,12 +6009,14 @@ Ember.empty = function(obj) {
   - 0 if both are equal,
   - 1 if the first is greater than the second.
 
- The order is calculated based on Ember.ORDER_DEFINITION, if types are different.
+ The order is calculated based on `Ember.ORDER_DEFINITION`, if types are different.
  In case they have the same type an appropriate comparison for this type is made.
 
-    Ember.compare('hello', 'hello');  => 0
-    Ember.compare('abc', 'dfg');      => -1
-    Ember.compare(2, 1);              => 1
+  ```javascript
+  Ember.compare('hello', 'hello');  // 0
+  Ember.compare('abc', 'dfg');      // -1
+  Ember.compare(2, 1);              // 1
+  ```javascript
 
  @method compare
  @for Ember
@@ -5573,7 +6124,7 @@ function _copy(obj, deep, seen, copies) {
 
   Ember.assert('Cannot clone an Ember.Object that does not implement Ember.Copyable', !(obj instanceof Ember.Object) || (Ember.Copyable && Ember.Copyable.detect(obj)));
 
-  // IMPORTANT: this specific test will detect a native array only.  Any other
+  // IMPORTANT: this specific test will detect a native array only. Any other
   // object will need to implement Copyable.
   if (Ember.typeOf(obj) === 'array') {
     ret = obj.slice();
@@ -5604,7 +6155,7 @@ function _copy(obj, deep, seen, copies) {
   any type of object and create a clone of it, including primitive values
   (which are not actually cloned because they are immutable).
 
-  If the passed object implements the clone() method, then this function
+  If the passed object implements the `clone()` method, then this function
   will simply call that method and return the result.
 
   @method copy
@@ -5643,14 +6194,16 @@ Ember.inspect = function(obj) {
 };
 
 /**
-  Compares two objects, returning true if they are logically equal.  This is
+  Compares two objects, returning true if they are logically equal. This is
   a deeper comparison than a simple triple equal. For sets it will compare the
-  internal objects.  For any other object that implements `isEqual()` it will 
+  internal objects. For any other object that implements `isEqual()` it will
   respect that method.
 
-      Ember.isEqual('hello', 'hello');  => true
-      Ember.isEqual(1, 2);              => false
-      Ember.isEqual([4,2], [4,2]);      => false
+  ```javascript
+  Ember.isEqual('hello', 'hello');  // true
+  Ember.isEqual(1, 2);              // false
+  Ember.isEqual([4,2], [4,2]);      // false
+  ```
 
   @method isEqual
   @for Ember
@@ -5680,8 +6233,8 @@ Ember.ORDER_DEFINITION = Ember.ENV.ORDER_DEFINITION || [
 
 /**
   Returns all of the keys defined on an object or hash. This is useful
-  when inspecting objects for debugging.  On browsers that support it, this
-  uses the native Object.keys implementation.
+  when inspecting objects for debugging. On browsers that support it, this
+  uses the native `Object.keys` implementation.
 
   @method keys
   @for Ember
@@ -5743,8 +6296,8 @@ var STRING_UNDERSCORE_REGEXP_1 = (/([a-z\d])([A-Z]+)/g);
 var STRING_UNDERSCORE_REGEXP_2 = (/\-|\s+/g);
 
 /**
-  Defines the hash of localized strings for the current language.  Used by
-  the `Ember.String.loc()` helper.  To localize, add string values to this
+  Defines the hash of localized strings for the current language. Used by
+  the `Ember.String.loc()` helper. To localize, add string values to this
   hash.
 
   @property STRINGS
@@ -5755,8 +6308,8 @@ Ember.STRINGS = {};
 
 /**
   Defines string helper methods including string formatting and localization.
-  Unless Ember.EXTEND_PROTOTYPES = false these methods will also be added to the
-  String.prototype as well.
+  Unless `Ember.EXTEND_PROTOTYPES.String` is `false` these methods will also be
+  added to the `String.prototype` as well.
 
   @class String
   @namespace Ember
@@ -5765,17 +6318,19 @@ Ember.STRINGS = {};
 Ember.String = {
 
   /**
-    Apply formatting options to the string.  This will look for occurrences
-    of %@ in your string and substitute them with the arguments you pass into
-    this method.  If you want to control the specific order of replacement,
+    Apply formatting options to the string. This will look for occurrences
+    of "%@" in your string and substitute them with the arguments you pass into
+    this method. If you want to control the specific order of replacement,
     you can add a number after the key as well to indicate which argument
     you want to insert.
 
     Ordered insertions are most useful when building loc strings where values
     you need to insert may appear in different orders.
 
-        "Hello %@ %@".fmt('John', 'Doe') => "Hello John Doe"
-        "Hello %@2, %@1".fmt('John', 'Doe') => "Hello Doe, John"
+    ```javascript
+    "Hello %@ %@".fmt('John', 'Doe');     // "Hello John Doe"
+    "Hello %@2, %@1".fmt('John', 'Doe');  // "Hello Doe, John"
+    ```
 
     @method fmt
     @param {Object...} [args]
@@ -5793,23 +6348,22 @@ Ember.String = {
 
   /**
     Formats the passed string, but first looks up the string in the localized
-    strings hash.  This is a convenient way to localize text.  See
+    strings hash. This is a convenient way to localize text. See
     `Ember.String.fmt()` for more information on formatting.
 
     Note that it is traditional but not required to prefix localized string
     keys with an underscore or other character so you can easily identify
     localized strings.
 
-        Ember.STRINGS = {
-          '_Hello World': 'Bonjour le monde',
-          '_Hello %@ %@': 'Bonjour %@ %@'
-        };
+    ```javascript
+    Ember.STRINGS = {
+      '_Hello World': 'Bonjour le monde',
+      '_Hello %@ %@': 'Bonjour %@ %@'
+    };
 
-        Ember.String.loc("_Hello World");
-        => 'Bonjour le monde';
-
-        Ember.String.loc("_Hello %@ %@", ["John", "Smith"]);
-        => "Bonjour John Smith";
+    Ember.String.loc("_Hello World");  // 'Bonjour le monde';
+    Ember.String.loc("_Hello %@ %@", ["John", "Smith"]);  // "Bonjour John Smith";
+    ```
 
     @method loc
     @param {String} str The string to format
@@ -5823,15 +6377,18 @@ Ember.String = {
 
   /**
     Splits a string into separate units separated by spaces, eliminating any
-    empty strings in the process.  This is a convenience method for split that
-    is mostly useful when applied to the String.prototype.
+    empty strings in the process. This is a convenience method for split that
+    is mostly useful when applied to the `String.prototype`.
 
-        Ember.String.w("alpha beta gamma").forEach(function(key) {
-          console.log(key);
-        });
-        > alpha
-        > beta
-        > gamma
+    ```javascript
+    Ember.String.w("alpha beta gamma").forEach(function(key) {
+      console.log(key);
+    });
+
+    // > alpha
+    // > beta
+    // > gamma
+    ```
 
     @method w
     @param {String} str The string to split
@@ -5841,11 +6398,13 @@ Ember.String = {
 
   /**
     Converts a camelized string into all lower case separated by underscores.
-    
-        'innerHTML'.decamelize()         => 'inner_html'
-        'action_name'.decamelize()       => 'action_name'
-        'css-class-name'.decamelize()    => 'css-class-name'
-        'my favorite items'.decamelize() => 'my favorite items'
+
+    ```javascript
+    'innerHTML'.decamelize();           // 'inner_html'
+    'action_name'.decamelize();        // 'action_name'
+    'css-class-name'.decamelize();     // 'css-class-name'
+    'my favorite items'.decamelize();  // 'my favorite items'
+    ```
 
     @method decamelize
     @param {String} str The string to decamelize.
@@ -5857,11 +6416,13 @@ Ember.String = {
 
   /**
     Replaces underscores or spaces with dashes.
-    
-        'innerHTML'.dasherize()         => 'inner-html'
-        'action_name'.dasherize()       => 'action-name'
-        'css-class-name'.dasherize()    => 'css-class-name'
-        'my favorite items'.dasherize() => 'my-favorite-items'
+
+    ```javascript
+    'innerHTML'.dasherize();          // 'inner-html'
+    'action_name'.dasherize();        // 'action-name'
+    'css-class-name'.dasherize();     // 'css-class-name'
+    'my favorite items'.dasherize();  // 'my-favorite-items'
+    ```
 
     @method dasherize
     @param {String} str The string to dasherize.
@@ -5884,10 +6445,12 @@ Ember.String = {
   /**
     Returns the lowerCaseCamel form of a string.
 
-        'innerHTML'.camelize()         => 'innerHTML'
-        'action_name'.camelize()       => 'actionName'
-        'css-class-name'.camelize()    => 'cssClassName'
-        'my favorite items'.camelize() => 'myFavoriteItems'
+    ```javascript
+    'innerHTML'.camelize();          // 'innerHTML'
+    'action_name'.camelize();        // 'actionName'
+    'css-class-name'.camelize();     // 'cssClassName'
+    'my favorite items'.camelize();  // 'myFavoriteItems'
+    ```
 
     @method camelize
     @param {String} str The string to camelize.
@@ -5902,10 +6465,12 @@ Ember.String = {
   /**
     Returns the UpperCamelCase form of a string.
 
-        'innerHTML'.classify()         => 'InnerHTML'
-        'action_name'.classify()       => 'ActionName'
-        'css-class-name'.classify()    => 'CssClassName'
-        'my favorite items'.classify() => 'MyFavoriteItems'
+    ```javascript
+    'innerHTML'.classify();          // 'InnerHTML'
+    'action_name'.classify();        // 'ActionName'
+    'css-class-name'.classify();     // 'CssClassName'
+    'my favorite items'.classify();  // 'MyFavoriteItems'
+    ``` 
 
     @method classify
     @param {String} str the string to classify
@@ -5917,13 +6482,15 @@ Ember.String = {
   },
 
   /**
-    More general than decamelize. Returns the lower_case_and_underscored
+    More general than decamelize. Returns the lower\_case\_and\_underscored
     form of a string.
 
-        'innerHTML'.underscore()         => 'inner_html'
-        'action_name'.underscore()       => 'action_name'
-        'css-class-name'.underscore()    => 'css_class_name'
-        'my favorite items'.underscore() => 'my_favorite_items'
+    ```javascript
+    'innerHTML'.underscore();          // 'inner_html'
+    'action_name'.underscore();        // 'action_name'
+    'css-class-name'.underscore();     // 'css_class_name'
+    'my favorite items'.underscore();  // 'my_favorite_items'
+    ```
 
     @property underscore
     @param {String} str The string to underscore.
@@ -5953,9 +6520,10 @@ var fmt = Ember.String.fmt,
     camelize = Ember.String.camelize,
     decamelize = Ember.String.decamelize,
     dasherize = Ember.String.dasherize,
-    underscore = Ember.String.underscore;
+    underscore = Ember.String.underscore,
+    classify = Ember.String.classify;
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
   /**
     See {{#crossLink "Ember.String/fmt"}}{{/crossLink}}
@@ -6027,6 +6595,15 @@ if (Ember.EXTEND_PROTOTYPES) {
     return underscore(this);
   };
 
+  /**
+    See {{#crossLink "Ember.String/classify"}}{{/crossLink}}
+
+    @method classify
+    @for String
+  */
+  String.prototype.classify = function() {
+    return classify(this);
+  };
 }
 
 
@@ -6042,48 +6619,53 @@ if (Ember.EXTEND_PROTOTYPES) {
 
 var a_slice = Array.prototype.slice;
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
   /**
     The `property` extension of Javascript's Function prototype is available
-    when Ember.EXTEND_PROTOTYPES is true, which is the default.
+    when `Ember.EXTEND_PROTOTYPES` or `Ember.EXTEND_PROTOTYPES.Function` is
+    `true`, which is the default.
 
     Computed properties allow you to treat a function like a property:
 
-        MyApp.president = Ember.Object.create({
-          firstName: "Barack",
-          lastName: "Obama",
+    ```javascript
+    MyApp.president = Ember.Object.create({
+      firstName: "Barack",
+      lastName: "Obama",
 
-          fullName: function() {
-            return this.get('firstName') + ' ' + this.get('lastName');
+      fullName: function() {
+        return this.get('firstName') + ' ' + this.get('lastName');
 
-            // Call this flag to mark the function as a property
-          }.property()
-        });
+        // Call this flag to mark the function as a property
+      }.property()
+    });
 
-        MyApp.president.get('fullName');    => "Barack Obama"
+    MyApp.president.get('fullName');    // "Barack Obama"
+    ```
 
     Treating a function like a property is useful because they can work with
     bindings, just like any other property.
 
     Many computed properties have dependencies on other properties. For
     example, in the above example, the `fullName` property depends on
-    `firstName` and `lastName` to determine its value. You can tell Ember.js
+    `firstName` and `lastName` to determine its value. You can tell Ember
     about these dependencies like this:
 
-        MyApp.president = Ember.Object.create({
-          firstName: "Barack",
-          lastName: "Obama",
+    ```javascript
+    MyApp.president = Ember.Object.create({
+      firstName: "Barack",
+      lastName: "Obama",
 
-          fullName: function() {
-            return this.get('firstName') + ' ' + this.get('lastName');
+      fullName: function() {
+        return this.get('firstName') + ' ' + this.get('lastName');
 
-            // Tell Ember.js that this computed property depends on firstName
-            // and lastName
-          }.property('firstName', 'lastName')
-        });
+        // Tell Ember.js that this computed property depends on firstName
+        // and lastName
+      }.property('firstName', 'lastName')
+    });
+    ```
 
-    Make sure you list these dependencies so Ember.js knows when to update
+    Make sure you list these dependencies so Ember knows when to update
     bindings that connect to a computed property. Changing a dependency
     will not immediately trigger an update of the computed property, but
     will instead clear the cache so that it is updated when the next `get`
@@ -6102,17 +6684,20 @@ if (Ember.EXTEND_PROTOTYPES) {
 
   /**
     The `observes` extension of Javascript's Function prototype is available
-    when Ember.EXTEND_PROTOTYPES is true, which is the default.
+    when `Ember.EXTEND_PROTOTYPES` or `Ember.EXTEND_PROTOTYPES.Function` is
+    true, which is the default.
 
     You can observe property changes simply by adding the `observes`
     call to the end of your method declarations in classes that you write.
     For example:
 
-        Ember.Object.create({
-          valueObserver: function() {
-            // Executes whenever the "value" property changes
-          }.observes('value')
-        });
+    ```javascript
+    Ember.Object.create({
+      valueObserver: function() {
+        // Executes whenever the "value" property changes
+      }.observes('value')
+    });
+    ```
 
     See {{#crossLink "Ember.Observable/observes"}}{{/crossLink}}
 
@@ -6126,17 +6711,20 @@ if (Ember.EXTEND_PROTOTYPES) {
 
   /**
     The `observesBefore` extension of Javascript's Function prototype is
-    available when Ember.EXTEND_PROTOTYPES is true, which is the default.
+    available when `Ember.EXTEND_PROTOTYPES` or
+    `Ember.EXTEND_PROTOTYPES.Function` is true, which is the default.
 
     You can get notified when a property changes is about to happen by
     by adding the `observesBefore` call to the end of your method
     declarations in classes that you write. For example:
 
-        Ember.Object.create({
-          valueObserver: function() {
-            // Executes whenever the "value" property is about to change
-          }.observesBefore('value')
-        });
+    ```javascript
+    Ember.Object.create({
+      valueObserver: function() {
+        // Executes whenever the "value" property is about to change
+      }.observesBefore('value')
+    });
+    ```
 
     See {{#crossLink "Ember.Observable/observesBefore"}}{{/crossLink}}
 
@@ -6198,33 +6786,33 @@ function iter(key, value) {
 
 /**
   This mixin defines the common interface implemented by enumerable objects
-  in Ember.  Most of these methods follow the standard Array iteration
+  in Ember. Most of these methods follow the standard Array iteration
   API defined up to JavaScript 1.8 (excluding language-specific features that
   cannot be emulated in older versions of JavaScript).
 
   This mixin is applied automatically to the Array class on page load, so you
-  can use any of these methods on simple arrays.  If Array already implements
+  can use any of these methods on simple arrays. If Array already implements
   one of these methods, the mixin will not override them.
 
-  h3. Writing Your Own Enumerable
+  ## Writing Your Own Enumerable
 
   To make your own custom class enumerable, you need two items:
 
-  1. You must have a length property.  This property should change whenever
-     the number of items in your enumerable object changes.  If you using this
-     with an Ember.Object subclass, you should be sure to change the length
-     property using set().
+  1. You must have a length property. This property should change whenever
+     the number of items in your enumerable object changes. If you using this
+     with an `Ember.Object` subclass, you should be sure to change the length
+     property using `set().`
 
-  2. If you must implement nextObject().  See documentation.
+  2. If you must implement `nextObject().` See documentation.
 
-  Once you have these two methods implement, apply the Ember.Enumerable mixin
+  Once you have these two methods implement, apply the `Ember.Enumerable` mixin
   to your class and you will be able to enumerate the contents of your object
   like any other collection.
 
-  h3. Using Ember Enumeration with Other Libraries
+  ## Using Ember Enumeration with Other Libraries
 
   Many other libraries provide some kind of iterator or enumeration like
-  facility.  This is often where the most common API conflicts occur.
+  facility. This is often where the most common API conflicts occur.
   Ember's API is designed to be as friendly as possible with other
   libraries by implementing only methods that mostly correspond to the
   JavaScript 1.8 API.
@@ -6243,24 +6831,24 @@ Ember.Enumerable = Ember.Mixin.create(
   /**
     Implement this method to make your class enumerable.
 
-    This method will be call repeatedly during enumeration.  The index value
-    will always begin with 0 and increment monotonically.  You don't have to
+    This method will be call repeatedly during enumeration. The index value
+    will always begin with 0 and increment monotonically. You don't have to
     rely on the index value to determine what object to return, but you should
     always check the value and start from the beginning when you see the
     requested index is 0.
 
-    The previousObject is the object that was returned from the last call
-    to nextObject for the current iteration.  This is a useful way to
+    The `previousObject` is the object that was returned from the last call
+    to `nextObject` for the current iteration. This is a useful way to
     manage iteration if you are tracing a linked list, for example.
 
     Finally the context parameter will always contain a hash you can use as
     a "scratchpad" to maintain any other state you need in order to iterate
-    properly.  The context object is reused and is not reset between
+    properly. The context object is reused and is not reset between
     iterations so make sure you setup the context with a fresh state whenever
     the index parameter is 0.
 
-    Generally iterators will continue to call nextObject until the index
-    reaches the your current length-1.  If you run out of data before this
+    Generally iterators will continue to call `nextObject` until the index
+    reaches the your current length-1. If you run out of data before this
     time for some reason, you should simply return undefined.
 
     The default implementation of this method simply looks up the index.
@@ -6268,27 +6856,30 @@ Ember.Enumerable = Ember.Mixin.create(
 
     @method nextObject
     @param {Number} index the current index of the iteration
-    @param {Object} previousObject the value returned by the last call to nextObject.
+    @param {Object} previousObject the value returned by the last call to 
+      `nextObject`.
     @param {Object} context a context object you can use to maintain state.
     @return {Object} the next object in the iteration or undefined
   */
   nextObject: Ember.required(Function),
 
   /**
-    Helper method returns the first object from a collection.  This is usually
+    Helper method returns the first object from a collection. This is usually
     used by bindings and other parts of the framework to extract a single
     object if the enumerable contains only one item.
 
     If you override this method, you should implement it so that it will
-    always return the same value each time it is called.  If your enumerable
+    always return the same value each time it is called. If your enumerable
     contains only one object, this method should always return that object.
-    If your enumerable is empty, this method should return undefined.
+    If your enumerable is empty, this method should return `undefined`.
 
-        var arr = ["a", "b", "c"];
-        arr.firstObject(); => "a"
+    ```javascript
+    var arr = ["a", "b", "c"];
+    arr.firstObject();  // "a"
 
-        var arr = [];
-        arr.firstObject(); => undefined
+    var arr = [];
+    arr.firstObject();  // undefined
+    ```
 
     @property firstObject
     @return {Object} the object or undefined
@@ -6301,18 +6892,20 @@ Ember.Enumerable = Ember.Mixin.create(
     ret = this.nextObject(0, null, context);
     pushCtx(context);
     return ret ;
-  }).property('[]').cacheable(),
+  }).property('[]'),
 
   /**
     Helper method returns the last object from a collection. If your enumerable
     contains only one object, this method should always return that object.
-    If your enumerable is empty, this method should return undefined.
+    If your enumerable is empty, this method should return `undefined`.
 
-        var arr = ["a", "b", "c"];
-        arr.lastObject(); => "c"
+    ```javascript
+    var arr = ["a", "b", "c"];
+    arr.lastObject();  // "c"
 
-        var arr = [];
-        arr.lastObject(); => undefined
+    var arr = [];
+    arr.lastObject();  // undefined
+    ```
 
     @property lastObject
     @return {Object} the last object or undefined
@@ -6327,20 +6920,22 @@ Ember.Enumerable = Ember.Mixin.create(
     } while (cur !== undefined);
     pushCtx(context);
     return last;
-  }).property('[]').cacheable(),
+  }).property('[]'),
 
   /**
-    Returns true if the passed object can be found in the receiver.  The
+    Returns `true` if the passed object can be found in the receiver. The
     default version will iterate through the enumerable until the object
-    is found.  You may want to override this with a more efficient version.
+    is found. You may want to override this with a more efficient version.
 
-        var arr = ["a", "b", "c"];
-        arr.contains("a"); => true
-        arr.contains("z"); => false
+    ```javascript
+    var arr = ["a", "b", "c"];
+    arr.contains("a"); // true
+    arr.contains("z"); // false
+    ```
 
     @method contains
     @param {Object} obj The object to search for.
-    @return {Boolean} true if object is found in enumerable.
+    @return {Boolean} `true` if object is found in enumerable.
   */
   contains: function(obj) {
     return this.find(function(item) { return item===obj; }) !== undefined;
@@ -6348,20 +6943,22 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Iterates through the enumerable, calling the passed function on each
-    item. This method corresponds to the forEach() method defined in
+    item. This method corresponds to the `forEach()` method defined in
     JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     @method forEach
@@ -6386,7 +6983,7 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Alias for mapProperty
+    Alias for `mapProperty`
 
     @method getEach
     @param {String} key name of the property
@@ -6399,8 +6996,8 @@ Ember.Enumerable = Ember.Mixin.create(
   /**
     Sets the value on the named property for each member. This is more
     efficient than using other methods defined on this helper. If the object
-    implements Ember.Observable, the value will be changed to set(), otherwise
-    it will be set directly. null objects are skipped.
+    implements Ember.Observable, the value will be changed to `set(),` otherwise
+    it will be set directly. `null` objects are skipped.
 
     @method setEach
     @param {String} key The key to set
@@ -6415,21 +7012,23 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Maps all of the items in the enumeration to another value, returning
-    a new array. This method corresponds to map() defined in JavaScript 1.6.
+    a new array. This method corresponds to `map()` defined in JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-        function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
     It should return the mapped value.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     @method map
@@ -6461,22 +7060,25 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Returns an array with all of the items in the enumeration that the passed
-    function returns true for. This method corresponds to filter() defined in
+    function returns true for. This method corresponds to `filter()` defined in
     JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
-    It should return the true to include the item in the results, false otherwise.
+    It should return the `true` to include the item in the results, `false`
+    otherwise.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     @method filter
@@ -6493,9 +7095,9 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns an array with just the items with the matched property.  You
-    can pass an optional second argument with the target value.  Otherwise
-    this will match any property that evaluates to true.
+    Returns an array with just the items with the matched property. You
+    can pass an optional second argument with the target value. Otherwise
+    this will match any property that evaluates to `true`.
 
     @method filterProperty
     @param {String} key the property to test
@@ -6508,28 +7110,31 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Returns the first item in the array for which the callback returns true.
-    This method works similar to the filter() method defined in JavaScript 1.6
+    This method works similar to the `filter()` method defined in JavaScript 1.6
     except that it will stop working on the array once a match is found.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
-    It should return the true to include the item in the results, false otherwise.
+    It should return the `true` to include the item in the results, `false`
+    otherwise.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     @method find
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
-    @return {Object} Found item or null.
+    @return {Object} Found item or `null`.
   */
   find: function(callback, target) {
     var len = get(this, 'length') ;
@@ -6548,43 +7153,47 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns the first item with a property matching the passed value.  You
-    can pass an optional second argument with the target value.  Otherwise
-    this will match any property that evaluates to true.
+    Returns the first item with a property matching the passed value. You
+    can pass an optional second argument with the target value. Otherwise
+    this will match any property that evaluates to `true`.
 
-    This method works much like the more generic find() method.
+    This method works much like the more generic `find()` method.
 
     @method findProperty
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
-    @return {Object} found item or null
+    @return {Object} found item or `null`
   */
   findProperty: function(key, value) {
     return this.find(iter.apply(this, arguments));
   },
 
   /**
-    Returns true if the passed function returns true for every item in the
-    enumeration. This corresponds with the every() method in JavaScript 1.6.
+    Returns `true` if the passed function returns true for every item in the
+    enumeration. This corresponds with the `every()` method in JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
-    It should return the true or false.
+    It should return the `true` or `false`.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     Example Usage:
 
-          if (people.every(isEngineer)) { Paychecks.addBigBonus(); }
+    ```javascript
+    if (people.every(isEngineer)) { Paychecks.addBigBonus(); }
+    ```
 
     @method every
     @param {Function} callback The callback to execute
@@ -6598,13 +7207,13 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns true if the passed property resolves to true for all items in the
-    enumerable.  This method is often simpler/faster than using a callback.
+    Returns `true` if the passed property resolves to `true` for all items in
+    the enumerable. This method is often simpler/faster than using a callback.
 
     @method everyProperty
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
-    @return {Array} filtered array
+    @return {Boolean}
   */
   everyProperty: function(key, value) {
     return this.every(iter.apply(this, arguments));
@@ -6612,27 +7221,32 @@ Ember.Enumerable = Ember.Mixin.create(
 
 
   /**
-    Returns true if the passed function returns true for any item in the
-    enumeration. This corresponds with the every() method in JavaScript 1.6.
+    Returns `true` if the passed function returns true for any item in the
+    enumeration. This corresponds with the `every()` method in JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
-    It should return the true to include the item in the results, false otherwise.
+    It should return the `true` to include the item in the results, `false`
+    otherwise.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     Usage Example:
 
-          if (people.some(isManager)) { Paychecks.addBiggerBonus(); }
+    ```javascript
+    if (people.some(isManager)) { Paychecks.addBiggerBonus(); }
+    ```
 
     @method some
     @param {Function} callback The callback to execute
@@ -6646,13 +7260,13 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns true if the passed property resolves to true for any item in the
-    enumerable.  This method is often simpler/faster than using a callback.
+    Returns `true` if the passed property resolves to `true` for any item in
+    the enumerable. This method is often simpler/faster than using a callback.
 
     @method someProperty
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
-    @return {Boolean} true
+    @return {Boolean} `true`
   */
   someProperty: function(key, value) {
     return this.some(iter.apply(this, arguments));
@@ -6661,21 +7275,23 @@ Ember.Enumerable = Ember.Mixin.create(
   /**
     This will combine the values of the enumerator into a single value. It
     is a useful way to collect a summary value from an enumeration. This
-    corresponds to the reduce() method defined in JavaScript 1.8.
+    corresponds to the `reduce()` method defined in JavaScript 1.8.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(previousValue, item, index, enumerable);
+    ```javascript
+    function(previousValue, item, index, enumerable);
+    ```
 
-    - *previousValue* is the value returned by the last call to the iterator.
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `previousValue` is the value returned by the last call to the iterator.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
     Return the new cumulative value.
 
-    In addition to the callback you can also pass an initialValue. An error
+    In addition to the callback you can also pass an `initialValue`. An error
     will be raised if you do not pass an initial value and the enumerator is
     empty.
 
@@ -6703,7 +7319,7 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Invokes the named method on every object in the receiver that
-    implements it.  This method corresponds to the implementation in
+    implements it. This method corresponds to the implementation in
     Prototype 1.6.
 
     @method invoke
@@ -6726,8 +7342,8 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Simply converts the enumerable into a genuine array.  The order is not
-    guaranteed.  Corresponds to the method implemented by Prototype.
+    Simply converts the enumerable into a genuine array. The order is not
+    guaranteed. Corresponds to the method implemented by Prototype.
 
     @method toArray
     @return {Array} the enumerable as an array.
@@ -6741,8 +7357,10 @@ Ember.Enumerable = Ember.Mixin.create(
   /**
     Returns a copy of the array with all null elements removed.
 
-        var arr = ["a", null, "c", null];
-        arr.compact(); => ["a", "c"]
+    ```javascript
+    var arr = ["a", null, "c", null];
+    arr.compact();  // ["a", "c"]
+    ```
 
     @method compact
     @return {Array} the array without null elements.
@@ -6750,12 +7368,14 @@ Ember.Enumerable = Ember.Mixin.create(
   compact: function() { return this.without(null); },
 
   /**
-    Returns a new enumerable that excludes the passed value.  The default
+    Returns a new enumerable that excludes the passed value. The default
     implementation returns an array regardless of the receiver type unless
     the receiver does not contain the value.
 
-        var arr = ["a", "b", "a", "c"];
-        arr.without("a"); => ["b", "c"]
+    ```javascript
+    var arr = ["a", "b", "a", "c"];
+    arr.without("a");  // ["b", "c"]
+    ```
 
     @method without
     @param {Object} value
@@ -6771,11 +7391,13 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns a new enumerable that contains only unique values.  The default
+    Returns a new enumerable that contains only unique values. The default
     implementation returns an array regardless of the receiver type.
 
-        var arr = ["a", "a", "b", "b"];
-        arr.uniq(); => ["a", "b"]
+    ```javascript
+    var arr = ["a", "a", "b", "b"];
+    arr.uniq();  // ["a", "b"]
+    ```
 
     @method uniq
     @return {Ember.Enumerable}
@@ -6793,7 +7415,7 @@ Ember.Enumerable = Ember.Mixin.create(
     You can observe this property to be notified of changes to the enumerables
     content.
 
-    For plain enumerables, this property is read only.  Ember.Array overrides
+    For plain enumerables, this property is read only. `Ember.Array` overrides
     this method.
 
     @property []
@@ -6801,14 +7423,14 @@ Ember.Enumerable = Ember.Mixin.create(
   */
   '[]': Ember.computed(function(key, value) {
     return this;
-  }).property().cacheable(),
+  }).property(),
 
   // ..........................................................
   // ENUMERABLE OBSERVERS
   //
 
   /**
-    Registers an enumerable observer.   Must implement Ember.EnumerableObserver
+    Registers an enumerable observer. Must implement `Ember.EnumerableObserver`
     mixin.
 
     @method addEnumerableObserver
@@ -6855,12 +7477,12 @@ Ember.Enumerable = Ember.Mixin.create(
   */
   hasEnumerableObservers: Ember.computed(function() {
     return Ember.hasListeners(this, '@enumerable:change') || Ember.hasListeners(this, '@enumerable:before');
-  }).property().cacheable(),
+  }).property(),
 
 
   /**
     Invoke this method just before the contents of your enumerable will
-    change.  You can either omit the parameters completely or pass the objects
+    change. You can either omit the parameters completely or pass the objects
     to be removed or added if available or just a count.
 
     @method enumerableContentWillChange
@@ -6896,7 +7518,7 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Invoke this method when the contents of your enumerable has changed.
-    This will notify any observers watching for content changes.  If your are
+    This will notify any observers watching for content changes. If your are
     implementing an ordered enumerable (such as an array), also pass the
     start and end values where the content changed so that it can be used to
     notify range observers.
@@ -6935,9 +7557,6 @@ Ember.Enumerable = Ember.Mixin.create(
 
 }) ;
 
-
-
-
 })();
 
 
@@ -6960,12 +7579,12 @@ function none(obj) { return obj===null || obj===undefined; }
 // ARRAY
 //
 /**
-  This module implements Observer-friendly Array-like behavior.  This mixin is
+  This module implements Observer-friendly Array-like behavior. This mixin is
   picked up by the Array class as well as other controllers, etc. that want to
   appear to be arrays.
 
-  Unlike Ember.Enumerable, this mixin defines methods specifically for
-  collections that provide index-ordered access to their contents.  When you
+  Unlike `Ember.Enumerable,` this mixin defines methods specifically for
+  collections that provide index-ordered access to their contents. When you
   are designing code that needs to accept any kind of Array-like object, you
   should use these methods instead of Array primitives because these will
   properly notify observers of changes to the array.
@@ -6976,15 +7595,15 @@ function none(obj) { return obj===null || obj===undefined; }
   as controllers and collections.
 
   You can use the methods defined in this module to access and modify array
-  contents in a KVO-friendly way.  You can also be notified whenever the
+  contents in a KVO-friendly way. You can also be notified whenever the
   membership if an array changes by changing the syntax of the property to
-  .observes('*myProperty.[]') .
+  `.observes('*myProperty.[]')`.
 
-  To support Ember.Array in your own class, you must override two
-  primitives to use it: replace() and objectAt().
+  To support `Ember.Array` in your own class, you must override two
+  primitives to use it: `replace()` and `objectAt()`.
 
-  Note that the Ember.Array mixin also incorporates the Ember.Enumerable mixin.  All
-  Ember.Array-like objects are also enumerable.
+  Note that the Ember.Array mixin also incorporates the `Ember.Enumerable`
+  mixin. All `Ember.Array`-like objects are also enumerable.
 
   @class Array
   @namespace Ember
@@ -6998,7 +7617,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   isSCArray: true,
 
   /**
-    Your array must support the length property. Your replace methods should
+    Your array must support the `length` property. Your replace methods should
     set this property whenever it changes.
 
     @property {Number} length
@@ -7006,24 +7625,25 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   length: Ember.required(),
 
   /**
-    Returns the object at the given index. If the given index is negative or
-    is greater or equal than the array length, returns `undefined`.
+    Returns the object at the given `index`. If the given `index` is negative
+    or is greater or equal than the array length, returns `undefined`.
 
     This is one of the primitives you must implement to support `Ember.Array`.
     If your object supports retrieving the value of an array item using `get()`
     (i.e. `myArray.get(0)`), then you do not need to implement this method
     yourself.
 
-        var arr = ['a', 'b', 'c', 'd'];
-        arr.objectAt(0);  => "a"
-        arr.objectAt(3);  => "d"
-        arr.objectAt(-1); => undefined
-        arr.objectAt(4);  => undefined
-        arr.objectAt(5);  => undefined
+    ```javascript
+    var arr = ['a', 'b', 'c', 'd'];
+    arr.objectAt(0);   // "a"
+    arr.objectAt(3);   // "d"
+    arr.objectAt(-1);  // undefined
+    arr.objectAt(4);   // undefined
+    arr.objectAt(5);   // undefined
+    ```
 
     @method objectAt
-    @param {Number} idx
-      The index of the item to return.
+    @param {Number} idx The index of the item to return.
   */
   objectAt: function(idx) {
     if ((idx < 0) || (idx>=get(this, 'length'))) return undefined ;
@@ -7033,13 +7653,14 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   /**
     This returns the objects at the specified indexes, using `objectAt`.
 
-        var arr = ['a', 'b', 'c', 'd'];
-        arr.objectsAt([0, 1, 2]) => ["a", "b", "c"]
-        arr.objectsAt([2, 3, 4]) => ["c", "d", undefined]
+    ```javascript
+    var arr = ['a', 'b', 'c', 'd'];
+    arr.objectsAt([0, 1, 2]);  // ["a", "b", "c"]
+    arr.objectsAt([2, 3, 4]);  // ["c", "d", undefined]
+    ```
 
     @method objectsAt
-    @param {Array} indexes
-      An array of indexes of items to return.
+    @param {Array} indexes An array of indexes of items to return.
    */
   objectsAt: function(indexes) {
     var self = this;
@@ -7052,26 +7673,26 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   },
 
   /**
-    This is the handler for the special array content property.  If you get
-    this property, it will return this.  If you set this property it a new
+    This is the handler for the special array content property. If you get
+    this property, it will return this. If you set this property it a new
     array, it will replace the current content.
 
-    This property overrides the default property defined in Ember.Enumerable.
+    This property overrides the default property defined in `Ember.Enumerable`.
 
     @property []
   */
   '[]': Ember.computed(function(key, value) {
     if (value !== undefined) this.replace(0, get(this, 'length'), value) ;
     return this ;
-  }).property().cacheable(),
+  }).property(),
 
   firstObject: Ember.computed(function() {
     return this.objectAt(0);
-  }).property().cacheable(),
+  }).property(),
 
   lastObject: Ember.computed(function() {
     return this.objectAt(get(this, 'length')-1);
-  }).property().cacheable(),
+  }).property(),
 
   // optimized version from Enumerable
   contains: function(obj){
@@ -7084,10 +7705,12 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
     uses the observable array methods to retrieve the objects for the new
     slice.
 
-        var arr = ['red', 'green', 'blue'];
-        arr.slice(0);      => ['red', 'green', 'blue']
-        arr.slice(0, 2);   => ['red', 'green']
-        arr.slice(1, 100); => ['green', 'blue']
+    ```javascript
+    var arr = ['red', 'green', 'blue'];
+    arr.slice(0);       // ['red', 'green', 'blue']
+    arr.slice(0, 2);    // ['red', 'green']
+    arr.slice(1, 100);  // ['green', 'blue']
+    ```
 
     @method slice
     @param beginIndex {Integer} (Optional) index to begin slicing from.
@@ -7107,17 +7730,19 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
 
   /**
     Returns the index of the given object's first occurrence.
-    If no startAt argument is given, the starting location to
+    If no `startAt` argument is given, the starting location to
     search is 0. If it's negative, will count backward from
     the end of the array. Returns -1 if no match is found.
 
-        var arr = ["a", "b", "c", "d", "a"];
-        arr.indexOf("a");      =>  0
-        arr.indexOf("z");      => -1
-        arr.indexOf("a", 2);   =>  4
-        arr.indexOf("a", -1);  =>  4
-        arr.indexOf("b", 3);   => -1
-        arr.indexOf("a", 100); => -1
+    ```javascript
+    var arr = ["a", "b", "c", "d", "a"];
+    arr.indexOf("a");       //  0
+    arr.indexOf("z");       // -1
+    arr.indexOf("a", 2);    //  4
+    arr.indexOf("a", -1);   //  4
+    arr.indexOf("b", 3);    // -1
+    arr.indexOf("a", 100);  // -1
+    ```javascript
 
     @method indexOf
     @param {Object} object the item to search for
@@ -7138,17 +7763,19 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
 
   /**
     Returns the index of the given object's last occurrence.
-    If no startAt argument is given, the search starts from
+    If no `startAt` argument is given, the search starts from
     the last position. If it's negative, will count backward
     from the end of the array. Returns -1 if no match is found.
 
-        var arr = ["a", "b", "c", "d", "a"];
-        arr.lastIndexOf("a");      =>  4
-        arr.lastIndexOf("z");      => -1
-        arr.lastIndexOf("a", 2);   =>  0
-        arr.lastIndexOf("a", -1);  =>  4
-        arr.lastIndexOf("b", 3);   =>  1
-        arr.lastIndexOf("a", 100); =>  4
+    ```javascript
+    var arr = ["a", "b", "c", "d", "a"];
+    arr.lastIndexOf("a");       //  4
+    arr.lastIndexOf("z");       // -1
+    arr.lastIndexOf("a", 2);    //  0
+    arr.lastIndexOf("a", -1);   //  4
+    arr.lastIndexOf("b", 3);    //  1
+    arr.lastIndexOf("a", 100);  //  4
+    ```
 
     @method lastIndexOf
     @param {Object} object the item to search for
@@ -7172,7 +7799,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   //
 
   /**
-    Adds an array observer to the receiving array.  The array observer object
+    Adds an array observer to the receiving array. The array observer object
     normally must implement two methods:
 
     * `arrayWillChange(start, removeCount, addCount)` - This method will be
@@ -7181,7 +7808,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
       called just after the array is modified.
 
     Both callbacks will be passed the starting index of the change as well a
-    a count of the items to be removed and added.  You can use these callbacks
+    a count of the items to be removed and added. You can use these callbacks
     to optionally inspect the array during the change, clear caches, or do
     any other bookkeeping necessary.
 
@@ -7192,7 +7819,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
     @method addArrayObserver
     @param {Object} target The observer object.
     @param {Hash} opts Optional hash of configuration options including
-      willChange, didChange, and a context option.
+      `willChange`, `didChange`, and a `context` option.
     @return {Ember.Array} receiver
   */
   addArrayObserver: function(target, opts) {
@@ -7209,7 +7836,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
 
   /**
     Removes an array observer from the object if the observer is current
-    registered.  Calling this method multiple times with the same object will
+    registered. Calling this method multiple times with the same object will
     have no effect.
 
     @method removeArrayObserver
@@ -7236,18 +7863,20 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   */
   hasArrayObservers: Ember.computed(function() {
     return Ember.hasListeners(this, '@array:change') || Ember.hasListeners(this, '@array:before');
-  }).property().cacheable(),
+  }).property(),
 
   /**
-    If you are implementing an object that supports Ember.Array, call this
+    If you are implementing an object that supports `Ember.Array`, call this
     method just before the array content changes to notify any observers and
-    invalidate any related properties.  Pass the starting index of the change
+    invalidate any related properties. Pass the starting index of the change
     as well as a delta of the amounts to change.
 
     @method arrayContentWillChange
     @param {Number} startIdx The starting index in the array that will change.
-    @param {Number} removeAmt The number of items that will be removed.  If you pass null assumes 0
-    @param {Number} addAmt The number of items that will be added.  If you pass null assumes 0.
+    @param {Number} removeAmt The number of items that will be removed. If you 
+      pass `null` assumes 0
+    @param {Number} addAmt The number of items that will be added  If you 
+      pass `null` assumes 0.
     @return {Ember.Array} receiver
   */
   arrayContentWillChange: function(startIdx, removeAmt, addAmt) {
@@ -7324,7 +7953,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
 
   /**
     Returns a special object that can be used to observe individual properties
-    on the array.  Just get an equivalent property on this object and it will
+    on the array. Just get an equivalent property on this object and it will
     return an enumerable that maps automatically to the named key on the
     member objects.
 
@@ -7333,7 +7962,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   '@each': Ember.computed(function() {
     if (!this.__each) this.__each = new Ember.EachProxy(this);
     return this.__each;
-  }).property().cacheable()
+  }).property()
 
 }) ;
 
@@ -7352,7 +7981,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   Implements some standard methods for comparing objects. Add this mixin to
   any class you create that can compare its instances.
 
-  You should implement the compare() method.
+  You should implement the `compare()` method.
 
   @class Comparable
   @namespace Ember
@@ -7374,9 +8003,9 @@ Ember.Comparable = Ember.Mixin.create( /** @scope Ember.Comparable.prototype */{
     Override to return the result of the comparison of the two parameters. The
     compare method should return:
 
-      - `-1` if `a < b`
-      - `0` if `a == b`
-      - `1` if `a > b`
+    - `-1` if `a < b`
+    - `0` if `a == b`
+    - `1` if `a > b`
 
     Default implementation raises an exception.
 
@@ -7405,14 +8034,15 @@ Ember.Comparable = Ember.Mixin.create( /** @scope Ember.Comparable.prototype */{
 var get = Ember.get, set = Ember.set;
 
 /**
-  Implements some standard methods for copying an object.  Add this mixin to
-  any object you create that can create a copy of itself.  This mixin is
+  Implements some standard methods for copying an object. Add this mixin to
+  any object you create that can create a copy of itself. This mixin is
   added automatically to the built-in array.
 
-  You should generally implement the copy() method to return a copy of the
+  You should generally implement the `copy()` method to return a copy of the
   receiver.
 
-  Note that frozenCopy() will only work if you also implement Ember.Freezable.
+  Note that `frozenCopy()` will only work if you also implement
+  `Ember.Freezable`.
 
   @class Copyable
   @namespace Ember
@@ -7423,18 +8053,18 @@ Ember.Copyable = Ember.Mixin.create(
 /** @scope Ember.Copyable.prototype */ {
 
   /**
-    Override to return a copy of the receiver.  Default implementation raises
+    Override to return a copy of the receiver. Default implementation raises
     an exception.
 
     @method copy
-    @param deep {Boolean} if true, a deep copy of the object should be made
+    @param deep {Boolean} if `true`, a deep copy of the object should be made
     @return {Object} copy of receiver
   */
   copy: Ember.required(Function),
 
   /**
-    If the object implements Ember.Freezable, then this will return a new copy
-    if the object is not frozen and the receiver if the object is frozen.
+    If the object implements `Ember.Freezable`, then this will return a new
+    copy if the object is not frozen and the receiver if the object is frozen.
 
     Raises an exception if you try to call this method on a object that does
     not support freezing.
@@ -7455,9 +8085,6 @@ Ember.Copyable = Ember.Mixin.create(
   }
 });
 
-
-
-
 })();
 
 
@@ -7472,8 +8099,8 @@ Ember.Copyable = Ember.Mixin.create(
 var get = Ember.get, set = Ember.set;
 
 /**
-  The Ember.Freezable mixin implements some basic methods for marking an object
-  as frozen. Once an object is frozen it should be read only. No changes
+  The `Ember.Freezable` mixin implements some basic methods for marking an
+  object as frozen. Once an object is frozen it should be read only. No changes
   may be made the internal state of the object.
 
   ## Enforcement
@@ -7481,47 +8108,47 @@ var get = Ember.get, set = Ember.set;
   To fully support freezing in your subclass, you must include this mixin and
   override any method that might alter any property on the object to instead
   raise an exception. You can check the state of an object by checking the
-  isFrozen property.
+  `isFrozen` property.
 
   Although future versions of JavaScript may support language-level freezing
   object objects, that is not the case today. Even if an object is freezable,
   it is still technically possible to modify the object, even though it could
   break other parts of your application that do not expect a frozen object to
   change. It is, therefore, very important that you always respect the
-  isFrozen property on all freezable objects.
+  `isFrozen` property on all freezable objects.
 
   ## Example Usage
 
-  The example below shows a simple object that implement the Ember.Freezable
+  The example below shows a simple object that implement the `Ember.Freezable`
   protocol.
 
-        Contact = Ember.Object.extend(Ember.Freezable, {
+  ```javascript
+  Contact = Ember.Object.extend(Ember.Freezable, {
+    firstName: null,
+    lastName: null,
 
-          firstName: null,
+    // swaps the names
+    swapNames: function() {
+      if (this.get('isFrozen')) throw Ember.FROZEN_ERROR;
+      var tmp = this.get('firstName');
+      this.set('firstName', this.get('lastName'));
+      this.set('lastName', tmp);
+      return this;
+    }
 
-          lastName: null,
+  });
 
-          // swaps the names
-          swapNames: function() {
-            if (this.get('isFrozen')) throw Ember.FROZEN_ERROR;
-            var tmp = this.get('firstName');
-            this.set('firstName', this.get('lastName'));
-            this.set('lastName', tmp);
-            return this;
-          }
-
-        });
-
-        c = Context.create({ firstName: "John", lastName: "Doe" });
-        c.swapNames();  => returns c
-        c.freeze();
-        c.swapNames();  => EXCEPTION
+  c = Context.create({ firstName: "John", lastName: "Doe" });
+  c.swapNames();  // returns c
+  c.freeze();
+  c.swapNames();  // EXCEPTION
+  ```
 
   ## Copying
 
-  Usually the Ember.Freezable protocol is implemented in cooperation with the
-  Ember.Copyable protocol, which defines a frozenCopy() method that will return
-  a frozen object, if the object implements this method as well.
+  Usually the `Ember.Freezable` protocol is implemented in cooperation with the
+  `Ember.Copyable` protocol, which defines a `frozenCopy()` method that will
+  return a frozen object, if the object implements this method as well.
 
   @class Freezable
   @namespace Ember
@@ -7532,8 +8159,8 @@ Ember.Freezable = Ember.Mixin.create(
 /** @scope Ember.Freezable.prototype */ {
 
   /**
-    Set to true when the object is frozen.  Use this property to detect whether
-    your object is frozen or not.
+    Set to `true` when the object is frozen. Use this property to detect
+    whether your object is frozen or not.
 
     @property isFrozen
     @type Boolean
@@ -7541,7 +8168,7 @@ Ember.Freezable = Ember.Mixin.create(
   isFrozen: false,
 
   /**
-    Freezes the object.  Once this method has been called the object should
+    Freezes the object. Once this method has been called the object should
     no longer allow any properties to be edited.
 
     @method freeze
@@ -7570,7 +8197,7 @@ Ember.FROZEN_ERROR = "Frozen object cannot be modified.";
 var forEach = Ember.EnumerableUtils.forEach;
 
 /**
-  This mixin defines the API for modifying generic enumerables.  These methods
+  This mixin defines the API for modifying generic enumerables. These methods
   can be applied to an object regardless of whether it is ordered or
   unordered.
 
@@ -7580,24 +8207,28 @@ var forEach = Ember.EnumerableUtils.forEach;
 
   ## Adding Objects
 
-  To add an object to an enumerable, use the addObject() method.  This
+  To add an object to an enumerable, use the `addObject()` method. This
   method will only add the object to the enumerable if the object is not
   already present and the object if of a type supported by the enumerable.
 
-      set.addObject(contact);
+  ```javascript
+  set.addObject(contact);
+  ```
 
   ## Removing Objects
 
-  To remove an object form an enumerable, use the removeObject() method.  This
+  To remove an object form an enumerable, use the `removeObject()` method. This
   will only remove the object if it is already in the enumerable, otherwise
   this method has no effect.
 
-      set.removeObject(contact);
+  ```javascript
+  set.removeObject(contact);
+  ```
 
   ## Implementing In Your Own Code
 
   If you are implementing an object and want to support this API, just include
-  this mixin in your class and implement the required methods.  In your unit
+  this mixin in your class and implement the required methods. In your unit
   tests, be sure to apply the Ember.MutableEnumerableTests to your object.
 
   @class MutableEnumerable
@@ -7642,7 +8273,7 @@ Ember.MutableEnumerable = Ember.Mixin.create(Ember.Enumerable,
     __Required.__ You must implement this method to apply this mixin.
 
     Attempts to remove the passed object from the receiver collection if the
-    object is in present in the collection.  If the object is not present,
+    object is in present in the collection. If the object is not present,
     this method has no effect.
 
     If the passed object is of a type not supported by the receiver
@@ -7694,7 +8325,7 @@ var EMPTY = [];
 var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
 
 /**
-  This mixin defines the API for modifying array-like objects.  These methods
+  This mixin defines the API for modifying array-like objects. These methods
   can be applied only to a collection that keeps its items in an ordered set.
 
   Note that an Array can change even if it does not implement this mixin.
@@ -7713,17 +8344,17 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   /**
     __Required.__ You must implement this method to apply this mixin.
 
-    This is one of the primitives you must implement to support Ember.Array.  You
-    should replace amt objects started at idx with the objects in the passed
-    array.  You should also call this.enumerableContentDidChange() ;
+    This is one of the primitives you must implement to support `Ember.Array`.
+    You should replace amt objects started at idx with the objects in the
+    passed array. You should also call `this.enumerableContentDidChange()`
 
     @method replace
-    @param {Number} idx Starting index in the array to replace.  If idx >= length,
-      then append to the end of the array.
-    @param {Number} amt Number of elements that should be removed from the array,
-      starting at *idx*.
-    @param {Array} objects An array of zero or more objects that should be inserted
-      into the array at *idx*
+    @param {Number} idx Starting index in the array to replace. If 
+      idx >= length, then append to the end of the array.
+    @param {Number} amt Number of elements that should be removed from 
+      the array, starting at *idx*.
+    @param {Array} objects An array of zero or more objects that should be 
+      inserted into the array at *idx*
   */
   replace: Ember.required(),
 
@@ -7731,13 +8362,15 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
     Remove all elements from self. This is useful if you
     want to reuse an existing array without having to recreate it.
 
-        var colors = ["red", "green", "blue"];
-        color.length();  => 3
-        colors.clear();  => []
-        colors.length(); => 0
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    color.length();   //  3
+    colors.clear();   //  []
+    colors.length();  //  0
+    ```
 
     @method clear
-    @return {Ember.Array} An empty Array. 
+    @return {Ember.Array} An empty Array.
   */
   clear: function () {
     var len = get(this, 'length');
@@ -7747,12 +8380,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    This will use the primitive replace() method to insert an object at the
+    This will use the primitive `replace()` method to insert an object at the
     specified index.
 
-        var colors = ["red", "green", "blue"];
-        colors.insertAt(2, "yellow"); => ["red", "green", "yellow", "blue"]
-        colors.insertAt(5, "orange"); => Error: Index out of range
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.insertAt(2, "yellow");  // ["red", "green", "yellow", "blue"]
+    colors.insertAt(5, "orange");  // Error: Index out of range
+    ```javascript
 
     @method insertAt
     @param {Number} idx index of insert the object at.
@@ -7765,16 +8400,18 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Remove an object at the specified index using the replace() primitive
-    method.  You can pass either a single index, or a start and a length.
+    Remove an object at the specified index using the `replace()` primitive
+    method. You can pass either a single index, or a start and a length.
 
     If you pass a start and length that is beyond the
-    length this method will throw an Ember.OUT_OF_RANGE_EXCEPTION
+    length this method will throw an `Ember.OUT_OF_RANGE_EXCEPTION`
 
-        var colors = ["red", "green", "blue", "yellow", "orange"];
-        colors.removeAt(0); => ["green", "blue", "yellow", "orange"]
-        colors.removeAt(2, 2); => ["green", "blue"]
-        colors.removeAt(4, 2); => Error: Index out of range
+    ```javascript
+    var colors = ["red", "green", "blue", "yellow", "orange"];
+    colors.removeAt(0);     // ["green", "blue", "yellow", "orange"]
+    colors.removeAt(2, 2);  // ["green", "blue"]
+    colors.removeAt(4, 2);  // Error: Index out of range
+    ```
 
     @method removeAt
     @param {Number} start index, start of range
@@ -7797,12 +8434,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Push the object onto the end of the array.  Works just like push() but it
+    Push the object onto the end of the array. Works just like `push()` but it
     is KVO-compliant.
 
-        var colors = ["red", "green", "blue"];
-        colors.pushObject("black"); => ["red", "green", "blue", "black"]
-        colors.pushObject(["yellow", "orange"]); => ["red", "green", "blue", "black", ["yellow", "orange"]]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.pushObject("black");               // ["red", "green", "blue", "black"]
+    colors.pushObject(["yellow", "orange"]);  // ["red", "green", "blue", "black", ["yellow", "orange"]]
+    ```
 
     @method pushObject
     @param {anything} obj object to push
@@ -7813,12 +8452,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Add the objects in the passed numerable to the end of the array.  Defers
+    Add the objects in the passed numerable to the end of the array. Defers
     notifying observers of the change until all objects are added.
 
-        var colors = ["red", "green", "blue"];
-        colors.pushObjects("black"); => ["red", "green", "blue", "black"]
-        colors.pushObjects(["yellow", "orange"]); => ["red", "green", "blue", "black", "yellow", "orange"]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.pushObjects("black");               // ["red", "green", "blue", "black"]
+    colors.pushObjects(["yellow", "orange"]);  // ["red", "green", "blue", "black", "yellow", "orange"]
+    ```
 
     @method pushObjects
     @param {Ember.Enumerable} objects the objects to add
@@ -7830,12 +8471,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Pop object from array or nil if none are left.  Works just like pop() but
+    Pop object from array or nil if none are left. Works just like `pop()` but
     it is KVO-compliant.
 
-        var colors = ["red", "green", "blue"];
-        colors.popObject(); => "blue"
-        console.log(colors); => ["red", "green"]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.popObject();   // "blue"
+    console.log(colors);  // ["red", "green"]
+    ```
 
     @method popObject
     @return object
@@ -7850,12 +8493,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Shift an object from start of array or nil if none are left.  Works just
-    like shift() but it is KVO-compliant.
+    Shift an object from start of array or nil if none are left. Works just
+    like `shift()` but it is KVO-compliant.
 
-        var colors = ["red", "green", "blue"];
-        colors.shiftObject(); => "red"
-        console.log(colors); => ["green", "blue"]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.shiftObject();  // "red"
+    console.log(colors);   // ["green", "blue"]
+    ```
 
     @method shiftObject
     @return object
@@ -7868,12 +8513,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Unshift an object to start of array.  Works just like unshift() but it is
+    Unshift an object to start of array. Works just like `unshift()` but it is
     KVO-compliant.
 
-        var colors = ["red", "green", "blue"];
-        colors.unshiftObject("yellow"); => ["yellow", "red", "green", "blue"]
-        colors.unshiftObject(["black", "white"]); => [["black", "white"], "yellow", "red", "green", "blue"]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.unshiftObject("yellow");             // ["yellow", "red", "green", "blue"]
+    colors.unshiftObject(["black", "white"]);   // [["black", "white"], "yellow", "red", "green", "blue"]
+    ```
 
     @method unshiftObject
     @param {anything} obj object to unshift
@@ -7884,12 +8531,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Adds the named objects to the beginning of the array.  Defers notifying
+    Adds the named objects to the beginning of the array. Defers notifying
     observers until all objects have been added.
 
-        var colors = ["red", "green", "blue"];
-        colors.unshiftObjects(["black", "white"]); => ["black", "white", "red", "green", "blue"]
-        colors.unshiftObjects("yellow"); => Type Error: 'undefined' is not a function
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.unshiftObjects(["black", "white"]);   // ["black", "white", "red", "green", "blue"]
+    colors.unshiftObjects("yellow");             // Type Error: 'undefined' is not a function
+    ```
 
     @method unshiftObjects
     @param {Ember.Enumerable} objects the objects to add
@@ -7901,7 +8550,7 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Reverse objects in the array.  Works just like reverse() but it is
+    Reverse objects in the array. Works just like `reverse()` but it is
     KVO-compliant.
 
     @method reverseObjects
@@ -7919,9 +8568,11 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
     Replace all the the receiver's content with content of the argument.
     If argument is an empty array receiver will be cleared.
 
-        var colors = ["red", "green", "blue"];
-        colors.setObjects(["black", "white"]); => ["black", "white"]
-        colors.setObjects([]); => []
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.setObjects(["black", "white"]);  // ["black", "white"]
+    colors.setObjects([]);                  // []
+    ```
 
     @method setObjects
     @param {Ember.Array} objects array whose content will be used for replacing
@@ -7981,14 +8632,14 @@ var get = Ember.get, set = Ember.set, defineProperty = Ember.defineProperty;
   application.
 
   Any object that has this mixin applied can be used in observer
-  operations. That includes Ember.Object and most objects you will
+  operations. That includes `Ember.Object` and most objects you will
   interact with as you write your Ember application.
 
   Note that you will not generally apply this mixin to classes yourself,
   but you will use the features provided by this module frequently, so it
   is important to understand how to use it.
 
-  ## Using get() and set()
+  ## Using `get()` and `set()`
 
   Because of Ember's support for bindings and observers, you will always
   access properties using the get method, and set properties using the
@@ -8003,21 +8654,25 @@ var get = Ember.get, set = Ember.set, defineProperty = Ember.defineProperty;
   call to the end of your method declarations in classes that you write.
   For example:
 
-      Ember.Object.create({
-        valueObserver: function() {
-          // Executes whenever the "value" property changes
-        }.observes('value')
-      });
+  ```javascript
+  Ember.Object.create({
+    valueObserver: function() {
+      // Executes whenever the "value" property changes
+    }.observes('value')
+  });
+  ```
 
   Although this is the most common way to add an observer, this capability
-  is actually built into the Ember.Object class on top of two methods
+  is actually built into the `Ember.Object` class on top of two methods
   defined in this mixin: `addObserver` and `removeObserver`. You can use
   these two methods to add and remove observers yourself if you need to
   do so at runtime.
 
   To add an observer for a property, call:
 
-      object.addObserver('propertyKey', targetObject, targetAction)
+  ```javascript
+  object.addObserver('propertyKey', targetObject, targetAction)
+  ```
 
   This will call the `targetAction` method on the `targetObject` to be called
   whenever the value of the `propertyKey` changes.
@@ -8039,7 +8694,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   /**
     Retrieves the value of a property from the object.
 
-    This method is usually similar to using object[keyName] or object.keyName,
+    This method is usually similar to using `object[keyName]` or `object.keyName`,
     however it supports both computed properties and the unknownProperty
     handler.
 
@@ -8052,9 +8707,11 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     Computed properties are methods defined with the `property` modifier
     declared at the end, such as:
 
-          fullName: function() {
-            return this.getEach('firstName', 'lastName').compact().join(' ');
-          }.property('firstName', 'lastName')
+    ```javascript
+    fullName: function() {
+      return this.getEach('firstName', 'lastName').compact().join(' ');
+    }.property('firstName', 'lastName')
+    ```
 
     When you call `get` on a computed property, the function will be
     called and the return value will be returned instead of the function
@@ -8063,8 +8720,8 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     ### Unknown Properties
 
     Likewise, if you try to call `get` on a property whose value is
-    undefined, the unknownProperty() method will be called on the object.
-    If this method returns any value other than undefined, it will be returned
+    `undefined`, the `unknownProperty()` method will be called on the object.
+    If this method returns any value other than `undefined`, it will be returned
     instead. This allows you to implement "virtual" properties that are
     not defined upfront.
 
@@ -8077,14 +8734,18 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   },
 
   /**
-    To get multiple properties at once, call getProperties
+    To get multiple properties at once, call `getProperties`
     with a list of strings or an array:
 
-          record.getProperties('firstName', 'lastName', 'zipCode'); // => { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    ```javascript
+    record.getProperties('firstName', 'lastName', 'zipCode');  // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    ```
 
-   is equivalent to:
+    is equivalent to:
 
-          record.getProperties(['firstName', 'lastName', 'zipCode']); // => { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    ```javascript
+    record.getProperties(['firstName', 'lastName', 'zipCode']);  // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    ```
 
     @method getProperties
     @param {String...|Array} list of keys to get
@@ -8105,14 +8766,14 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   /**
     Sets the provided key or path to the value.
 
-    This method is generally very similar to calling object[key] = value or
-    object.key = value, except that it provides support for computed
-    properties, the unknownProperty() method and property observers.
+    This method is generally very similar to calling `object[key] = value` or
+    `object.key = value`, except that it provides support for computed
+    properties, the `unknownProperty()` method and property observers.
 
     ### Computed Properties
 
     If you try to set a value on a key that has a computed property handler
-    defined (see the get() method for an example), then set() will call
+    defined (see the `get()` method for an example), then `set()` will call
     that method, passing both the value and key instead of simply changing
     the value itself. This is useful for those times when you need to
     implement a property that is composed of one or more member
@@ -8121,31 +8782,33 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     ### Unknown Properties
 
     If you try to set a value on a key that is undefined in the target
-    object, then the unknownProperty() handler will be called instead. This
+    object, then the `unknownProperty()` handler will be called instead. This
     gives you an opportunity to implement complex "virtual" properties that
-    are not predefined on the object. If unknownProperty() returns
-    undefined, then set() will simply set the value on the object.
+    are not predefined on the object. If `unknownProperty()` returns
+    undefined, then `set()` will simply set the value on the object.
 
     ### Property Observers
 
-    In addition to changing the property, set() will also register a
-    property change with the object. Unless you have placed this call
-    inside of a beginPropertyChanges() and endPropertyChanges(), any "local"
-    observers (i.e. observer methods declared on the same object), will be
-    called immediately. Any "remote" observers (i.e. observer methods
-    declared on another object) will be placed in a queue and called at a
-    later time in a coalesced manner.
+    In addition to changing the property, `set()` will also register a property
+    change with the object. Unless you have placed this call inside of a
+    `beginPropertyChanges()` and `endPropertyChanges(),` any "local" observers
+    (i.e. observer methods declared on the same object), will be called
+    immediately. Any "remote" observers (i.e. observer methods declared on
+    another object) will be placed in a queue and called at a later time in a
+    coalesced manner.
 
     ### Chaining
 
-    In addition to property changes, set() returns the value of the object
+    In addition to property changes, `set()` returns the value of the object
     itself so you can do chaining like this:
 
-          record.set('firstName', 'Charles').set('lastName', 'Jolley');
+    ```javascript
+    record.set('firstName', 'Charles').set('lastName', 'Jolley');
+    ```
 
     @method set
     @param {String} key The property to set
-    @param {Object} value The value to set or null.
+    @param {Object} value The value to set or `null`.
     @return {Ember.Observable}
   */
   set: function(keyName, value) {
@@ -8154,10 +8817,12 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   },
 
   /**
-    To set multiple properties at once, call setProperties
+    To set multiple properties at once, call `setProperties`
     with a Hash:
 
-          record.setProperties({ firstName: 'Charles', lastName: 'Jolley' });
+    ```javascript
+    record.setProperties({ firstName: 'Charles', lastName: 'Jolley' });
+    ```
 
     @method setProperties
     @param {Hash} hash the hash of keys and values to set
@@ -8174,8 +8839,9 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     will not be sent until the changes are finished. If you plan to make a
     large number of changes to an object at one time, you should call this
     method at the beginning of the changes to begin deferring change
-    notifications. When you are done making changes, call endPropertyChanges()
-    to deliver the deferred change notifications and end deferring.
+    notifications. When you are done making changes, call
+    `endPropertyChanges()` to deliver the deferred change notifications and end
+    deferring.
 
     @method beginPropertyChanges
     @return {Ember.Observable}
@@ -8191,7 +8857,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     You can use this method to group property changes so that notifications
     will not be sent until the changes are finished. If you plan to make a
     large number of changes to an object at one time, you should call
-    beginPropertyChanges() at the beginning of the changes to defer change
+    `beginPropertyChanges()` at the beginning of the changes to defer change
     notifications. When you are done making changes, call this method to
     deliver the deferred change notifications and end deferring.
 
@@ -8207,14 +8873,15 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     Notify the observer system that a property is about to change.
 
     Sometimes you need to change a value directly or indirectly without
-    actually calling get() or set() on it. In this case, you can use this
-    method and propertyDidChange() instead. Calling these two methods
+    actually calling `get()` or `set()` on it. In this case, you can use this
+    method and `propertyDidChange()` instead. Calling these two methods
     together will notify all observers that the property has potentially
     changed value.
 
-    Note that you must always call propertyWillChange and propertyDidChange as
-    a pair. If you do not, it may get the property change groups out of order
-    and cause notifications to be delivered more often than you would like.
+    Note that you must always call `propertyWillChange` and `propertyDidChange`
+    as a pair. If you do not, it may get the property change groups out of
+    order and cause notifications to be delivered more often than you would
+    like.
 
     @method propertyWillChange
     @param {String} key The property key that is about to change.
@@ -8229,14 +8896,15 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     Notify the observer system that a property has just changed.
 
     Sometimes you need to change a value directly or indirectly without
-    actually calling get() or set() on it. In this case, you can use this
-    method and propertyWillChange() instead. Calling these two methods
+    actually calling `get()` or `set()` on it. In this case, you can use this
+    method and `propertyWillChange()` instead. Calling these two methods
     together will notify all observers that the property has potentially
     changed value.
 
-    Note that you must always call propertyWillChange and propertyDidChange as
-    a pair. If you do not, it may get the property change groups out of order
-    and cause notifications to be delivered more often than you would like.
+    Note that you must always call `propertyWillChange` and `propertyDidChange`
+    as a pair. If you do not, it may get the property change groups out of
+    order and cause notifications to be delivered more often than you would
+    like.
 
     @method propertyDidChange
     @param {String} keyName The property key that has just changed.
@@ -8284,19 +8952,23 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     ### Observer Methods
 
     Observer methods you pass should generally have the following signature if
-    you do not pass a "context" parameter:
+    you do not pass a `context` parameter:
 
-          fooDidChange: function(sender, key, value, rev);
+    ```javascript
+    fooDidChange: function(sender, key, value, rev) { };
+    ```
 
     The sender is the object that changed. The key is the property that
     changes. The value property is currently reserved and unused. The rev
     is the last property revision of the object when it changed, which you can
     use to detect if the key value has really changed or not.
 
-    If you pass a "context" parameter, the context will be passed before the
+    If you pass a `context` parameter, the context will be passed before the
     revision like so:
 
-          fooDidChange: function(sender, key, value, context, rev);
+    ```javascript
+    fooDidChange: function(sender, key, value, context, rev) { };
+    ```
 
     Usually you will not need the value, context or revision parameters at
     the end. In this case, it is common to write observer methods that take
@@ -8315,7 +8987,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
 
   /**
     Remove an observer you have previously registered on this object. Pass
-    the same key, target, and method you passed to addObserver() and your
+    the same key, target, and method you passed to `addObserver()` and your
     target will no longer receive notifications.
 
     @method removeObserver
@@ -8329,7 +9001,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   },
 
   /**
-    Returns true if the object currently has observers registered for a
+    Returns `true` if the object currently has observers registered for a
     particular key. You can use this method to potentially defer performing
     an expensive action until someone begins observing a particular property
     on the object.
@@ -8340,33 +9012,6 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   */
   hasObserverFor: function(key) {
     return Ember.hasListeners(this, key+':change');
-  },
-
-  /**
-    This method will be called when a client attempts to get the value of a
-    property that has not been defined in one of the typical ways. Override
-    this method to create "virtual" properties.
-
-    @method unknownProperty
-    @param {String} key The name of the unknown property that was requested.
-    @return {Object} The property value or undefined. Default is undefined.
-  */
-  unknownProperty: function(key) {
-    return undefined;
-  },
-
-  /**
-    This method will be called when a client attempts to set the value of a
-    property that has not been defined in one of the typical ways. Override
-    this method to create "virtual" properties.
-
-    @method setUnknownProperty
-    @param {String} key The name of the unknown property to be set.
-    @param {Object} value The value the unknown property is to be set to.
-  */
-  setUnknownProperty: function(key, value) {
-    defineProperty(this, key);
-    set(this, key, value);
   },
 
   /**
@@ -8384,7 +9029,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     @deprecated
     @method setPath
     @param {String} path The path to the property that will be set
-    @param {Object} value The value to set or null.
+    @param {Object} value The value to set or `null`.
     @return {Ember.Observable}
   */
   setPath: function(path, value) {
@@ -8393,10 +9038,12 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   },
 
   /**
-    Retrieves the value of a property, or a default value in the case that the property
-    returns undefined.
+    Retrieves the value of a property, or a default value in the case that the
+    property returns `undefined`.
 
-        person.getWithDefault('lastName', 'Doe');
+    ```javascript
+    person.getWithDefault('lastName', 'Doe');
+    ```
 
     @method getWithDefault
     @param {String} keyName The name of the property to retrieve
@@ -8410,8 +9057,10 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   /**
     Set the value of a property to the current value plus some amount.
 
-        person.incrementProperty('age');
-        team.incrementProperty('score', 2);
+    ```javascript
+    person.incrementProperty('age');
+    team.incrementProperty('score', 2);
+    ```
 
     @method incrementProperty
     @param {String} keyName The name of the property to increment
@@ -8427,8 +9076,10 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   /**
     Set the value of a property to the current value minus some amount.
 
-        player.decrementProperty('lives');
-        orc.decrementProperty('health', 5);
+    ```javascript
+    player.decrementProperty('lives');
+    orc.decrementProperty('health', 5);
+    ```
 
     @method decrementProperty
     @param {String} keyName The name of the property to decrement
@@ -8445,7 +9096,9 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     Set the value of a boolean property to the opposite of it's
     current value.
 
-        starship.toggleProperty('warpDriveEnaged');
+    ```javascript
+    starship.toggleProperty('warpDriveEnaged');
+    ```
 
     @method toggleProperty
     @param {String} keyName The name of the property to toggle
@@ -8503,12 +9156,12 @@ Ember.TargetActionSupport = Ember.Mixin.create({
 
     if (Ember.typeOf(target) === "string") {
       var value = get(this, target);
-      if (value === undefined) { value = get(window, target); }
+      if (value === undefined) { value = get(Ember.lookup, target); }
       return value;
     } else {
       return target;
     }
-  }).property('target').cacheable(),
+  }).property('target'),
 
   triggerAction: function() {
     var action = get(this, 'action'),
@@ -8545,37 +9198,97 @@ Ember.TargetActionSupport = Ember.Mixin.create({
 */
 
 /**
+  This mixin allows for Ember objects to subscribe to and emit events.
+
+  ```javascript
+  App.Person = Ember.Object.extend(Ember.Evented, {
+    greet: function() {
+      // ...
+      this.trigger('greet');
+    }
+  });
+
+  var person = App.Person.create();
+
+  person.on('greet', function() {
+    console.log('Our person has greeted');
+  });
+
+  person.greet();
+
+  // outputs: 'Our person has greeted'
+  ```
+
   @class Evented
   @namespace Ember
   @extends Ember.Mixin
  */
 Ember.Evented = Ember.Mixin.create({
+
+  /**
+   Subscribes to a named event with given function.
+
+   ```javascript
+   person.on('didLoad', function() {
+     // fired once the person has loaded
+   });
+   ```
+
+   An optional target can be passed in as the 2nd argument that will
+   be set as the "this" for the callback. This is a good way to give your
+   function access to the object triggering the event. When the target
+   parameter is used the callback becomes the third argument.
+
+   @method on
+   @param {String} name The name of the event
+   @param {Object} [target] The "this" binding for the callback
+   @param {Function} method The callback to execute
+  */
   on: function(name, target, method) {
     Ember.addListener(this, name, target, method);
   },
 
+  /**
+    Subscribes a function to a named event and then cancels the subscription
+    after the first time the event is triggered. It is good to use ``one`` when
+    you only care about the first time an event has taken place.
+
+    This function takes an optional 2nd argument that will become the "this"
+    value for the callback. If this argument is passed then the 3rd argument
+    becomes the function.
+
+    @method one
+    @param {String} name The name of the event
+    @param {Object} [target] The "this" binding for the callback
+    @param {Function} method The callback to execute
+  */
   one: function(name, target, method) {
     if (!method) {
       method = target;
       target = null;
     }
 
-    var self = this;
-    var wrapped = function() {
-      Ember.removeListener(self, name, target, wrapped);
-
-      if ('string' === typeof method) { method = this[method]; }
-
-      // Internally, a `null` target means that the target is
-      // the first parameter to addListener. That means that
-      // the `this` passed into this function is the target
-      // determined by the event system.
-      method.apply(this, arguments);
-    };
-
-    this.on(name, target, wrapped);
+    Ember.addListener(this, name, target, method, true);
   },
 
+  /**
+    Triggers a named event for the object. Any additional arguments
+    will be passed as parameters to the functions that are subscribed to the
+    event.
+
+    ```javascript
+    person.on('didEat', food) {
+      console.log('person ate some ' + food);
+    });
+
+    person.trigger('didEat', 'broccoli');
+
+    // outputs: person ate some broccoli
+    ```
+    @method trigger
+    @param {String} name The name of the event
+    @param {Object...} args Optional arguments to pass on
+  */
   trigger: function(name) {
     var args = [], i, l;
     for (i = 1, l = arguments.length; i < l; i++) {
@@ -8589,13 +9302,84 @@ Ember.Evented = Ember.Mixin.create({
     this.trigger.apply(this, arguments);
   },
 
+  /**
+    Cancels subscription for give name, target, and method.
+
+    @method off
+    @param {String} name The name of the event
+    @param {Object} target The target of the subscription
+    @param {Function} method The function of the subscription
+  */
   off: function(name, target, method) {
     Ember.removeListener(this, name, target, method);
   },
 
+  /**
+    Checks to see if object has any subscriptions for named event.
+
+    @method has
+    @param {String} name The name of the event
+    @return {Boolean} does the object have a subscription for event
+   */
   has: function(name) {
     return Ember.hasListeners(this, name);
   }
+});
+
+})();
+
+
+
+(function() {
+var RSVP = requireModule("rsvp");
+
+/**
+@module ember
+@submodule ember-runtime
+*/
+
+var get = Ember.get,
+    slice = Array.prototype.slice;
+
+/**
+  @class Deferred
+  @namespace Ember
+  @extends Ember.Mixin
+ */
+Ember.Deferred = Ember.Mixin.create({
+
+  /**
+    Add handlers to be called when the Deferred object is resolved or rejected.
+
+    @method then
+    @param {Function} doneCallback a callback function to be called when done
+    @param {Function} failCallback a callback function to be called when failed
+  */
+  then: function(doneCallback, failCallback) {
+    return get(this, 'promise').then(doneCallback, failCallback);
+  },
+
+  /**
+    Resolve a Deferred object and call any `doneCallbacks` with the given args.
+
+    @method resolve
+  */
+  resolve: function(value) {
+    get(this, 'promise').resolve(value);
+  },
+
+  /**
+    Reject a Deferred object and call any `failCallbacks` with the given args.
+
+    @method reject
+  */
+  reject: function(value) {
+    get(this, 'promise').reject(value);
+  },
+
+  promise: Ember.computed(function() {
+    return new RSVP.Promise();
+  })
 });
 
 })();
@@ -8615,8 +9399,8 @@ Ember.Evented = Ember.Mixin.create({
 */
 
 
-// NOTE: this object should never be included directly.  Instead use Ember.
-// Ember.Object.  We only define this separately so that Ember.Set can depend on it
+// NOTE: this object should never be included directly. Instead use Ember.
+// Ember.Object. We only define this separately so that Ember.Set can depend on it
 
 
 var set = Ember.set, get = Ember.get,
@@ -8635,7 +9419,8 @@ var set = Ember.set, get = Ember.get,
     applyMixin = Mixin._apply,
     finishPartial = Mixin.finishPartial,
     reopen = Mixin.prototype.reopen,
-    classToString = Mixin.prototype.toString;
+    classToString = Mixin.prototype.toString,
+    MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
 
 var undefinedDescriptor = {
   configurable: true,
@@ -8647,10 +9432,10 @@ var undefinedDescriptor = {
 function makeCtor() {
 
   // Note: avoid accessing any properties on the object since it makes the
-  // method a lot faster.  This is glue code so we want it to be as fast as
+  // method a lot faster. This is glue code so we want it to be as fast as
   // possible.
 
-  var wasApplied = false, initMixins;
+  var wasApplied = false, initMixins, initProperties;
 
   var Class = function() {
     if (!wasApplied) {
@@ -8661,8 +9446,69 @@ function makeCtor() {
     var m = meta(this);
     m.proto = this;
     if (initMixins) {
-      this.reopen.apply(this, initMixins);
+      // capture locally so we can clear the closed over variable
+      var mixins = initMixins;
       initMixins = null;
+      this.reopen.apply(this, mixins);
+    }
+    if (initProperties) {
+      // capture locally so we can clear the closed over variable
+      var props = initProperties;
+      initProperties = null;
+
+      var concatenatedProperties = this.concatenatedProperties;
+
+      for (var i = 0, l = props.length; i < l; i++) {
+        var properties = props[i];
+        for (var keyName in properties) {
+          if (!properties.hasOwnProperty(keyName)) { continue; }
+
+          var value = properties[keyName],
+              IS_BINDING = Ember.IS_BINDING;
+
+          if (IS_BINDING.test(keyName)) {
+            var bindings = m.bindings;
+            if (!bindings) {
+              bindings = m.bindings = { __emberproto__: this };
+            } else if (bindings.__emberproto__ !== this) {
+              bindings = m.bindings = o_create(m.bindings);
+              bindings.__emberproto__ = this;
+            }
+            bindings[keyName] = value;
+          }
+
+          var desc = m.descs[keyName];
+
+          Ember.assert("Ember.Object.create no longer supports defining computed properties.", !(value instanceof Ember.ComputedProperty));
+          Ember.assert("Ember.Object.create no longer supports defining methods that call _super.", !(typeof value === 'function' && value.toString().indexOf('_super') !== -1));
+
+          if (concatenatedProperties && concatenatedProperties.indexOf(keyName) >= 0) {
+            var baseValue = this[keyName];
+
+            if (baseValue) {
+              if ('function' === typeof baseValue.concat) {
+                value = baseValue.concat(value);
+              } else {
+                value = Ember.makeArray(baseValue).concat(value);
+              }
+            } else {
+              value = Ember.makeArray(value);
+            }
+          }
+
+          if (desc) {
+            desc.set(this, keyName, value);
+          } else {
+            if (typeof this.setUnknownProperty === 'function' && !(keyName in this)) {
+              this.setUnknownProperty(keyName, value);
+            } else if (MANDATORY_SETTER) {
+              Ember.defineProperty(this, keyName, null, value); // setup mandatory setter
+            } else {
+              this[keyName] = value;
+            }
+          }
+        }
+      }
     }
     finishPartial(this, m);
     delete m.proto;
@@ -8679,6 +9525,7 @@ function makeCtor() {
     wasApplied = false;
   };
   Class._initMixins = function(args) { initMixins = args; };
+  Class._initProperties = function(args) { initProperties = args; };
 
   Class.proto = function() {
     var superclass = Class.superclass;
@@ -8723,7 +9570,7 @@ CoreObject.PrototypeMixin = Mixin.create({
   isDestroying: false,
 
   /**
-    Destroys an object by setting the isDestroyed flag and removing its
+    Destroys an object by setting the `isDestroyed` flag and removing its
     metadata, which effectively destroys observers and bindings.
 
     If you try to set a property on a destroyed object, an exception will be
@@ -8766,8 +9613,40 @@ CoreObject.PrototypeMixin = Mixin.create({
     return from;
   },
 
+  /**
+    Returns a string representation which attempts to provide more information
+    than Javascript's `toString` typically does, in a generic way for all Ember
+    objects.
+
+        App.Person = Em.Object.extend()
+        person = App.Person.create()
+        person.toString() //=> "<App.Person:ember1024>"
+
+    If the object's class is not defined on an Ember namespace, it will
+    indicate it is a subclass of the registered superclass:
+
+        Student = App.Person.extend()
+        student = Student.create()
+        student.toString() //=> "<(subclass of App.Person):ember1025>"
+
+    If the method `toStringExtension` is defined, its return value will be
+    included in the output.
+
+        App.Teacher = App.Person.extend({
+          toStringExtension: function(){
+            return @get('fullName');
+          }
+        });
+        teacher = App.Teacher.create()
+        teacher.toString(); // #=> "<App.Teacher:ember1026:Tom Dale>"
+
+    @method toString
+    @return {String} string representation
+  */
   toString: function() {
-    return '<'+this.constructor.toString()+':'+guidFor(this)+'>';
+    var hasToStringExtension = Ember.typeOf(this.toStringExtension) === 'function',
+        extension = hasToStringExtension ? ":" + this.toStringExtension() : '';
+    return '<'+this.constructor.toString()+':'+guidFor(this)+extension+'>';
   }
 });
 
@@ -8809,9 +9688,15 @@ var ClassMixin = Mixin.create({
     return Class;
   },
 
-  create: function() {
+  createWithMixins: function() {
     var C = this;
     if (arguments.length>0) { this._initMixins(arguments); }
+    return new C();
+  },
+
+  create: function() {
+    var C = this;
+    if (arguments.length>0) { this._initProperties(arguments); }
     return new C();
   },
 
@@ -8842,21 +9727,25 @@ var ClassMixin = Mixin.create({
 
   /**
     In some cases, you may want to annotate computed properties with additional
-    metadata about how they function or what values they operate on. For example,
-    computed property functions may close over variables that are then no longer
-    available for introspection.
+    metadata about how they function or what values they operate on. For
+    example, computed property functions may close over variables that are then
+    no longer available for introspection.
 
     You can pass a hash of these values to a computed property like this:
 
-        person: function() {
-          var personId = this.get('personId');
-          return App.Person.create({ id: personId });
-        }.property().meta({ type: App.Person })
+    ```javascript
+    person: function() {
+      var personId = this.get('personId');
+      return App.Person.create({ id: personId });
+    }.property().meta({ type: App.Person })
+    ```
 
     Once you've done this, you can retrieve the values saved to the computed
     property from your class like this:
 
-        MyClass.metaForProperty('person');
+    ```javascript
+    MyClass.metaForProperty('person');
+    ```
 
     This will return the original hash that was passed to `meta()`.
 
@@ -8926,10 +9815,10 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
 /**
   An unordered collection of objects.
 
-  A Set works a bit like an array except that its items are not ordered.
-  You can create a set to efficiently test for membership for an object. You
-  can also iterate through a set just like an array, even accessing objects
-  by index, however there is no guarantee as to their order.
+  A Set works a bit like an array except that its items are not ordered. You
+  can create a set to efficiently test for membership for an object. You can
+  also iterate through a set just like an array, even accessing objects by
+  index, however there is no guarantee as to their order.
 
   All Sets are observable via the Enumerable Observer API - which works
   on any enumerable object including both Sets and Arrays.
@@ -8937,25 +9826,26 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
   ## Creating a Set
 
   You can create a set like you would most objects using
-  `new Ember.Set()`.  Most new sets you create will be empty, but you can
+  `new Ember.Set()`. Most new sets you create will be empty, but you can
   also initialize the set with some content by passing an array or other
   enumerable of objects to the constructor.
 
   Finally, you can pass in an existing set and the set will be copied. You
   can also create a copy of a set by calling `Ember.Set#copy()`.
 
-      #js
-      // creates a new empty set
-      var foundNames = new Ember.Set();
+  ```javascript
+  // creates a new empty set
+  var foundNames = new Ember.Set();
 
-      // creates a set with four names in it.
-      var names = new Ember.Set(["Charles", "Tom", "Juan", "Alex"]); // :P
+  // creates a set with four names in it.
+  var names = new Ember.Set(["Charles", "Tom", "Juan", "Alex"]); // :P
 
-      // creates a copy of the names set.
-      var namesCopy = new Ember.Set(names);
+  // creates a copy of the names set.
+  var namesCopy = new Ember.Set(names);
 
-      // same as above.
-      var anotherNamesCopy = names.copy();
+  // same as above.
+  var anotherNamesCopy = names.copy();
+  ```
 
   ## Adding/Removing Objects
 
@@ -8969,8 +9859,8 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
   remove the object the first time and have no effect on future calls until
   you add the object to the set again.
 
-  NOTE: You cannot add/remove null or undefined to a set. Any attempt to do so
-  will be ignored.
+  NOTE: You cannot add/remove `null` or `undefined` to a set. Any attempt to do
+  so will be ignored.
 
   In addition to add/remove you can also call `push()`/`pop()`. Push behaves
   just like `add()` but `pop()`, unlike `remove()` will pick an arbitrary
@@ -8985,9 +9875,9 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
   ## Observing changes
 
   When using `Ember.Set`, you can observe the `"[]"` property to be
-  alerted whenever the content changes.  You can also add an enumerable
+  alerted whenever the content changes. You can also add an enumerable
   observer to the set to be notified of specific objects that are added and
-  removed from the set.  See `Ember.Enumerable` for more information on
+  removed from the set. See `Ember.Enumerable` for more information on
   enumerables.
 
   This is often unhelpful. If you are filtering sets of objects, for instance,
@@ -8998,16 +9888,16 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
 
   ## Other Methods
 
-  `Ember.Set` primary implements other mixin APIs.  For a complete reference
+  `Ember.Set` primary implements other mixin APIs. For a complete reference
   on the methods you will use with `Ember.Set`, please consult these mixins.
   The most useful ones will be `Ember.Enumerable` and
   `Ember.MutableEnumerable` which implement most of the common iterator
   methods you are used to on Array.
 
   Note that you can also use the `Ember.Copyable` and `Ember.Freezable`
-  APIs on `Ember.Set` as well.  Once a set is frozen it can no longer be
-  modified.  The benefit of this is that when you call frozenCopy() on it,
-  Ember will avoid making copies of the set.  This allows you to write
+  APIs on `Ember.Set` as well. Once a set is frozen it can no longer be
+  modified. The benefit of this is that when you call `frozenCopy()` on it,
+  Ember will avoid making copies of the set. This allows you to write
   code that can know with certainty when the underlying set data will or
   will not be modified.
 
@@ -9039,10 +9929,12 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
     Clears the set. This is useful if you want to reuse an existing set
     without having to recreate it.
 
-        var colors = new Ember.Set(["red", "green", "blue"]);
-        colors.length;  => 3
-        colors.clear();
-        colors.length;  => 0
+    ```javascript
+    var colors = new Ember.Set(["red", "green", "blue"]);
+    colors.length;  // 3
+    colors.clear();
+    colors.length;  // 0
+    ```
 
     @method clear
     @return {Ember.Set} An empty Set
@@ -9078,10 +9970,13 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
     Returns true if the passed object is also an enumerable that contains the
     same objects as the receiver.
 
-        var colors = ["red", "green", "blue"],
-            same_colors = new Ember.Set(colors);
-        same_colors.isEqual(colors); => true
-        same_colors.isEqual(["purple", "brown"]); => false
+    ```javascript
+    var colors = ["red", "green", "blue"],
+        same_colors = new Ember.Set(colors);
+
+    same_colors.isEqual(colors);               // true
+    same_colors.isEqual(["purple", "brown"]);  // false
+    ```
 
     @method isEqual
     @param {Ember.Set} obj the other object.
@@ -9102,18 +9997,20 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   },
 
   /**
-    Adds an object to the set. Only non-null objects can be added to a set
+    Adds an object to the set. Only non-`null` objects can be added to a set
     and those can only be added once. If the object is already in the set or
     the passed value is null this method will have no effect.
 
     This is an alias for `Ember.MutableEnumerable.addObject()`.
 
-        var colors = new Ember.Set();
-        colors.add("blue");    => ["blue"]
-        colors.add("blue");    => ["blue"]
-        colors.add("red");     => ["blue", "red"]
-        colors.add(null);      => ["blue", "red"]
-        colors.add(undefined); => ["blue", "red"]
+    ```javascript
+    var colors = new Ember.Set();
+    colors.add("blue");     // ["blue"]
+    colors.add("blue");     // ["blue"]
+    colors.add("red");      // ["blue", "red"]
+    colors.add(null);       // ["blue", "red"]
+    colors.add(undefined);  // ["blue", "red"]
+    ```
 
     @method add
     @param {Object} obj The object to add.
@@ -9122,14 +10019,16 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   add: Ember.alias('addObject'),
 
   /**
-    Removes the object from the set if it is found.  If you pass a null value
+    Removes the object from the set if it is found. If you pass a `null` value
     or an object that is already not in the set, this method will have no
     effect. This is an alias for `Ember.MutableEnumerable.removeObject()`.
 
-        var colors = new Ember.Set(["red", "green", "blue"]);
-        colors.remove("red");    => ["blue", "green"]
-        colors.remove("purple"); => ["blue", "green"]
-        colors.remove(null);     => ["blue", "green"]
+    ```javascript
+    var colors = new Ember.Set(["red", "green", "blue"]);
+    colors.remove("red");     // ["blue", "green"]
+    colors.remove("purple");  // ["blue", "green"]
+    colors.remove(null);      // ["blue", "green"]
+    ```
 
     @method remove
     @param {Object} obj The object to remove
@@ -9138,12 +10037,14 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   remove: Ember.alias('removeObject'),
 
   /**
-    Removes the last element from the set and returns it, or null if it's empty.
+    Removes the last element from the set and returns it, or `null` if it's empty.
 
-        var colors = new Ember.Set(["green", "blue"]);
-        colors.pop(); => "blue"
-        colors.pop(); => "green"
-        colors.pop(); => null
+    ```javascript
+    var colors = new Ember.Set(["green", "blue"]);
+    colors.pop();  // "blue"
+    colors.pop();  // "green"
+    colors.pop();  // null
+    ```
 
     @method pop
     @return {Object} The removed object from the set or null.
@@ -9161,10 +10062,12 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
 
     This is an alias for `Ember.MutableEnumerable.addObject()`.
 
-        var colors = new Ember.Set();
-        colors.push("red");   => ["red"]
-        colors.push("green"); => ["red", "green"]
-        colors.push("blue");  => ["red", "green", "blue"]
+    ```javascript
+    var colors = new Ember.Set();
+    colors.push("red");   // ["red"]
+    colors.push("green"); // ["red", "green"]
+    colors.push("blue");  // ["red", "green", "blue"]
+    ```
 
     @method push
     @return {Ember.Set} The set itself.
@@ -9172,14 +10075,16 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   push: Ember.alias('addObject'),
 
   /**
-    Removes the last element from the set and returns it, or null if it's empty.
+    Removes the last element from the set and returns it, or `null` if it's empty.
 
     This is an alias for `Ember.Set.pop()`.
 
-        var colors = new Ember.Set(["green", "blue"]);
-        colors.shift(); => "blue"
-        colors.shift(); => "green"
-        colors.shift(); => null
+    ```javascript
+    var colors = new Ember.Set(["green", "blue"]);
+    colors.shift();  // "blue"
+    colors.shift();  // "green"
+    colors.shift();  // null
+    ```
 
     @method shift
     @return {Object} The removed object from the set or null.
@@ -9192,10 +10097,12 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
 
     This is an alias of `Ember.Set.push()`
 
-        var colors = new Ember.Set();
-        colors.unshift("red");   => ["red"]
-        colors.unshift("green"); => ["red", "green"]
-        colors.unshift("blue");  => ["red", "green", "blue"]
+    ```javascript
+    var colors = new Ember.Set();
+    colors.unshift("red");    // ["red"]
+    colors.unshift("green");  // ["red", "green"]
+    colors.unshift("blue");   // ["red", "green", "blue"]
+    ```
 
     @method unshift
     @return {Ember.Set} The set itself.
@@ -9207,8 +10114,8 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
 
     This is an alias of `Ember.MutableEnumerable.addObjects()`
 
-        var colors = new Ember.Set();
-        colors.addEach(["red", "green", "blue"]); => ["red", "green", "blue"]
+    var colors = new Ember.Set();
+    colors.addEach(["red", "green", "blue"]);  // ["red", "green", "blue"]
 
     @method addEach
     @param {Ember.Enumerable} objects the objects to add.
@@ -9221,8 +10128,10 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
 
     This is an alias of `Ember.MutableEnumerable.removeObjects()`
 
-        var colors = new Ember.Set(["red", "green", "blue"]);
-        colors.removeEach(["red", "blue"]); => ["green"]
+    ```javascript
+    var colors = new Ember.Set(["red", "green", "blue"]);
+    colors.removeEach(["red", "blue"]);  //  ["green"]
+    ```
 
     @method removeEach
     @param {Ember.Enumerable} objects the objects to remove.
@@ -9247,12 +10156,12 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   // more optimized version
   firstObject: Ember.computed(function() {
     return this.length > 0 ? this[0] : undefined;
-  }).property().cacheable(),
+  }).property(),
 
   // more optimized version
   lastObject: Ember.computed(function() {
     return this.length > 0 ? this[this.length-1] : undefined;
-  }).property().cacheable(),
+  }).property(),
 
   // implements Ember.MutableEnumerable
   addObject: function(obj) {
@@ -9382,14 +10291,16 @@ var indexOf = Ember.ArrayPolyfills.indexOf;
 
 /**
   A Namespace is an object usually used to contain other objects or methods
-  such as an application or framework.  Create a namespace anytime you want
+  such as an application or framework. Create a namespace anytime you want
   to define one of these new containers.
 
   # Example Usage
 
-      MyFramework = Ember.Namespace.create({
-        VERSION: '1.0.0'
-      });
+  ```javascript
+  MyFramework = Ember.Namespace.create({
+    VERSION: '1.0.0'
+  });
+  ```
 
   @class Namespace
   @namespace Ember
@@ -9410,7 +10321,7 @@ Ember.Namespace = Ember.Object.extend({
 
   destroy: function() {
     var namespaces = Ember.Namespace.NAMESPACES;
-    window[this.toString()] = undefined;
+    Ember.lookup[this.toString()] = undefined;
     namespaces.splice(indexOf.call(namespaces, this), 1);
     this._super();
   }
@@ -9430,24 +10341,26 @@ Ember.Namespace.PROCESSED = false;
 */
 
 /**
-  Defines a namespace that will contain an executable application.  This is
+  Defines a namespace that will contain an executable application. This is
   very similar to a normal namespace except that it is expected to include at
   least a 'ready' function which can be run to initialize the application.
 
-  Currently Ember.Application is very similar to Ember.Namespace.  However, this
-  class may be augmented by additional frameworks so it is important to use
-  this instance when building new applications.
+  Currently `Ember.Application` is very similar to `Ember.Namespace.`  However,
+  this class may be augmented by additional frameworks so it is important to
+  use this instance when building new applications.
 
   # Example Usage
 
-      MyApp = Ember.Application.create({
-        VERSION: '1.0.0',
-        store: Ember.Store.create().from(Ember.fixtures)
-      });
+  ```javascript
+  MyApp = Ember.Application.create({
+    VERSION: '1.0.0',
+    store: Ember.Store.create().from(Ember.fixtures)
+  });
 
-      MyApp.ready = function() {
-        //..init code goes here...
-      }
+  MyApp.ready = function() {
+    //..init code goes here...
+  }
+  ```
 
   @class Application
   @namespace Ember
@@ -9470,32 +10383,37 @@ Ember.Application = Ember.Namespace.extend();
 var get = Ember.get, set = Ember.set;
 
 /**
-  An ArrayProxy wraps any other object that implements Ember.Array and/or
-  Ember.MutableArray, forwarding all requests. This makes it very useful for
+  An ArrayProxy wraps any other object that implements `Ember.Array` and/or
+  `Ember.MutableArray,` forwarding all requests. This makes it very useful for
   a number of binding use cases or other cases where being able to swap
   out the underlying array is useful.
 
   A simple example of usage:
 
-      var pets = ['dog', 'cat', 'fish'];
-      var ap = Ember.ArrayProxy.create({ content: Ember.A(pets) });
-      ap.get('firstObject'); // => 'dog'
-      ap.set('content', ['amoeba', 'paramecium']);
-      ap.get('firstObject'); // => 'amoeba'
+  ```javascript
+  var pets = ['dog', 'cat', 'fish'];
+  var ap = Ember.ArrayProxy.create({ content: Ember.A(pets) });
+
+  ap.get('firstObject');                        // 'dog'
+  ap.set('content', ['amoeba', 'paramecium']);
+  ap.get('firstObject');                        // 'amoeba'
+  ```
 
   This class can also be useful as a layer to transform the contents of
   an array, as they are accessed. This can be done by overriding
   `objectAtContent`:
 
-      var pets = ['dog', 'cat', 'fish'];
-      var ap = Ember.ArrayProxy.create({
-          content: Ember.A(pets),
-          objectAtContent: function(idx) {
-              return this.get('content').objectAt(idx).toUpperCase();
-          }
-      });
-      ap.get('firstObject'); // => 'DOG'
+  ```javascript
+  var pets = ['dog', 'cat', 'fish'];
+  var ap = Ember.ArrayProxy.create({
+      content: Ember.A(pets),
+      objectAtContent: function(idx) {
+          return this.get('content').objectAt(idx).toUpperCase();
+      }
+  });
 
+  ap.get('firstObject'); // . 'DOG'
+  ```
 
   @class ArrayProxy
   @namespace Ember
@@ -9506,8 +10424,8 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
 /** @scope Ember.ArrayProxy.prototype */ {
 
   /**
-    The content array.  Must be an object that implements Ember.Array and/or
-    Ember.MutableArray.
+    The content array. Must be an object that implements `Ember.Array` and/or
+    `Ember.MutableArray.`
 
     @property content
     @type Ember.Array
@@ -9518,19 +10436,19 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
    The array that the proxy pretends to be. In the default `ArrayProxy`
    implementation, this and `content` are the same. Subclasses of `ArrayProxy`
    can override this property to provide things like sorting and filtering.
-   
+
    @property arrangedContent
   */
   arrangedContent: Ember.computed('content', function() {
     return get(this, 'content');
-  }).cacheable(),
+  }),
 
   /**
     Should actually retrieve the object at the specified index from the
     content. You can override this method in subclasses to transform the
     content item to something new.
 
-    This method will only be called if content is non-null.
+    This method will only be called if content is non-`null`.
 
     @method objectAtContent
     @param {Number} idx The index to retrieve.
@@ -9545,16 +10463,17 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
     You can override this method in subclasses to transform the content item
     into something new.
 
-    This method will only be called if content is non-null.
+    This method will only be called if content is non-`null`.
 
     @method replaceContent
     @param {Number} idx The starting index
     @param {Number} amt The number of items to remove from the content.
-    @param {Array} objects Optional array of objects to insert or null if no objects.
+    @param {Array} objects Optional array of objects to insert or null if no
+      objects.
     @return {void}
   */
   replaceContent: function(idx, amt, objects) {
-    get(this, 'arrangedContent').replace(idx, amt, objects);
+    get(this, 'content').replace(idx, amt, objects);
   },
 
   /**
@@ -9586,7 +10505,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
   /**
     @private
 
-    Invoked when the content property changes.  Notifies observers that the
+    Invoked when the content property changes. Notifies observers that the
     entire array content has changed.
 
     @method _contentDidChange
@@ -9665,9 +10584,10 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
     var arrangedContent = get(this, 'arrangedContent');
     return arrangedContent ? get(arrangedContent, 'length') : 0;
     // No dependencies since Enumerable notifies length of change
-  }).property().cacheable(),
+  }).property(),
 
   replace: function(idx, amt, objects) {
+    Ember.assert('The content property of '+ this.constructor + ' should be set before modifying it', this.get('content'));
     if (get(this, 'content')) this.replaceContent(idx, amt, objects);
     return this;
   },
@@ -9729,53 +10649,64 @@ function contentPropertyDidChange(content, contentKey) {
   `Ember.ObjectProxy` forwards all properties not defined by the proxy itself
   to a proxied `content` object.
 
-      object = Ember.Object.create({
-        name: 'Foo'
-      });
-      proxy = Ember.ObjectProxy.create({
-        content: object
-      });
+  ```javascript
+  object = Ember.Object.create({
+    name: 'Foo'
+  });
 
-      // Access and change existing properties
-      proxy.get('name') // => 'Foo'
-      proxy.set('name', 'Bar');
-      object.get('name') // => 'Bar'
+  proxy = Ember.ObjectProxy.create({
+    content: object
+  });
 
-      // Create new 'description' property on `object`
-      proxy.set('description', 'Foo is a whizboo baz');
-      object.get('description') // => 'Foo is a whizboo baz'
+  // Access and change existing properties
+  proxy.get('name')          // 'Foo'
+  proxy.set('name', 'Bar');
+  object.get('name')         // 'Bar'
 
-  While `content` is unset, setting a property to be delegated will throw an Error.
+  // Create new 'description' property on `object`
+  proxy.set('description', 'Foo is a whizboo baz');
+  object.get('description')  // 'Foo is a whizboo baz'
+  ```
 
-      proxy = Ember.ObjectProxy.create({
-        content: null,
-        flag: null
-      });
-      proxy.set('flag', true);
-      proxy.get('flag'); // => true
-      proxy.get('foo'); // => undefined
-      proxy.set('foo', 'data'); // throws Error
+  While `content` is unset, setting a property to be delegated will throw an
+  Error.
+
+  ```javascript
+  proxy = Ember.ObjectProxy.create({
+    content: null,
+    flag: null
+  });
+  proxy.set('flag', true);
+  proxy.get('flag');         // true
+  proxy.get('foo');          // undefined
+  proxy.set('foo', 'data');  // throws Error
+  ```
 
   Delegated properties can be bound to and will change when content is updated.
 
   Computed properties on the proxy itself can depend on delegated properties.
 
-      ProxyWithComputedProperty = Ember.ObjectProxy.extend({
-        fullName: function () {
-          var firstName = this.get('firstName'),
-              lastName = this.get('lastName');
-          if (firstName && lastName) {
-            return firstName + ' ' + lastName;
-          }
-          return firstName || lastName;
-        }.property('firstName', 'lastName')
-      });
-      proxy = ProxyWithComputedProperty.create();
-      proxy.get('fullName'); => undefined
-      proxy.set('content', {
-        firstName: 'Tom', lastName: 'Dale'
-      }); // triggers property change for fullName on proxy
-      proxy.get('fullName'); => 'Tom Dale'
+  ```javascript
+  ProxyWithComputedProperty = Ember.ObjectProxy.extend({
+    fullName: function () {
+      var firstName = this.get('firstName'),
+          lastName = this.get('lastName');
+      if (firstName && lastName) {
+        return firstName + ' ' + lastName;
+      }
+      return firstName || lastName;
+    }.property('firstName', 'lastName')
+  });
+
+  proxy = ProxyWithComputedProperty.create();
+
+  proxy.get('fullName');  // undefined
+  proxy.set('content', {
+    firstName: 'Tom', lastName: 'Dale'
+  }); // triggers property change for fullName on proxy
+
+  proxy.get('fullName');  // 'Tom Dale'
+  ```
 
   @class ObjectProxy
   @namespace Ember
@@ -9852,7 +10783,7 @@ var EachArray = Ember.Object.extend(Ember.Array, {
   length: Ember.computed(function() {
     var content = this._content;
     return content ? get(content, 'length') : 0;
-  }).property().cacheable()
+  }).property()
 
 });
 
@@ -9896,8 +10827,8 @@ function removeObserverForContentKey(content, keyName, proxy, idx, loc) {
 }
 
 /**
-  This is the object instance returned when you get the @each property on an
-  array.  It uses the unknownProperty handler to automatically create
+  This is the object instance returned when you get the `@each` property on an
+  array. It uses the unknownProperty handler to automatically create
   EachArray instances for property names.
 
   @private
@@ -9921,7 +10852,7 @@ Ember.EachProxy = Ember.Object.extend({
 
   /**
     You can directly access mapped properties by simply requesting them.
-    The unknownProperty handler will generate an EachArray of each item.
+    The `unknownProperty` handler will generate an EachArray of each item.
 
     @method unknownProperty
     @param keyName {String}
@@ -10042,7 +10973,7 @@ Ember.EachProxy = Ember.Object.extend({
 
 var get = Ember.get, set = Ember.set;
 
-// Add Ember.Array to Array.prototype.  Remove methods with native
+// Add Ember.Array to Array.prototype. Remove methods with native
 // implementations and supply some more optimized versions of generic methods
 // because they are so common.
 var NativeArray = Ember.Mixin.create(Ember.MutableArray, Ember.Observable, Ember.Copyable, {
@@ -10065,7 +10996,7 @@ var NativeArray = Ember.Mixin.create(Ember.MutableArray, Ember.Observable, Ember
     if (this.isFrozen) throw Ember.FROZEN_ERROR ;
 
     // if we replaced exactly the same number of items, then pass only the
-    // replaced range.  Otherwise, pass the full remaining array length
+    // replaced range. Otherwise, pass the full remaining array length
     // since everything has shifted
     var len = objects ? get(objects, 'length') : 0;
     this.arrayContentWillChange(idx, amt, len);
@@ -10119,7 +11050,11 @@ var NativeArray = Ember.Mixin.create(Ember.MutableArray, Ember.Observable, Ember
     return -1;
   },
 
-  copy: function() {
+  copy: function(deep) {
+    if (deep) {
+      return this.map(function(item){ return Ember.copy(item, true); });
+    }
+
     return this.slice();
   }
 });
@@ -10136,10 +11071,10 @@ if (ignore.length>0) {
 
 /**
   The NativeArray mixin contains the properties needed to to make the native
-  Array support Ember.MutableArray and all of its dependent APIs.  Unless you
-  have Ember.EXTEND_PROTOTYPES set to false, this will be applied automatically.
-  Otherwise you can apply the mixin at anytime by calling
-  `Ember.NativeArray.activate`.
+  Array support Ember.MutableArray and all of its dependent APIs. Unless you
+  have `Ember.EXTEND_PROTOTYPES or `Ember.EXTEND_PROTOTYPES.Array` set to
+  false, this will be applied automatically. Otherwise you can apply the mixin
+  at anytime by calling `Ember.NativeArray.activate`.
 
   @class NativeArray
   @namespace Ember
@@ -10152,7 +11087,7 @@ if (ignore.length>0) {
 Ember.NativeArray = NativeArray;
 
 /**
-  Creates an Ember.NativeArray from an Array like object.
+  Creates an `Ember.NativeArray` from an Array like object.
   Does not modify the original object.
 
   @method A
@@ -10161,11 +11096,11 @@ Ember.NativeArray = NativeArray;
 */
 Ember.A = function(arr){
   if (arr === undefined) { arr = []; }
-  return Ember.NativeArray.apply(arr);
+  return Ember.Array.detect(arr) ? arr : Ember.NativeArray.apply(arr);
 };
 
 /**
-  Activates the mixin on the Array.prototype if not already applied.  Calling
+  Activates the mixin on the Array.prototype if not already applied. Calling
   this method more than once is safe.
 
   @method activate
@@ -10179,8 +11114,9 @@ Ember.NativeArray.activate = function() {
   Ember.A = function(arr) { return arr || []; };
 };
 
-if (Ember.EXTEND_PROTOTYPES) Ember.NativeArray.activate();
-
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Array) {
+  Ember.NativeArray.activate();
+}
 
 
 })();
@@ -10307,27 +11243,30 @@ Ember.runLoadHooks = function(name, object) {
 */
 
 /**
-  Ember.ControllerMixin provides a standard interface for all classes
-  that compose Ember's controller layer: Ember.Controller, Ember.ArrayController,
-  and Ember.ObjectController.
+  `Ember.ControllerMixin` provides a standard interface for all classes that
+  compose Ember's controller layer: `Ember.Controller`,
+  `Ember.ArrayController`, and `Ember.ObjectController`.
 
-  Within an Ember.Router-managed application single shared instaces of every
+  Within an `Ember.Router`-managed application single shared instaces of every
   Controller object in your application's namespace will be added to the
-  application's Ember.Router instance. See `Ember.Application#initialize`
+  application's `Ember.Router` instance. See `Ember.Application#initialize`
   for additional information.
 
   ## Views
+
   By default a controller instance will be the rendering context
-  for its associated Ember.View. This connection is made during calls to
+  for its associated `Ember.View.` This connection is made during calls to
   `Ember.ControllerMixin#connectOutlet`.
 
-  Within the view's template, the Ember.View instance can be accessed
+  Within the view's template, the `Ember.View` instance can be accessed
   through the controller with `{{view}}`.
 
   ## Target Forwarding
-  By default a controller will target your application's Ember.Router instance.
-  Calls to `{{action}}` within the template of a controller's view are forwarded
-  to the router. See `Ember.Handlebars.helpers.action` for additional information.
+
+  By default a controller will target your application's `Ember.Router`
+  instance. Calls to `{{action}}` within the template of a controller's view
+  are forwarded to the router. See `Ember.Handlebars.helpers.action` for
+  additional information.
 
   @class ControllerMixin
   @namespace Ember
@@ -10372,27 +11311,28 @@ Ember.Controller = Ember.Object.extend(Ember.ControllerMixin);
 var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
 
 /**
-  Ember.SortableMixin provides a standard interface for array proxies
+  `Ember.SortableMixin` provides a standard interface for array proxies
   to specify a sort order and maintain this sorting when objects are added,
   removed, or updated without changing the implicit order of their underlying
   content array:
 
-      songs = [
-        {trackNumber: 4, title: 'Ob-La-Di, Ob-La-Da'},
-        {trackNumber: 2, title: 'Back in the U.S.S.R.'},
-        {trackNumber: 3, title: 'Glass Onion'},
-      ];
+  ```javascript
+  songs = [
+    {trackNumber: 4, title: 'Ob-La-Di, Ob-La-Da'},
+    {trackNumber: 2, title: 'Back in the U.S.S.R.'},
+    {trackNumber: 3, title: 'Glass Onion'},
+  ];
 
-      songsController = Ember.ArrayController.create({
-        content: songs,
-        sortProperties: ['trackNumber']
-      });
+  songsController = Ember.ArrayController.create({
+    content: songs,
+    sortProperties: ['trackNumber']
+  });
 
-      songsController.get('firstObject'); // {trackNumber: 2, title: 'Back in the U.S.S.R.'}
+  songsController.get('firstObject');  // {trackNumber: 2, title: 'Back in the U.S.S.R.'}
 
-      songsController.addObject({trackNumber: 1, title: 'Dear Prudence'});
-      songsController.get('firstObject'); // {trackNumber: 1, title: 'Dear Prudence'}
-
+  songsController.addObject({trackNumber: 1, title: 'Dear Prudence'});
+  songsController.get('firstObject');  // {trackNumber: 1, title: 'Dear Prudence'}
+  ```
 
   @class SortableMixin
   @namespace Ember
@@ -10402,16 +11342,6 @@ var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
 Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
   sortProperties: null,
   sortAscending: true,
-
-  addObject: function(obj) {
-    var content = get(this, 'content');
-    content.pushObject(obj);
-  },
-
-  removeObject: function(obj) {
-    var content = get(this, 'content');
-    content.removeObject(obj);
-  },
 
   orderBy: function(item1, item2) {
     var result = 0,
@@ -10471,7 +11401,7 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
     }
 
     return content;
-  }).cacheable(),
+  }),
 
   _contentWillChange: Ember.beforeObserver(function() {
     var content = get(this, 'content'),
@@ -10550,9 +11480,12 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
   contentItemSortPropertyDidChange: function(item) {
     var arrangedContent = get(this, 'arrangedContent'),
         oldIndex = arrangedContent.indexOf(item),
-        newIndex = this._binarySearch(item, 0, get(arrangedContent, 'length'));
+        leftItem = arrangedContent.objectAt(oldIndex - 1),
+        rightItem = arrangedContent.objectAt(oldIndex + 1),
+        leftResult = leftItem && this.orderBy(item, leftItem),
+        rightResult = rightItem && this.orderBy(item, rightItem);
 
-    if (newIndex !== oldIndex) {
+    if (leftResult < 0 || rightResult > 0) {
       arrangedContent.removeObject(item);
       this.insertItemSorted(item);
     }
@@ -10595,18 +11528,18 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
 var get = Ember.get, set = Ember.set;
 
 /**
-  Ember.ArrayController provides a way for you to publish a collection of objects
-  so that you can easily bind to the collection from a Handlebars #each helper,
-  an Ember.CollectionView, or other controllers.
+  `Ember.ArrayController` provides a way for you to publish a collection of
+  objects so that you can easily bind to the collection from a Handlebars
+  `#each` helper, an `Ember.CollectionView`, or other controllers.
 
-  The advantage of using an ArrayController is that you only have to set up
+  The advantage of using an `ArrayController` is that you only have to set up
   your view bindings once; to change what's displayed, simply swap out the
   `content` property on the controller.
 
   For example, imagine you wanted to display a list of items fetched via an XHR
-  request. Create an Ember.ArrayController and set its `content` property:
+  request. Create an `Ember.ArrayController` and set its `content` property:
 
-  ``` javascript
+  ```javascript
   MyApp.listController = Ember.ArrayController.create();
 
   $.get('people.json', function(data) {
@@ -10616,7 +11549,7 @@ var get = Ember.get, set = Ember.set;
 
   Then, create a view that binds to your new controller:
 
-  ``` handlebars
+  ```handlebars
   {{#each MyApp.listController}}
     {{firstName}} {{lastName}}
   {{/each}}
@@ -10653,13 +11586,13 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
 */
 
 /**
-  Ember.ObjectController is part of Ember's Controller layer. A single
-  shared instance of each Ember.ObjectController subclass in your application's
+  `Ember.ObjectController` is part of Ember's Controller layer. A single shared
+  instance of each `Ember.ObjectController` subclass in your application's
   namespace will be created at application initialization and be stored on your
-  application's Ember.Router instance.
+  application's `Ember.Router` instance.
 
-  Ember.ObjectController derives its functionality from its superclass
-  Ember.ObjectProxy and the Ember.ControllerMixin mixin.
+  `Ember.ObjectController` derives its functionality from its superclass
+  `Ember.ObjectProxy` and the `Ember.ControllerMixin` mixin.
 
   @class ObjectController
   @namespace Ember
@@ -10807,12 +11740,12 @@ Ember.DAG = DAG;
 var get = Ember.get, set = Ember.set;
 
 /**
-  An instance of `Ember.Application` is the starting point for every Ember.js
+  An instance of `Ember.Application` is the starting point for every Ember
   application. It helps to instantiate, initialize and coordinate the many
   objects that make up your app.
 
-  Each Ember.js app has one and only one `Ember.Application` object. In fact, the very
-  first thing you should do in your application is create the instance:
+  Each Ember app has one and only one `Ember.Application` object. In fact, the
+  very first thing you should do in your application is create the instance:
 
   ```javascript
   window.App = Ember.Application.create();
@@ -10828,12 +11761,15 @@ var get = Ember.get, set = Ember.set;
   App.MyView = Ember.View.extend();
   ```
 
-  After all of your classes are defined, call `App.initialize()` to start the
-  application.
+  Calling `Ember.Application.create()` will automatically initialize your
+  application by calling the `Ember.Application.initialize()` method. If you
+  need to delay initialization, you can pass `{autoinit: false}` to the
+  `Ember.Application.create()` method, and call `App.initialize()`
+  later.
 
   Because `Ember.Application` inherits from `Ember.Namespace`, any classes
-  you create will have useful string representations when calling `toString()`;
-  see the `Ember.Namespace` documentation for more information.
+  you create will have useful string representations when calling `toString()`.
+  See the `Ember.Namespace` documentation for more information.
 
   While you can think of your `Ember.Application` as a container that holds the
   other classes in your application, there are several other responsibilities
@@ -10841,24 +11777,24 @@ var get = Ember.get, set = Ember.set;
 
   ### Event Delegation
 
-  Ember.js uses a technique called _event delegation_. This allows the framework
-  to set up a global, shared event listener instead of requiring each view to do
-  it manually. For example, instead of each view registering its own `mousedown`
-  listener on its associated element, Ember.js sets up a `mousedown` listener on
-  the `body`.
+  Ember uses a technique called _event delegation_. This allows the framework
+  to set up a global, shared event listener instead of requiring each view to
+  do it manually. For example, instead of each view registering its own
+  `mousedown` listener on its associated element, Ember sets up a `mousedown`
+  listener on the `body`.
 
-  If a `mousedown` event occurs, Ember.js will look at the target of the event and
-  start walking up the DOM node tree, finding corresponding views and invoking their
-  `mouseDown` method as it goes.
+  If a `mousedown` event occurs, Ember will look at the target of the event and
+  start walking up the DOM node tree, finding corresponding views and invoking
+  their `mouseDown` method as it goes.
 
-  `Ember.Application` has a number of default events that it listens for, as well
-  as a mapping from lowercase events to camel-cased view method names. For
+  `Ember.Application` has a number of default events that it listens for, as
+  well as a mapping from lowercase events to camel-cased view method names. For
   example, the `keypress` event causes the `keyPress` method on the view to be
   called, the `dblclick` event causes `doubleClick` to be called, and so on.
 
-  If there is a browser event that Ember.js does not listen for by default, you
-  can specify custom events and their corresponding view method names by setting
-  the application's `customEvents` property:
+  If there is a browser event that Ember does not listen for by default, you
+  can specify custom events and their corresponding view method names by
+  setting the application's `customEvents` property:
 
   ```javascript
   App = Ember.Application.create({
@@ -10870,13 +11806,13 @@ var get = Ember.get, set = Ember.set;
   });
   ```
 
-  By default, the application sets up these event listeners on the document body.
-  However, in cases where you are embedding an Ember.js application inside an
-  existing page, you may want it to set up the listeners on an element inside
-  the body.
+  By default, the application sets up these event listeners on the document
+  body. However, in cases where you are embedding an Ember application inside
+  an existing page, you may want it to set up the listeners on an element
+  inside the body.
 
-  For example, if only events inside a DOM element with the ID of `ember-app` should
-  be delegated, set your application's `rootElement` property:
+  For example, if only events inside a DOM element with the ID of `ember-app`
+  should be delegated, set your application's `rootElement` property:
 
   ```javascript
   window.App = Ember.Application.create({
@@ -10885,22 +11821,23 @@ var get = Ember.get, set = Ember.set;
   ```
 
   The `rootElement` can be either a DOM element or a jQuery-compatible selector
-  string. Note that *views appended to the DOM outside the root element will not
-  receive events.* If you specify a custom root element, make sure you only append
-  views inside it!
+  string. Note that *views appended to the DOM outside the root element will
+  not receive events.* If you specify a custom root element, make sure you only
+  append views inside it!
 
-  To learn more about the advantages of event delegation and the Ember.js view layer,
-  and a list of the event listeners that are setup by default, visit the
-  [Ember.js View Layer guide](http://emberjs.com/guides/view_layer#toc_event-delegation).
+  To learn more about the advantages of event delegation and the Ember view
+  layer, and a list of the event listeners that are setup by default, visit the
+  [Ember View Layer guide](http://emberjs.com/guides/view_layer#toc_event-delegation).
 
   ### Dependency Injection
 
-  One thing you may have noticed while using Ember.js is that you define *classes*, not
-  *instances*. When your application loads, all of the instances are created for you.
-  Creating these instances is the responsibility of `Ember.Application`.
+  One thing you may have noticed while using Ember is that you define
+  *classes*, not *instances*. When your application loads, all of the instances
+  are created for you. Creating these instances is the responsibility of
+  `Ember.Application`.
 
-  When the `Ember.Application` initializes, it will look for an `Ember.Router` class
-  defined on the applications's `Router` property, like this:
+  When the `Ember.Application` initializes, it will look for an `Ember.Router`
+  class defined on the applications's `Router` property, like this:
 
   ```javascript
   App.Router = Ember.Router.extend({
@@ -10909,9 +11846,9 @@ var get = Ember.get, set = Ember.set;
   ```
 
   If found, the router is instantiated and saved on the application's `router`
-  property (note the lowercase 'r'). While you should *not* reference this router
-  instance directly from your application code, having access to `App.router`
-  from the console can be useful during debugging.
+  property (note the lowercase 'r'). While you should *not* reference this
+  router instance directly from your application code, having access to
+  `App.router` from the console can be useful during debugging.
 
   After the router is created, the application loops through all of the
   registered _injections_ and invokes them once for each property on the
@@ -10932,7 +11869,7 @@ var get = Ember.get, set = Ember.set;
   Your router will receive an instance of `App.MyController` saved on its
   `myController` property.
 
-  Libraries on top of Ember.js can register additional injections. For example,
+  Libraries on top of Ember can register additional injections. For example,
   if your application is using Ember Data, it registers an injection that
   instantiates `DS.Store`:
 
@@ -10951,16 +11888,17 @@ var get = Ember.get, set = Ember.set;
 
   ### Routing
 
-  In addition to creating your application's router, `Ember.Application` is also
-  responsible for telling the router when to start routing.
+  In addition to creating your application's router, `Ember.Application` is
+  also responsible for telling the router when to start routing.
 
   By default, the router will begin trying to translate the current URL into
   application state once the browser emits the `DOMContentReady` event. If you
-  need to defer routing, you can call the application's `deferReadiness()` method.
-  Once routing can begin, call the `advanceReadiness()` method.
+  need to defer routing, you can call the application's `deferReadiness()`
+  method. Once routing can begin, call the `advanceReadiness()` method.
 
-  If there is any setup required before routing begins, you can implement a `ready()`
-  method on your app that will be invoked immediately before routing begins:
+  If there is any setup required before routing begins, you can implement a
+  `ready()` method on your app that will be invoked immediately before routing
+  begins:
 
   ```javascript
   window.App = Ember.Application.create({
@@ -11032,13 +11970,15 @@ Ember.Application = Ember.Namespace.extend(
     to a hash containing the DOM event name as the key and the
     corresponding view method name as the value. For example:
 
-        App = Ember.Application.create({
-          customEvents: {
-            // add support for the loadedmetadata media
-            // player event
-            'loadedmetadata': "loadedMetadata"
-          }
-        });
+    ```javascript
+    App = Ember.Application.create({
+      customEvents: {
+        // add support for the loadedmetadata media
+        // player event
+        'loadedmetadata': "loadedMetadata"
+      }
+    });
+    ```
 
     @property customEvents
     @type Object
@@ -11046,6 +11986,14 @@ Ember.Application = Ember.Namespace.extend(
   */
   customEvents: null,
 
+  /**
+    Should the application initialize itself after it's created. You can
+    set this to `false` if you'd like to choose when to initialize your 
+    application. This defaults to `!Ember.testing`
+
+    @property autoinit
+    @type Boolean
+  */
   autoinit: !Ember.testing,
 
   isInitialized: false,
@@ -11110,25 +12058,25 @@ Ember.Application = Ember.Namespace.extend(
 
     Example:
 
-        App.PostsController = Ember.ArrayController.extend();
-        App.CommentsController = Ember.ArrayController.extend();
+    ```javascript
+    App.PostsController = Ember.ArrayController.extend();
+    App.CommentsController = Ember.ArrayController.extend();
 
-        var router = Ember.Router.create({
-          ...
-        });
+    var router = Ember.Router.create({
+      ...
+    });
 
-        App.initialize(router);
+    App.initialize(router);
 
-        router.get('postsController')     // <App.PostsController:ember1234>
-        router.get('commentsController')  // <App.CommentsController:ember1235>
-
-        router.get('postsController.router') // router
+    router.get('postsController');     // <App.PostsController:ember1234>
+    router.get('commentsController');  // <App.CommentsController:ember1235>
+    ```
 
     @method initialize
     @param router {Ember.Router}
   */
   initialize: function(router) {
-    Ember.assert("Application initialize may only be call once", !this.isInitialized);
+    Ember.assert("Application initialize may only be called once", !this.isInitialized);
     Ember.assert("Application not destroyed", !this.isDestroyed);
 
     router = this.setupRouter(router);
@@ -11207,6 +12155,8 @@ Ember.Application = Ember.Namespace.extend(
     if (router && router instanceof Ember.Router) {
       this.startRouting(router);
     }
+
+    Ember.BOOTED = true;
   },
 
   createApplicationView: function (router) {
@@ -11302,6 +12252,7 @@ Ember.Application.reopenClass({
 Ember.Application.registerInjection({
   name: 'controllers',
   injection: function(app, router, property) {
+    if (!router) { return; }
     if (!/^[A-Z].*Controller$/.test(property)) { return; }
 
     var name = property.charAt(0).toLowerCase() + property.substr(1),
@@ -11350,7 +12301,8 @@ Ember Application
 @submodule ember-views
 */
 
-Ember.assert("Ember Views require jQuery 1.7 or 1.8", window.jQuery && (window.jQuery().jquery.match(/^1\.[78](\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY));
+var jQuery = Ember.imports.jQuery;
+Ember.assert("Ember Views require jQuery 1.7 or 1.8", jQuery && (jQuery().jquery.match(/^1\.(7(?!$)(?!\.[01])|8)(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY));
 
 /**
   Alias for jQuery
@@ -11358,7 +12310,7 @@ Ember.assert("Ember Views require jQuery 1.7 or 1.8", window.jQuery && (window.j
   @method $
   @for Ember
 */
-Ember.$ = window.jQuery;
+Ember.$ = jQuery;
 
 })();
 
@@ -11411,8 +12363,8 @@ ClassSet.prototype = {
 };
 
 /**
-  Ember.RenderBuffer gathers information regarding the a view and generates the
-  final representation. Ember.RenderBuffer will generate HTML which can be pushed
+  `Ember.RenderBuffer` gathers information regarding the a view and generates the
+  final representation. `Ember.RenderBuffer` will generate HTML which can be pushed
   to the DOM.
 
   @class RenderBuffer
@@ -11423,6 +12375,7 @@ Ember.RenderBuffer = function(tagName) {
   return new Ember._RenderBuffer(tagName);
 };
 
+
 Ember._RenderBuffer = function(tagName) {
   this.elementTag = tagName;
   this.childBuffers = [];
@@ -11432,10 +12385,11 @@ Ember._RenderBuffer.prototype =
 /** @scope Ember.RenderBuffer.prototype */ {
 
   /**
-    Array of class-names which will be applied in the class="" attribute
+    @private
 
-    You should not maintain this array yourself, rather, you should use
-    the addClass() method of Ember.RenderBuffer.
+    An internal set used to de-dupe class names when `addClass()` is
+    used. After each call to `addClass()`, the `classes` property
+    will be updated.
 
     @property elementClasses
     @type Array
@@ -11444,10 +12398,22 @@ Ember._RenderBuffer.prototype =
   elementClasses: null,
 
   /**
-    The id in of the element, to be applied in the id="" attribute
+    Array of class names which will be applied in the class attribute.
+
+    You can use `setClasses()` to set this property directly. If you
+    use `addClass()`, it will be maintained for you.
+
+    @property classes
+    @type Array
+    @default []
+  */
+  classes: null,
+
+  /**
+    The id in of the element, to be applied in the id attribute.
 
     You should not set this property yourself, rather, you should use
-    the id() method of Ember.RenderBuffer.
+    the `id()` method of `Ember.RenderBuffer`.
 
     @property elementId
     @type String
@@ -11458,11 +12424,11 @@ Ember._RenderBuffer.prototype =
   /**
     A hash keyed on the name of the attribute and whose value will be
     applied to that attribute. For example, if you wanted to apply a
-    data-view="Foo.bar" property to an element, you would set the
-    elementAttributes hash to {'data-view':'Foo.bar'}
+    `data-view="Foo.bar"` property to an element, you would set the
+    elementAttributes hash to `{'data-view':'Foo.bar'}`.
 
     You should not maintain this hash yourself, rather, you should use
-    the attr() method of Ember.RenderBuffer.
+    the `attr()` method of `Ember.RenderBuffer`.
 
     @property elementAttributes
     @type Hash
@@ -11471,12 +12437,14 @@ Ember._RenderBuffer.prototype =
   elementAttributes: null,
 
   /**
-    The tagname of the element an instance of Ember.RenderBuffer represents.
+    The tagname of the element an instance of `Ember.RenderBuffer` represents.
 
-    Usually, this gets set as the first parameter to Ember.RenderBuffer. For
+    Usually, this gets set as the first parameter to `Ember.RenderBuffer`. For
     example, if you wanted to create a `p` tag, then you would call
 
-      Ember.RenderBuffer('p')
+    ```javascript
+    Ember.RenderBuffer('p')
+    ```
 
     @property elementTag
     @type String
@@ -11487,11 +12455,11 @@ Ember._RenderBuffer.prototype =
   /**
     A hash keyed on the name of the style attribute and whose value will
     be applied to that attribute. For example, if you wanted to apply a
-    background-color:black;" style to an element, you would set the
-    elementStyle hash to {'background-color':'black'}
+    `background-color:black;` style to an element, you would set the
+    elementStyle hash to `{'background-color':'black'}`.
 
     You should not maintain this hash yourself, rather, you should use
-    the style() method of Ember.RenderBuffer.
+    the `style()` method of `Ember.RenderBuffer`.
 
     @property elementStyle
     @type Hash
@@ -11500,7 +12468,7 @@ Ember._RenderBuffer.prototype =
   elementStyle: null,
 
   /**
-    Nested RenderBuffers will set this to their parent RenderBuffer
+    Nested `RenderBuffers` will set this to their parent `RenderBuffer`
     instance.
 
     @property parentBuffer
@@ -11509,7 +12477,7 @@ Ember._RenderBuffer.prototype =
   parentBuffer: null,
 
   /**
-    Adds a string of HTML to the RenderBuffer.
+    Adds a string of HTML to the `RenderBuffer`.
 
     @method push
     @param {String} string HTML to push into the buffer
@@ -11531,8 +12499,13 @@ Ember._RenderBuffer.prototype =
     // lazily create elementClasses
     var elementClasses = this.elementClasses = (this.elementClasses || new ClassSet());
     this.elementClasses.add(className);
+    this.classes = this.elementClasses.list;
 
     return this;
+  },
+
+  setClasses: function(classNames) {
+    this.classes = classNames;
   },
 
   /**
@@ -11655,9 +12628,9 @@ Ember._RenderBuffer.prototype =
   },
 
   /**
-    Creates a new Ember.RenderBuffer object with the provided tagName as
-    the element tag and with its parentBuffer property set to the current
-    Ember.RenderBuffer.
+    Creates a new `Ember.RenderBuffer` object with the provided tagName as
+    the element tag and with its `parentBuffer` property set to the current
+    `Ember.RenderBuffer`.
 
     @method begin
     @param {String} tagName Tag name to use for the child buffer's element
@@ -11732,63 +12705,122 @@ Ember._RenderBuffer.prototype =
       of this buffer
   */
   element: function() {
-    return Ember.$(this.string())[0];
+    var element = document.createElement(this.elementTag),
+        $element = Ember.$(element),
+        id = this.elementId,
+        classes = this.classes,
+        attrs = this.elementAttributes,
+        style = this.elementStyle,
+        styleBuffer = '', prop;
+
+    if (id) { $element.attr('id', id); }
+    if (classes) { $element.attr('class', classes.join(' ')); }
+
+    if (style) {
+      for (prop in style) {
+        if (style.hasOwnProperty(prop)) {
+          styleBuffer += (prop + ':' + style[prop] + ';');
+        }
+      }
+
+      $element.attr('style', styleBuffer);
+    }
+
+    if (attrs) {
+      for (prop in attrs) {
+        if (attrs.hasOwnProperty(prop)) {
+          $element.attr(prop, attrs[prop]);
+        }
+      }
+    }
+
+    this.elementTag = ''; // hack to avoid creating an innerString function
+    var html = this.string();
+
+    if (!Ember.$.support.htmlSerialize) { // work around IE zero-scope bug by inserting a script tag
+      html = '&shy;' + html;
+    }
+
+    element.innerHTML = html;
+
+    if (!Ember.$.support.htmlSerialize) {
+      // This code is copied from Metamorph
+      var shyElement = element.firstChild;
+      while (shyElement.nodeType === 1 && !shyElement.nodeName) {
+        shyElement = shyElement.firstChild;
+      }
+      if (shyElement.nodeType === 3 && shyElement.nodeValue.charAt(0) === "\u00AD") {
+        shyElement.nodeValue = shyElement.nodeValue.slice(1);
+      }
+    }
+
+    return element;
   },
 
   /**
     Generates the HTML content for this buffer.
 
     @method string
-    @return {String} The generated HTMl
+    @return {String} The generated HTML
   */
   string: function() {
-    var content = '', tag = this.elementTag, openTag;
+    var content = [];
+    return this.array(content).join('');
+  },
+
+  array: function(content) {
+    var tag = this.elementTag, openTag;
 
     if (tag) {
       var id = this.elementId,
-          classes = this.elementClasses,
+          classes = this.classes,
           attrs = this.elementAttributes,
           style = this.elementStyle,
           styleBuffer = '', prop;
 
-      openTag = ["<" + tag];
+      content.push("<" + tag);
 
-      if (id) { openTag.push('id="' + this._escapeAttribute(id) + '"'); }
-      if (classes) { openTag.push('class="' + this._escapeAttribute(classes.toDOM()) + '"'); }
+      if (id) { content.push(' id="' + this._escapeAttribute(id) + '"'); }
+      if (classes) { content.push(' class="' + this._escapeAttribute(classes.join(' ')) + '"'); }
 
       if (style) {
+        content.push(' style="');
+
         for (prop in style) {
           if (style.hasOwnProperty(prop)) {
-            styleBuffer += (prop + ':' + this._escapeAttribute(style[prop]) + ';');
+            content.push(prop + ':' + this._escapeAttribute(style[prop]) + ';');
           }
         }
 
-        openTag.push('style="' + styleBuffer + '"');
+        content.push('"');
       }
 
       if (attrs) {
         for (prop in attrs) {
           if (attrs.hasOwnProperty(prop)) {
-            openTag.push(prop + '="' + this._escapeAttribute(attrs[prop]) + '"');
+            content.push(' ' + prop + '="' + this._escapeAttribute(attrs[prop]) + '"');
           }
         }
       }
 
-      openTag = openTag.join(" ") + '>';
+      content.push('>');
     }
 
     var childBuffers = this.childBuffers;
 
     Ember.ArrayPolyfills.forEach.call(childBuffers, function(buffer) {
       var stringy = typeof buffer === 'string';
-      content += (stringy ? buffer : buffer.string());
+      if (stringy) {
+        content.push(buffer);
+      } else {
+        buffer.array(content);
+      }
     });
 
     if (tag) {
-      return openTag + content + "</" + tag + ">";
-    } else {
-      return content;
+      content.push("</" + tag + ">");
     }
+    return content;
   },
 
   _escapeAttribute: function(value) {
@@ -11830,9 +12862,10 @@ Ember._RenderBuffer.prototype =
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
 /**
-  Ember.EventDispatcher handles delegating browser events to their corresponding
-  Ember.Views. For example, when you click on a view, Ember.EventDispatcher ensures
-  that that view's `mouseDown` method gets called.
+  `Ember.EventDispatcher` handles delegating browser events to their
+  corresponding `Ember.Views.` For example, when you click on a view,
+  `Ember.EventDispatcher` ensures that that view's `mouseDown` method gets
+  called.
 
   @class EventDispatcher
   @namespace Ember
@@ -11864,7 +12897,7 @@ Ember.EventDispatcher = Ember.Object.extend(
 
     Sets up event listeners for standard browser events.
 
-    This will be called after the browser sends a DOMContentReady event. By
+    This will be called after the browser sends a `DOMContentReady` event. By
     default, it will set up all of the listeners on the document body. If you
     would like to register the listeners on a different element, set the event
     dispatcher's `root` property.
@@ -11926,17 +12959,18 @@ Ember.EventDispatcher = Ember.Object.extend(
     @private
 
     Registers an event listener on the document. If the given event is
-    triggered, the provided event handler will be triggered on the target
-    view.
+    triggered, the provided event handler will be triggered on the target view.
 
     If the target view does not implement the event handler, or if the handler
-    returns false, the parent view will be called. The event will continue to
+    returns `false`, the parent view will be called. The event will continue to
     bubble to each successive parent view until it reaches the top.
 
     For example, to have the `mouseDown` method called on the target view when
     a `mousedown` event is received from the browser, do the following:
 
-        setupHandler('mousedown', 'mouseDown');
+    ```javascript
+    setupHandler('mousedown', 'mouseDown');
+    ```
 
     @method setupHandler
     @param {Element} rootElement
@@ -12031,9 +13065,10 @@ Ember.EventDispatcher = Ember.Object.extend(
 */
 
 // Add a new named queue for rendering views that happens
-// after bindings have synced.
+// after bindings have synced, and a queue for scheduling actions
+// that that should occur after view rendering.
 var queues = Ember.run.queues;
-queues.splice(Ember.$.inArray('actions', queues)+1, 0, 'render');
+queues.splice(Ember.$.inArray('actions', queues)+1, 0, 'render', 'afterRender');
 
 })();
 
@@ -12074,7 +13109,7 @@ Ember.ControllerMixin.reopen({
     For example, an application view's template may look like
     this:
 
-    ``` handlebars
+    ```handlebars
     <h1>My Blog</h1>
     {{outlet}}
     ```
@@ -12084,7 +13119,7 @@ Ember.ControllerMixin.reopen({
     following code will assign a new `App.PostsView` to
     that outlet:
 
-    ``` javascript
+    ```javascript
     applicationController.connectOutlet('posts');
     ```
 
@@ -12104,35 +13139,34 @@ Ember.ControllerMixin.reopen({
     You can supply a `content` for the controller by supplying
     a final argument after the view class:
 
-    ``` javascript
+    ```javascript
     applicationController.connectOutlet('posts', App.Post.find());
     ```
 
     You can specify a particular outlet to use. For example, if your main
     template looks like:
 
-    ``` handlebars
+    ```handlebars
     <h1>My Blog</h1>
-    {{outlet master}}
-    {{outlet detail}}
+    {{outlet masterView}}
+    {{outlet detailView}}
     ```
 
-    You can assign an `App.PostsView` to the master outlet:
+    You can assign an `App.PostsView` to the masterView outlet:
 
-    ``` javascript
+    ```javascript
     applicationController.connectOutlet({
+      outletName: 'masterView',
       name: 'posts',
-      outletName: 'master',
       context: App.Post.find()
     });
     ```
 
     You can write this as:
 
-    ``` javascript
-    applicationController.connectOutlet('master', 'posts', App.Post.find());
+    ```javascript
+    applicationController.connectOutlet('masterView', 'posts', App.Post.find());
     ```
-
 
     @method connectOutlet
     @param {String} outletName a name for the outlet to set
@@ -12187,7 +13221,9 @@ Ember.ControllerMixin.reopen({
 
     outletName = outletName || 'view';
 
-    Ember.assert("You must supply a name or a view class to connectOutlet, but not both", (!!name && !viewClass && !controller) || (!name && !!viewClass));
+    Ember.assert("The viewClass is either missing or the one provided did not resolve to a view", !!name || (!name && !!viewClass));
+
+    Ember.assert("You must supply a name or a viewClass to connectOutlet, but not both", (!!name && !viewClass && !controller) || (!name && !!viewClass));
 
     if (name) {
       var namespace = get(this, 'namespace'),
@@ -12218,7 +13254,9 @@ Ember.ControllerMixin.reopen({
     For example, to make the `personController` and the `postController` available
     on the `overviewController`, you would call:
 
-        overviewController.connectControllers('person', 'post');
+    ```javascript
+    overviewController.connectControllers('person', 'post');
+    ```
 
     @method connectControllers
     @param {String...} controllerNames the controllers to make available
@@ -12271,15 +13309,18 @@ Ember.ControllerMixin.reopen({
 
 
 (function() {
+var states = {};
+
 /**
 @module ember
 @submodule ember-views
 */
 
 var get = Ember.get, set = Ember.set, addObserver = Ember.addObserver, removeObserver = Ember.removeObserver;
-var meta = Ember.meta, fmt = Ember.String.fmt;
+var meta = Ember.meta, guidFor = Ember.guidFor, fmt = Ember.String.fmt;
 var a_slice = [].slice;
 var a_forEach = Ember.EnumerableUtils.forEach;
+var a_addObject = Ember.EnumerableUtils.addObject;
 
 var childViewsProperty = Ember.computed(function() {
   var childViews = this._childViews;
@@ -12295,10 +13336,9 @@ var childViewsProperty = Ember.computed(function() {
   });
 
   return ret;
-}).property().cacheable();
+}).property();
 
-var VIEW_PRESERVES_CONTEXT = Ember.VIEW_PRESERVES_CONTEXT;
-Ember.warn("The way that the {{view}} helper affects templates is about to change. Previously, templates inside child views would use the new view as the context. Soon, views will preserve their parent context when rendering their template. You can opt-in early to the new behavior by setting `ENV.VIEW_PRESERVES_CONTEXT = true`. For more information, see https://gist.github.com/2494968. You should update your templates as soon as possible; this default will change soon, and the option will be eliminated entirely before the 1.0 release.", VIEW_PRESERVES_CONTEXT);
+Ember.warn("The VIEW_PRESERVES_CONTEXT flag has been removed and the functionality can no longer be disabled.", Ember.ENV.VIEW_PRESERVES_CONTEXT !== false);
 
 /**
   Global hash of shared templates. This will automatically be populated
@@ -12311,24 +13351,207 @@ Ember.warn("The way that the {{view}} helper affects templates is about to chang
 */
 Ember.TEMPLATES = {};
 
-var invokeForState = {
-  preRender: {},
-  inBuffer: {},
-  hasElement: {},
-  inDOM: {},
-  destroyed: {}
-};
+Ember.CoreView = Ember.Object.extend(Ember.Evented, {
+  isView: true,
+
+  states: states,
+
+  init: function() {
+    this._super();
+
+    // Register the view for event handling. This hash is used by
+    // Ember.EventDispatcher to dispatch incoming events.
+    if (!this.isVirtual) Ember.View.views[this.elementId] = this;
+
+    this.addBeforeObserver('elementId', function() {
+      throw new Error("Changing a view's elementId after creation is not allowed");
+    });
+
+    this.transitionTo('preRender');
+  },
+
+  /**
+    If the view is currently inserted into the DOM of a parent view, this
+    property will point to the parent of the view.
+
+    @property parentView
+    @type Ember.View
+    @default null
+  */
+  parentView: Ember.computed(function() {
+    var parent = this._parentView;
+
+    if (parent && parent.isVirtual) {
+      return get(parent, 'parentView');
+    } else {
+      return parent;
+    }
+  }).property('_parentView'),
+
+  state: null,
+
+  _parentView: null,
+
+  // return the current view, not including virtual views
+  concreteView: Ember.computed(function() {
+    if (!this.isVirtual) { return this; }
+    else { return get(this, 'parentView'); }
+  }).property('parentView').volatile(),
+
+  /**
+    Creates a new `renderBuffer` with the passed `tagName`. You can override
+    this method to provide further customization to the buffer if needed.
+    Normally you will not need to call or override this method.
+
+    @method renderBuffer
+    @param [tagName] {String}
+    @return {Ember.RenderBuffer}
+  */
+  renderBuffer: function(tagName) {
+    tagName = tagName || this.tagName;
+
+    // Explicitly check for null or undefined, as tagName
+    // may be an empty string, which would evaluate to false.
+    if (tagName === null || tagName === undefined) {
+      tagName = 'div';
+    }
+
+    return Ember.RenderBuffer(tagName);
+  },
+
+  instrumentName: 'core_view',
+
+  instrumentDetails: function(hash) {
+    hash.object = this.toString();
+  },
+
+  /**
+    @private
+
+    Invoked by the view system when this view needs to produce an HTML
+    representation. This method will create a new render buffer, if needed,
+    then apply any default attributes, such as class names and visibility.
+    Finally, the `render()` method is invoked, which is responsible for
+    doing the bulk of the rendering.
+
+    You should not need to override this method; instead, implement the
+    `template` property, or if you need more control, override the `render`
+    method.
+
+    @method renderToBuffer
+    @param {Ember.RenderBuffer} buffer the render buffer. If no buffer is
+      passed, a default buffer, using the current view's `tagName`, will
+      be used.
+  */
+  renderToBuffer: function(parentBuffer, bufferOperation) {
+    var name = 'render-to-buffer.' + this.instrumentName,
+        details = {};
+
+    this.instrumentDetails(details);
+
+    return Ember.instrument(name, details, function() {
+      return this._renderToBuffer(parentBuffer, bufferOperation);
+    }, this);
+  },
+
+  _renderToBuffer: function(parentBuffer, bufferOperation) {
+    var buffer;
+
+    Ember.run.sync();
+
+    // Determine where in the parent buffer to start the new buffer.
+    // By default, a new buffer will be appended to the parent buffer.
+    // The buffer operation may be changed if the child views array is
+    // mutated by Ember.ContainerView.
+    bufferOperation = bufferOperation || 'begin';
+
+    // If this is the top-most view, start a new buffer. Otherwise,
+    // create a new buffer relative to the original using the
+    // provided buffer operation (for example, `insertAfter` will
+    // insert a new buffer after the "parent buffer").
+    if (parentBuffer) {
+      var tagName = this.tagName;
+      if (tagName === null || tagName === undefined) {
+        tagName = 'div';
+      }
+
+      buffer = parentBuffer[bufferOperation](tagName);
+    } else {
+      buffer = this.renderBuffer();
+    }
+
+    this.buffer = buffer;
+    this.transitionTo('inBuffer', false);
+
+    this.beforeRender(buffer);
+    this.render(buffer);
+    this.afterRender(buffer);
+
+    return buffer;
+  },
+
+  /**
+    @private
+
+    Override the default event firing from `Ember.Evented` to
+    also call methods with the given name.
+
+    @method trigger
+    @param name {String}
+  */
+  trigger: function(name) {
+    this._super.apply(this, arguments);
+    var method = this[name];
+    if (method) {
+      var args = [], i, l;
+      for (i = 1, l = arguments.length; i < l; i++) {
+        args.push(arguments[i]);
+      }
+      return method.apply(this, args);
+    }
+  },
+
+  has: function(name) {
+    return Ember.typeOf(this[name]) === 'function' || this._super(name);
+  },
+
+  willDestroy: function() {
+    var parent = this._parentView;
+
+    // destroy the element -- this will avoid each child view destroying
+    // the element over and over again...
+    if (!this.removedFromDOM) { this.destroyElement(); }
+
+    // remove from parent if found. Don't call removeFromParent,
+    // as removeFromParent will try to remove the element from
+    // the DOM again.
+    if (parent) { parent.removeChild(this); }
+
+    this.transitionTo('destroyed');
+
+    // next remove view from global hash
+    if (!this.isVirtual) delete Ember.View.views[this.elementId];
+  },
+
+  clearRenderedChildren: Ember.K,
+  triggerRecursively: Ember.K,
+  invokeRecursively: Ember.K,
+  transitionTo: Ember.K,
+  destroyElement: Ember.K
+});
 
 /**
-  `Ember.View` is the class in Ember responsible for encapsulating templates of HTML
-  content, combining templates with data to render as sections of a page's DOM, and
-  registering and responding to user-initiated events.
-  
-  ## HTML Tag
-  The default HTML tag name used for a view's DOM representation is `div`. This can be
-  customized by setting the `tagName` property. The following view class:
+  `Ember.View` is the class in Ember responsible for encapsulating templates of
+  HTML content, combining templates with data to render as sections of a page's
+  DOM, and registering and responding to user-initiated events.
 
-  ``` javascript
+  ## HTML Tag
+
+  The default HTML tag name used for a view's DOM representation is `div`. This
+  can be customized by setting the `tagName` property. The following view
+class:
+
+  ```javascript
   ParagraphView = Ember.View.extend({
     tagName: 'em'
   });
@@ -12336,15 +13559,16 @@ var invokeForState = {
 
   Would result in instances with the following HTML:
 
-  ``` html
+  ```html
   <em id="ember1" class="ember-view"></em>
   ```
 
   ## HTML `class` Attribute
-  The HTML `class` attribute of a view's tag can be set by providing a `classNames` property
-  that is set to an array of strings:
 
-  ``` javascript
+  The HTML `class` attribute of a view's tag can be set by providing a
+  `classNames` property that is set to an array of strings:
+
+  ```javascript
   MyView = Ember.View.extend({
     classNames: ['my-class', 'my-other-class']
   });
@@ -12352,16 +13576,16 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view my-class my-other-class"></div>
   ```
 
-  `class` attribute values can also be set by providing a `classNameBindings` property
-  set to an array of properties names for the view. The return value of these properties 
-  will be added as part of the value for the view's `class` attribute. These properties
-  can be computed properties:
+  `class` attribute values can also be set by providing a `classNameBindings`
+  property set to an array of properties names for the view. The return value
+  of these properties will be added as part of the value for the view's `class`
+  attribute. These properties can be computed properties:
 
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['propertyA', 'propertyB'],
     propertyA: 'from-a',
@@ -12373,15 +13597,15 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view from-a from-b"></div>
   ```
 
-  If the value of a class name binding returns a boolean the property name itself
-  will be used as the class name if the property is true. The class name will
-  not be added if the value is `false` or `undefined`.
+  If the value of a class name binding returns a boolean the property name
+  itself will be used as the class name if the property is true. The class name
+  will not be added if the value is `false` or `undefined`.
 
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['hovered'],
     hovered: true
@@ -12390,15 +13614,15 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view hovered"></div>
   ```
 
-  When using boolean class name bindings you can supply a string value other than the 
-  property name for use as the `class` HTML attribute by appending the preferred value after
-  a ":" character when defining the binding:
+  When using boolean class name bindings you can supply a string value other
+  than the property name for use as the `class` HTML attribute by appending the
+  preferred value after a ":" character when defining the binding:
 
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['awesome:so-very-cool'],
     awesome: true
@@ -12407,15 +13631,14 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view so-very-cool"></div>
   ```
 
+  Boolean value class name bindings whose property names are in a
+  camelCase-style format will be converted to a dasherized format:
 
-  Boolean value class name bindings whose property names are in a camelCase-style
-  format will be converted to a dasherized format:
-
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['isUrgent'],
     isUrgent: true
@@ -12424,15 +13647,14 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view is-urgent"></div>
   ```
-
 
   Class name bindings can also refer to object values that are found by
   traversing a path relative to the view itself:
 
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['messages.empty']
     messages: Ember.Object.create({
@@ -12443,16 +13665,15 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view empty"></div>
   ```
-
 
   If you want to add a class name for a property which evaluates to true and
   and a different class name if it evaluates to false, you can pass a binding
   like this:
 
-  ```
+  ```javascript
   // Applies 'enabled' class when isEnabled is true and 'disabled' when isEnabled is false
   Ember.View.create({
     classNameBindings: ['isEnabled:enabled:disabled']
@@ -12462,19 +13683,20 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view enabled"></div>
-  ``` 
+  ```
 
-  When isEnabled is `false`, the resulting HTML reprensentation looks like this:
+  When isEnabled is `false`, the resulting HTML reprensentation looks like
+  this:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view disabled"></div>
   ```
 
   This syntax offers the convenience to add a class if a property is `false`:
 
-  ``` javascript
+  ```javascript
   // Applies no class when isEnabled is true and class 'disabled' when isEnabled is false
   Ember.View.create({
     classNameBindings: ['isEnabled::disabled']
@@ -12484,31 +13706,34 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view"></div>
   ```
 
   When the `isEnabled` property on the view is set to `false`, it will result
   in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view disabled"></div>
   ```
 
-  Updates to the the value of a class name binding will result in automatic update 
-  of the  HTML `class` attribute in the view's rendered HTML representation.
-  If the value becomes  `false` or `undefined` the class name will be removed.
+  Updates to the the value of a class name binding will result in automatic
+  update of the  HTML `class` attribute in the view's rendered HTML
+  representation. If the value becomes `false` or `undefined` the class name
+  will be removed.
 
-  Both `classNames` and `classNameBindings` are concatenated properties. 
-  See `Ember.Object` documentation for more information about concatenated properties.
+  Both `classNames` and `classNameBindings` are concatenated properties. See
+  `Ember.Object` documentation for more information about concatenated
+  properties.
 
   ## HTML Attributes
 
-  The HTML attribute section of a view's tag can be set by providing an `attributeBindings`
-  property set to an array of property names on the view. The return value of these properties
-  will be used as the value of the view's HTML associated attribute:
+  The HTML attribute section of a view's tag can be set by providing an
+  `attributeBindings` property set to an array of property names on the view.
+  The return value of these properties will be used as the value of the view's
+  HTML associated attribute:
 
-  ``` javascript
+  ```javascript
   AnchorView = Ember.View.extend({
     tagName: 'a',
     attributeBindings: ['href'],
@@ -12518,7 +13743,7 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <a id="ember1" class="ember-view" href="http://google.com"></a>
   ```
 
@@ -12526,7 +13751,7 @@ var invokeForState = {
   the property will follow HTML's pattern of repeating the attribute's name as
   its value:
 
-  ``` javascript
+  ```javascript
   MyTextInput = Ember.View.extend({
     tagName: 'input',
     attributeBindings: ['disabled'],
@@ -12536,13 +13761,13 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <input id="ember1" class="ember-view" disabled="disabled" />
   ```
 
   `attributeBindings` can refer to computed properties:
 
-  ``` javascript
+  ```javascript
   MyTextInput = Ember.View.extend({
     tagName: 'input',
     attributeBindings: ['disabled'],
@@ -12556,19 +13781,21 @@ var invokeForState = {
   });
   ```
 
-  Updates to the the property of an attribute binding will result in automatic update 
-  of the  HTML attribute in the view's rendered HTML representation.
+  Updates to the the property of an attribute binding will result in automatic
+  update of the  HTML attribute in the view's rendered HTML representation.
 
-  `attributeBindings` is a concatenated property. See `Ember.Object` documentation
-  for more information about concatenated properties.
+  `attributeBindings` is a concatenated property. See `Ember.Object`
+  documentation for more information about concatenated properties.
 
   ## Templates
-  The HTML contents of a view's rendered representation are determined by its template.
-  Templates can be any function that accepts an optional context parameter and returns
-  a string of HTML that will be inserted within the view's tag. Most
-  typically in Ember this function will be a compiled Ember.Handlebars template.
 
-  ``` javascript
+  The HTML contents of a view's rendered representation are determined by its
+  template. Templates can be any function that accepts an optional context
+  parameter and returns a string of HTML that will be inserted within the
+  view's tag. Most typically in Ember this function will be a compiled
+  `Ember.Handlebars` template.
+
+  ```javascript
   AView = Ember.View.extend({
     template: Ember.Handlebars.compile('I am the template')
   });
@@ -12576,37 +13803,14 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">I am the template</div>
-  ``` 
-
-  The default context of the compiled template will be the view instance itself:
-
-  ``` javascript
-  AView = Ember.View.extend({
-    template: Ember.Handlebars.compile('Hello {{excitedGreeting}}')
-  });
-
-  aView = AView.create({
-    content: Ember.Object.create({
-      firstName: 'Barry'
-    })
-    excitedGreeting: function(){
-      return this.get("content.firstName") + "!!!"
-    }
-  });
-  ```
-
-  Will result in an HTML representation of:
-
-  ``` html
-  <div id="ember1" class="ember-view">Hello Barry!!!</div>
   ```
 
   Within an Ember application is more common to define a Handlebars templates as
   part of a page:
 
-  ``` handlebars
+  ```handlebars
   <script type='text/x-handlebars' data-template-name='some-template'>
     Hello
   </script>
@@ -12614,23 +13818,25 @@ var invokeForState = {
 
   And associate it by name using a view's `templateName` property:
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     templateName: 'some-template'
   });
   ```
 
-  Using a value for `templateName` that does not have a Handlebars template with a
-  matching `data-template-name` attribute will throw an error.
+  Using a value for `templateName` that does not have a Handlebars template
+  with a matching `data-template-name` attribute will throw an error.
 
-  Assigning a value to both `template` and `templateName` properties will throw an error.
+  Assigning a value to both `template` and `templateName` properties will throw
+  an error.
 
-  For views classes that may have a template later defined (e.g. as the block portion of a `{{view}}`
-  Handlebars helper call in another template or in a subclass), you can provide a `defaultTemplate`
-  property set to compiled template function. If a template is not later provided for the view
-  instance the `defaultTemplate` value will be used:
+  For views classes that may have a template later defined (e.g. as the block
+  portion of a `{{view}}` Handlebars helper call in another template or in
+  a subclass), you can provide a `defaultTemplate` property set to compiled
+  template function. If a template is not later provided for the view instance
+  the `defaultTemplate` value will be used:
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     defaultTemplate: Ember.Handlebars.compile('I was the default'),
     template: null,
@@ -12640,13 +13846,14 @@ var invokeForState = {
 
   Will result in instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">I was the default</div>
   ```
 
-  If a `template` or `templateName` is provided it will take precedence over `defaultTemplate`:
+  If a `template` or `templateName` is provided it will take precedence over
+  `defaultTemplate`:
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     defaultTemplate: Ember.Handlebars.compile('I was the default')
   });
@@ -12658,26 +13865,60 @@ var invokeForState = {
 
   Will result in the following HTML representation when rendered:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">I was the template, not default</div>
   ```
+
+  ## View Context
+
+  The default context of the compiled template is the view's controller:
+
+  ```javascript
+  AView = Ember.View.extend({
+    template: Ember.Handlebars.compile('Hello {{excitedGreeting}}')
+  });
+
+  aController = Ember.Object.create({
+    firstName: 'Barry',
+    excitedGreeting: function(){
+      return this.get("content.firstName") + "!!!"
+    }.property()
+  });
+
+  aView = AView.create({
+    controller: aController,
+  });
+  ```
+
+  Will result in an HTML representation of:
+
+  ```html
+  <div id="ember1" class="ember-view">Hello Barry!!!</div>
+  ```
+
+  A context can also be explicitly supplied through the view's `context`
+  property. If the view has neither `context` nor `controller` properties, the
+  `parentView`'s context will be used.
 
   ## Layouts
 
   Views can have a secondary template that wraps their main template. Like
-  primary templates, layouts can be any function that  accepts an optional context
-  parameter and returns a string of HTML that will be inserted inside view's tag. Views whose HTML
-  element is self closing (e.g. `<input />`) cannot have a layout and this property will be ignored.
-  
-  Most typically in Ember a layout will be a compiled Ember.Handlebars template.
+  primary templates, layouts can be any function that  accepts an optional
+  context parameter and returns a string of HTML that will be inserted inside
+  view's tag. Views whose HTML element is self closing (e.g. `<input />`)
+  cannot have a layout and this property will be ignored.
 
-  A view's layout can be set directly with the `layout` property or reference an
-  existing Handlebars template by name with the `layoutName` property.
+  Most typically in Ember a layout will be a compiled `Ember.Handlebars`
+  template.
 
-  A template used as a layout must contain a single use of the Handlebars `{{yield}}`
-  helper. The HTML contents of a view's rendered `template` will be inserted at this location:
+  A view's layout can be set directly with the `layout` property or reference
+  an existing Handlebars template by name with the `layoutName` property.
 
-  ``` javascript
+  A template used as a layout must contain a single use of the Handlebars
+  `{{yield}}` helper. The HTML contents of a view's rendered `template` will be
+  inserted at this location:
+
+  ```javascript
   AViewWithLayout = Ember.View.extend({
     layout: Ember.Handlebars.compile("<div class='my-decorative-class'>{{yield}}</div>")
     template: Ember.Handlebars.compile("I got wrapped"),
@@ -12686,7 +13927,7 @@ var invokeForState = {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">
     <div class="my-decorative-class">
       I got wrapped
@@ -12698,15 +13939,17 @@ var invokeForState = {
 
   ## Responding to Browser Events
 
-  Views can respond to user-initiated events in one of three ways: method implementation, 
-  through an event manager, and through `{{action}}` helper use in their template or layout.
+  Views can respond to user-initiated events in one of three ways: method
+  implementation, through an event manager, and through `{{action}}` helper use
+  in their template or layout.
 
   ### Method Implementation
 
-  Views can respond to user-initiated events by implementing a method that matches the
-  event name. A `jQuery.Event` object will be passed as the argument to this method.
+  Views can respond to user-initiated events by implementing a method that
+  matches the event name. A `jQuery.Event` object will be passed as the
+  argument to this method.
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     click: function(event){
       // will be called when when an instance's
@@ -12717,15 +13960,16 @@ var invokeForState = {
 
   ### Event Managers
 
-  Views can define an object as their `eventManager` property. This object can then
-  implement methods that match the desired event names. Matching events that occur
-  on the view's rendered HTML or the rendered HTML of any of its DOM descendants 
-  will trigger this method.  A `jQuery.Event` object will be passed as the first 
-  argument to the method and an  `Ember.View` object as the second. The `Ember.View`
-  will be the view whose rendered HTML was interacted with. This may be the view with
-  the `eventManager` property or one of its descendent views.
+  Views can define an object as their `eventManager` property. This object can
+  then implement methods that match the desired event names. Matching events
+  that occur on the view's rendered HTML or the rendered HTML of any of its DOM
+  descendants will trigger this method. A `jQuery.Event` object will be passed
+  as the first argument to the method and an  `Ember.View` object as the
+  second. The `Ember.View` will be the view whose rendered HTML was interacted
+  with. This may be the view with the `eventManager` property or one of its
+  descendent views.
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     eventManager: Ember.Object.create({
       doubleClick: function(event, view){
@@ -12738,11 +13982,10 @@ var invokeForState = {
   });
   ```
 
+  An event defined for an event manager takes precedence over events of the
+  same name handled through methods on the view.
 
-  An event defined for an event manager takes precedence over events of the same
-  name handled through methods on the view.
-
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     mouseEnter: function(event){
       // will never trigger.
@@ -12756,12 +13999,13 @@ var invokeForState = {
   ```
 
   Similarly a view's event manager will take precedence for events of any views
-  rendered as a descendent. A method name that matches an event name will not be called
-  if the view instance was rendered inside the HTML representation of a view that has 
-  an `eventManager` property defined that handles events of the name.  Events not handled
-  by the event manager will still trigger method calls on the descendent.
+  rendered as a descendent. A method name that matches an event name will not
+  be called if the view instance was rendered inside the HTML representation of
+  a view that has an `eventManager` property defined that handles events of the
+  name. Events not handled by the event manager will still trigger method calls
+  on the descendent.
 
-  ``` javascript
+  ```javascript
   OuterView = Ember.View.extend({
     template: Ember.Handlebars.compile("outer {{#view InnerView}}inner{{/view}} outer"),
     eventManager: Ember.Object.create({
@@ -12780,7 +14024,7 @@ var invokeForState = {
       // eventManager doesn't handle click events
     },
     mouseEnter: function(event){
-      // will never be called if rendered inside 
+      // will never be called if rendered inside
       // an OuterView.
     }
   });
@@ -12792,30 +14036,64 @@ var invokeForState = {
 
   ### Event Names
 
-  Possible events names for any of the responding approaches described above are:
+  Possible events names for any of the responding approaches described above
+  are:
 
-  Touch events: 'touchStart', 'touchMove', 'touchEnd', 'touchCancel'
+  Touch events:
 
-  Keyboard events: 'keyDown', 'keyUp', 'keyPress'
+  * `touchStart`
+  * `touchMove`
+  * `touchEnd`
+  * `touchCancel`
 
-  Mouse events: 'mouseDown', 'mouseUp', 'contextMenu', 'click', 'doubleClick', 'mouseMove',
-  'focusIn', 'focusOut', 'mouseEnter', 'mouseLeave'
+  Keyboard events
 
-  Form events: 'submit', 'change', 'focusIn', 'focusOut', 'input'
+  * `keyDown`
+  * `keyUp`
+  * `keyPress`
 
-  HTML5 drag and drop events: 'dragStart', 'drag', 'dragEnter', 'dragLeave', 'drop', 'dragEnd'
-  
+  Mouse events
+
+  * `mouseDown`
+  * `mouseUp`
+  * `contextMenu`
+  * `click`
+  * `doubleClick`
+  * `mouseMove`
+  * `focusIn`
+  * `focusOut`
+  * `mouseEnter`
+  * `mouseLeave`
+
+  Form events: 
+
+  * `submit`
+  * `change`
+  * `focusIn`
+  * `focusOut`
+  * `input`
+
+  HTML5 drag and drop events: 
+
+  * `dragStart`
+  * `drag`
+  * `dragEnter`
+  * `dragLeave`
+  * `drop`
+  * `dragEnd`
+
   ## Handlebars `{{view}}` Helper
-  
-  Other `Ember.View` instances can be included as part of a view's template by using the `{{view}}`
-  Handlebars helper. See `Handlebars.helpers.view` for additional information.
+
+  Other `Ember.View` instances can be included as part of a view's template by
+  using the `{{view}}` Handlebars helper. See `Handlebars.helpers.view` for
+  additional information.
 
   @class View
   @namespace Ember
   @extends Ember.Object
   @uses Ember.Evented
 */
-Ember.View = Ember.Object.extend(Ember.Evented,
+Ember.View = Ember.CoreView.extend(
 /** @scope Ember.View.prototype */ {
 
   concatenatedProperties: ['classNames', 'classNameBindings', 'attributeBindings'],
@@ -12835,7 +14113,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   /**
     The name of the template to lookup if no template is provided.
 
-    Ember.View will look for a template with this name in this view's
+    `Ember.View` will look for a template with this name in this view's
     `templates` object. By default, this will be a global object
     shared in `Ember.TEMPLATES`.
 
@@ -12848,7 +14126,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   /**
     The name of the layout to lookup if no layout is provided.
 
-    Ember.View will look for a template with this name in this view's
+    `Ember.View` will look for a template with this name in this view's
     `templates` object. By default, this will be a global object
     shared in `Ember.TEMPLATES`.
 
@@ -12885,7 +14163,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
         template = this.templateForName(templateName, 'template');
 
     return template || get(this, 'defaultTemplate');
-  }).property('templateName').cacheable(),
+  }).property('templateName'),
 
   /**
     The controller managing this view. If this property is set, it will be
@@ -12894,16 +14172,10 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @property controller
     @type Object
   */
-  controller: Ember.computed(function(key, value) {
-    var parentView;
-
-    if (arguments.length === 2) {
-      return value;
-    } else {
-      parentView = get(this, 'parentView');
-      return parentView ? get(parentView, 'controller') : null;
-    }
-  }).property().cacheable(),
+  controller: Ember.computed(function(key) {
+    var parentView = get(this, 'parentView');
+    return parentView ? get(parentView, 'controller') : null;
+  }).property(),
 
   /**
     A view may contain a layout. A layout is a regular template but
@@ -12919,17 +14191,17 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @property layout
     @type Function
   */
-  layout: Ember.computed(function(key, value) {
-    if (arguments.length === 2) { return value; }
-
+  layout: Ember.computed(function(key) {
     var layoutName = get(this, 'layoutName'),
         layout = this.templateForName(layoutName, 'layout');
 
     return layout || get(this, 'defaultLayout');
-  }).property('layoutName').cacheable(),
+  }).property('layoutName'),
 
   templateForName: function(name, type) {
     if (!name) { return; }
+
+    Ember.assert("templateNames are not allowed to contain periods: "+name, name.indexOf('.') === -1);
 
     var templates = get(this, 'templates'),
         template = get(templates, name);
@@ -12948,7 +14220,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     method is called, but it is up to the individual function to decide what
     to do with it.
 
-    By default, this will be the view itself.
+    By default, this will be the view's controller.
 
     @property context
     @type Object
@@ -12971,8 +14243,8 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
     The context of a view is looked up as follows:
 
-    1. Specified controller
-    2. Supplied context (usually by Handlebars)
+    1. Supplied context (usually by Handlebars)
+    2. Specified controller
     3. `parentView`'s context (for a child of a ContainerView)
 
     The code in Handlebars that overrides the `_context` property first
@@ -12981,26 +14253,20 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
     @property _context
   */
-  _context: Ember.computed(function(key, value) {
+  _context: Ember.computed(function(key) {
     var parentView, controller;
 
-    if (arguments.length === 2) {
-      return value;
+    if (controller = get(this, 'controller')) {
+      return controller;
     }
 
-    if (VIEW_PRESERVES_CONTEXT) {
-      if (controller = get(this, 'controller')) {
-        return controller;
-      }
-
-      parentView = get(this, '_parentView');
-      if (parentView) {
-        return get(parentView, '_context');
-      }
+    parentView = this._parentView;
+    if (parentView) {
+      return get(parentView, '_context');
     }
 
-    return this;
-  }).cacheable(),
+    return null;
+  }),
 
   /**
     @private
@@ -13010,38 +14276,12 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
     @method _displayPropertyDidChange
   */
-  _displayPropertyDidChange: Ember.observer(function() {
+  _contextDidChange: Ember.observer(function() {
     this.rerender();
-  }, 'context', 'controller'),
+  }, 'context'),
 
   /**
-    If the view is currently inserted into the DOM of a parent view, this
-    property will point to the parent of the view.
-
-    @property parentView
-    @type Ember.View
-    @default null
-  */
-  parentView: Ember.computed(function() {
-    var parent = get(this, '_parentView');
-
-    if (parent && parent.isVirtual) {
-      return get(parent, 'parentView');
-    } else {
-      return parent;
-    }
-  }).property('_parentView').volatile(),
-
-  _parentView: null,
-
-  // return the current view, not including virtual views
-  concreteView: Ember.computed(function() {
-    if (!this.isVirtual) { return this; }
-    else { return get(this, 'parentView'); }
-  }).property('_parentView').volatile(),
-
-  /**
-    If false, the view will appear hidden in DOM.
+    If `false`, the view will appear hidden in DOM.
 
     @property isVisible
     @type Boolean
@@ -13053,7 +14293,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @private
 
     Array of child views. You should never edit this array directly.
-    Instead, use appendChild and removeFromParent.
+    Instead, use `appendChild` and `removeFromParent`.
 
     @property childViews
     @type Array
@@ -13088,12 +14328,35 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @property nearestInstanceOf
     @param {Class} klass Subclass of Ember.View (or Ember.View itself)
     @return Ember.View
+    @deprecated
   */
   nearestInstanceOf: function(klass) {
+    Ember.deprecate("nearestInstanceOf is deprecated and will be removed from future releases. Use nearestOfType.");
     var view = get(this, 'parentView');
 
     while (view) {
       if(view instanceof klass) { return view; }
+      view = get(view, 'parentView');
+    }
+  },
+
+  /**
+    Return the nearest ancestor that is an instance of the provided
+    class or mixin.
+
+    @property nearestOfType
+    @param {Class,Mixin} klass Subclass of Ember.View (or Ember.View itself),
+           or an instance of Ember.Mixin.
+    @return Ember.View
+  */
+  nearestOfType: function(klass) {
+    var view = get(this, 'parentView'),
+        isOfType = klass instanceof Ember.Mixin ?
+                   function(view) { return klass.detect(view); } :
+                   function(view) { return klass.detect(view.constructor); };
+
+    while (view) {
+      if( isOfType(view) ) { return view; }
       view = get(view, 'parentView');
     }
   },
@@ -13132,53 +14395,14 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   },
 
   /**
-    Return the nearest ancestor that is an Ember.CollectionView
-
-    @property collectionView
-    @return Ember.CollectionView
-  */
-  collectionView: Ember.computed(function() {
-    return this.nearestInstanceOf(Ember.CollectionView);
-  }).cacheable(),
-
-  /**
-    Return the nearest ancestor that is a direct child of
-    an Ember.CollectionView
-
-    @property itemView
-    @return Ember.View
-  */
-  itemView: Ember.computed(function() {
-    return this.nearestChildOf(Ember.CollectionView);
-  }).cacheable(),
-
-  /**
-    Return the nearest ancestor that has the property
-    `content`.
-
-    @property contentView
-    @return Ember.View
-  */
-  contentView: Ember.computed(function() {
-    return this.nearestWithProperty('content');
-  }).cacheable(),
-
-  /**
     @private
 
-    When the parent view changes, recursively invalidate
-    collectionView, itemView, and contentView
+    When the parent view changes, recursively invalidate `controller`
 
     @method _parentViewDidChange
   */
   _parentViewDidChange: Ember.observer(function() {
     if (this.isDestroying) { return; }
-
-    this.invokeRecursively(function(view) {
-      view.propertyDidChange('collectionView');
-      view.propertyDidChange('itemView');
-      view.propertyDidChange('contentView');
-    });
 
     if (get(this, 'parentView.controller') && !get(this, 'controller')) {
       this.notifyPropertyChange('controller');
@@ -13187,6 +14411,8 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
   _controllerDidChange: Ember.observer(function() {
     if (this.isDestroying) { return; }
+
+    this.rerender();
 
     this.forEachChildView(function(view) {
       view.propertyDidChange('controller');
@@ -13205,10 +14431,10 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
   /**
     Called on your view when it should push strings of HTML into a
-    Ember.RenderBuffer. Most users will want to override the `template`
+    `Ember.RenderBuffer`. Most users will want to override the `template`
     or `templateName` properties instead of this method.
 
-    By default, Ember.View will look for a function in the `template`
+    By default, `Ember.View` will look for a function in the `template`
     property and invoke it with the value of `context`. The value of
     `context` will be the view's controller unless you override it.
 
@@ -13224,62 +14450,30 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     if (template) {
       var context = get(this, 'context');
       var keywords = this.cloneKeywords();
+      var output;
 
       var data = {
         view: this,
         buffer: buffer,
         isRenderData: true,
-        keywords: keywords
+        keywords: keywords,
+        insideGroup: get(this, 'templateData.insideGroup')
       };
 
       // Invoke the template with the provided template context, which
-      // is the view by default. A hash of data is also passed that provides
+      // is the view's controller by default. A hash of data is also passed that provides
       // the template with access to the view and render buffer.
 
       Ember.assert('template must be a function. Did you mean to call Ember.Handlebars.compile("...") or specify templateName instead?', typeof template === 'function');
       // The template should write directly to the render buffer instead
       // of returning a string.
-      var output = template(context, { data: data });
+      Ember.instrument('template.' + this.instrumentName,
+        { object: this.toString() },
+        function() { output = template(context, { data: data }); });
 
       // If the template returned a string instead of writing to the buffer,
       // push the string onto the buffer.
       if (output !== undefined) { buffer.push(output); }
-    }
-  },
-
-  invokeForState: function(name) {
-    var stateName = this.state, args, fn;
-
-    // try to find the function for the state in the cache
-    if (fn = invokeForState[stateName][name]) {
-      args = a_slice.call(arguments);
-      args[0] = this;
-
-      return fn.apply(this, args);
-    }
-
-    // otherwise, find and cache the function for this state
-    var parent = this, states = parent.states, state;
-
-    while (states) {
-      state = states[stateName];
-
-      while (state) {
-        fn = state[name];
-
-        if (fn) {
-          invokeForState[stateName][name] = fn;
-
-          args = a_slice.call(arguments, 1);
-          args.unshift(this);
-
-          return fn.apply(this, args);
-        }
-
-        state = state.parentState;
-      }
-
-      states = states.parent;
     }
   },
 
@@ -13300,7 +14494,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @method rerender
   */
   rerender: function() {
-    return this.invokeForState('rerender');
+    return this.currentState.rerender(this);
   },
 
   clearRenderedChildren: function() {
@@ -13328,12 +14522,9 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
     @method _applyClassNameBindings
   */
-  _applyClassNameBindings: function() {
-    var classBindings = get(this, 'classNameBindings'),
-        classNames = get(this, 'classNames'),
-        elem, newClass, dasherizedClass;
-
-    if (!classBindings) { return; }
+  _applyClassNameBindings: function(classBindings) {
+    var classNames = this.classNames,
+    elem, newClass, dasherizedClass;
 
     // Loop through all of the configured bindings. These will be either
     // property names ('isUrgent') or property paths relative to the view
@@ -13353,10 +14544,6 @@ Ember.View = Ember.Object.extend(Ember.Evented,
         // Get the current value of the property
         newClass = this._classStringForProperty(binding);
         elem = this.$();
-        if (!elem) {
-          removeObserver(this, parsedPath.path, observer);
-          return;
-        }
 
         // If we had previously added a class to the element, remove it.
         if (oldClass) {
@@ -13382,7 +14569,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
       if (dasherizedClass) {
         // Ensure that it gets into the classNames array
         // so it is displayed when we render.
-        classNames.push(dasherizedClass);
+        a_addObject(classNames, dasherizedClass);
 
         // Save a reference to the class name so we can remove it
         // if the observer fires. Remember that this variable has
@@ -13391,6 +14578,10 @@ Ember.View = Ember.Object.extend(Ember.Evented,
       }
 
       addObserver(this, parsedPath.path, observer);
+
+      this.one('willClearRender', function() {
+        removeObserver(this, parsedPath.path, observer);
+      });
     }, this);
   },
 
@@ -13403,11 +14594,8 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @method _applyAttributeBindings
     @param {Ember.RenderBuffer} buffer
   */
-  _applyAttributeBindings: function(buffer) {
-    var attributeBindings = get(this, 'attributeBindings'),
-        attributeValue, elem, type;
-
-    if (!attributeBindings) { return; }
+  _applyAttributeBindings: function(buffer, attributeBindings) {
+    var attributeValue, elem, type;
 
     a_forEach(attributeBindings, function(binding) {
       var split = binding.split(':'),
@@ -13426,6 +14614,10 @@ Ember.View = Ember.Object.extend(Ember.Evented,
       };
 
       addObserver(this, property, observer);
+
+      this.one('willClearRender', function() {
+        removeObserver(this, property, observer);
+      });
 
       // Determine the current value and add it to the render buffer
       // if necessary.
@@ -13452,7 +14644,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
     var val = get(this, path);
     if (val === undefined && Ember.isGlobalPath(path)) {
-      val = get(window, path);
+      val = get(Ember.lookup, path);
     }
 
     return Ember.View._classStringForValue(path, val, parsedPath.className, parsedPath.falsyClassName);
@@ -13470,11 +14662,11 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   */
   element: Ember.computed(function(key, value) {
     if (value !== undefined) {
-      return this.invokeForState('setElement', value);
+      return this.currentState.setElement(this, value);
     } else {
-      return this.invokeForState('getElement');
+      return this.currentState.getElement(this);
     }
-  }).property('_parentView').cacheable(),
+  }).property('_parentView'),
 
   /**
     Returns a jQuery object for this view's element. If you pass in a selector
@@ -13489,7 +14681,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @return {jQuery} the CoreQuery object for the DOM node
   */
   $: function(sel) {
-    return this.invokeForState('$', sel);
+    return this.currentState.$(this, sel);
   },
 
   mutateChildViews: function(callback) {
@@ -13531,11 +14723,11 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     element will not be appended to the given element until all bindings have
     finished synchronizing.
 
-    This is not typically a function that you will need to call directly
-    when building your application. You might consider using Ember.ContainerView
-    instead. If you do need to use appendTo, be sure that the target element you
-    are providing is associated with an Ember.Application and does not have an
-    ancestor element that is associated with an Ember view.
+    This is not typically a function that you will need to call directly when
+    building your application. You might consider using `Ember.ContainerView`
+    instead. If you do need to use `appendTo`, be sure that the target element
+    you are providing is associated with an `Ember.Application` and does not
+    have an ancestor element that is associated with an Ember view.
 
     @method appendTo
     @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
@@ -13553,9 +14745,9 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   },
 
   /**
-    Replaces the content of the specified parent element with this view's element.
-    If the view does not have an HTML representation yet, `createElement()`
-    will be called automatically.
+    Replaces the content of the specified parent element with this view's
+    element. If the view does not have an HTML representation yet,
+    `createElement()` will be called automatically.
 
     Note that this method just schedules the view to be appended; the DOM
     element will not be appended to the given element until all bindings have
@@ -13583,16 +14775,18 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     ensures that all bindings have finished synchronizing before the view is
     rendered.
 
-    To use, pass a function that performs a DOM operation..
+    To use, pass a function that performs a DOM operation.
 
     Before your function is called, this view and all child views will receive
     the `willInsertElement` event. After your function is invoked, this view
     and all of its child views will receive the `didInsertElement` event.
 
-        view._insertElementLater(function() {
-          this.createElement();
-          this.$().appendTo('body');
-        });
+    ```javascript
+    view._insertElementLater(function() {
+      this.createElement();
+      this.$().appendTo('body');
+    });
+    ```
 
     @method _insertElementLater
     @param {Function} fn the function that inserts the element into the DOM
@@ -13606,7 +14800,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   */
   _insertElement: function (fn) {
     this._scheduledInsert = null;
-    this.invokeForState('insertElement', fn);
+    this.currentState.insertElement(this, fn);
   },
 
   /**
@@ -13639,62 +14833,26 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     // important than elements get garbage collected.
     this.destroyElement();
     this.invokeRecursively(function(view) {
-      view.clearRenderedChildren();
+      if (view.clearRenderedChildren) { view.clearRenderedChildren(); }
     });
   },
 
-  /**
-    The ID to use when trying to locate the element in the DOM. If you do not
-    set the elementId explicitly, then the view's GUID will be used instead.
-    This ID must be set at the time the view is created.
-
-    @property elementId
-    @type String
-  */
-  elementId: Ember.computed(function(key, value) {
-    return value !== undefined ? value : Ember.guidFor(this);
-  }).cacheable(),
-
-  // TODO: Perhaps this should be removed from the production build somehow.
-  _elementIdDidChange: Ember.beforeObserver(function() {
-    throw "Changing a view's elementId after creation is not allowed.";
-  }, 'elementId'),
+  elementId: null,
 
   /**
     Attempts to discover the element in the parent element. The default
-    implementation looks for an element with an ID of elementId (or the view's
-    guid if elementId is null). You can override this method to provide your
-    own form of lookup. For example, if you want to discover your element
-    using a CSS class name instead of an ID.
+    implementation looks for an element with an ID of `elementId` (or the
+    view's guid if `elementId` is null). You can override this method to
+    provide your own form of lookup. For example, if you want to discover your
+    element using a CSS class name instead of an ID.
 
     @method findElementInParentElement
     @param {DOMElement} parentElement The parent's DOM element
     @return {DOMElement} The discovered element
   */
   findElementInParentElement: function(parentElem) {
-    var id = "#" + get(this, 'elementId');
+    var id = "#" + this.elementId;
     return Ember.$(id)[0] || Ember.$(id, parentElem)[0];
-  },
-
-  /**
-    Creates a new renderBuffer with the passed tagName. You can override this
-    method to provide further customization to the buffer if needed. Normally
-    you will not need to call or override this method.
-
-    @method renderBuffer
-    @param [tagName] {String}
-    @return {Ember.RenderBuffer}
-  */
-  renderBuffer: function(tagName) {
-    tagName = tagName || get(this, 'tagName');
-
-    // Explicitly check for null or undefined, as tagName
-    // may be an empty string, which would evaluate to false.
-    if (tagName === null || tagName === undefined) {
-      tagName = 'div';
-    }
-
-    return Ember.RenderBuffer(tagName);
   },
 
   /**
@@ -13737,9 +14895,9 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     been torn down. This is a good opportunity to tear down any manual
     observers you have installed based on the DOM state
 
-    @event willRerender
+    @event willClearRender
   */
-  willRerender: Ember.K,
+  willClearRender: Ember.K,
 
   /**
     @private
@@ -13750,67 +14908,37 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @param fn {Function}
   */
   invokeRecursively: function(fn) {
-    fn.call(this, this);
+    var childViews = [this], currentViews, view;
 
-    this.forEachChildView(function(view) {
-      view.invokeRecursively(fn);
-    });
+    while (childViews.length) {
+      currentViews = childViews.slice();
+      childViews = [];
+
+      for (var i=0, l=currentViews.length; i<l; i++) {
+        view = currentViews[i];
+        fn.call(view, view);
+        if (view._childViews) {
+          childViews.push.apply(childViews, view._childViews);
+        }
+      }
+    }
   },
 
-  /**
-    Invalidates the cache for a property on all child views.
+  triggerRecursively: function(eventName) {
+    var childViews = [this], currentViews, view;
 
-    @method invalidateRecursively
-  */
-  invalidateRecursively: function(key) {
-    this.forEachChildView(function(view) {
-      view.propertyDidChange(key);
-    });
-  },
+    while (childViews.length) {
+      currentViews = childViews.slice();
+      childViews = [];
 
-  /**
-    @private
-
-    Invokes the receiver's willInsertElement() method if it exists and then
-    invokes the same on all child views.
-
-    NOTE: In some cases this was called when the element existed. This no longer
-    works so we let people know. We can remove this warning code later.
-
-    @method _notifyWillInsertElement
-  */
-  _notifyWillInsertElement: function() {
-    this.invokeRecursively(function(view) {
-      view.trigger('willInsertElement');
-    });
-  },
-
-  /**
-    @private
-
-    Invokes the receiver's didInsertElement() method if it exists and then
-    invokes the same on all child views.
-
-    @method _notifyDidInsertElement
-  */
-  _notifyDidInsertElement: function() {
-    this.invokeRecursively(function(view) {
-      view.trigger('didInsertElement');
-    });
-  },
-
-  /**
-    @private
-
-    Invokes the receiver's willRerender() method if it exists and then
-    invokes the same on all child views.
-
-    @method _notifyWillRerender
-  */
-  _notifyWillRerender: function() {
-    this.invokeRecursively(function(view) {
-      view.trigger('willRerender');
-    });
+      for (var i=0, l=currentViews.length; i<l; i++) {
+        view = currentViews[i];
+        if (view.trigger) { view.trigger(eventName); }
+        if (view._childViews) {
+          childViews.push.apply(childViews, view._childViews);
+        }
+      }
+    }
   },
 
   /**
@@ -13818,12 +14946,12 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     as well. If the view does not currently have a element, then this method
     will do nothing.
 
-    If you implement willDestroyElement() on your view, then this method will
+    If you implement `willDestroyElement()` on your view, then this method will
     be invoked on your view before your element is destroyed to give you a
     chance to clean up any event handlers, etc.
 
-    If you write a willDestroyElement() handler, you can assume that your
-    didInsertElement() handler was called earlier for the same element.
+    If you write a `willDestroyElement()` handler, you can assume that your
+    `didInsertElement()` handler was called earlier for the same element.
 
     Normally you will not call or override this method yourself, but you may
     want to implement the above callbacks when it is run.
@@ -13832,7 +14960,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @return {Ember.View} receiver
   */
   destroyElement: function() {
-    return this.invokeForState('destroyElement');
+    return this.currentState.destroyElement(this);
   },
 
   /**
@@ -13847,14 +14975,18 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   /**
     @private
 
-    Invokes the `willDestroyElement` callback on the view and child views.
+    Triggers the `willDestroyElement` event (which invokes the
+    `willDestroyElement()` method if it exists) on this view and all child
+    views.
+
+    Before triggering `willDestroyElement`, it first triggers the
+    `willClearRender` event recursively.
 
     @method _notifyWillDestroyElement
   */
   _notifyWillDestroyElement: function() {
-    this.invokeRecursively(function(view) {
-      view.trigger('willDestroyElement');
-    });
+    this.triggerRecursively('willClearRender');
+    this.triggerRecursively('willDestroyElement');
   },
 
   _elementWillChange: Ember.beforeObserver(function() {
@@ -13885,66 +15017,23 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   */
   parentViewDidChange: Ember.K,
 
-  /**
-    @private
+  instrumentName: 'view',
 
-    Invoked by the view system when this view needs to produce an HTML
-    representation. This method will create a new render buffer, if needed,
-    then apply any default attributes, such as class names and visibility.
-    Finally, the `render()` method is invoked, which is responsible for
-    doing the bulk of the rendering.
+  instrumentDetails: function(hash) {
+    hash.template = get(this, 'templateName');
+    this._super(hash);
+  },
 
-    You should not need to override this method; instead, implement the
-    `template` property, or if you need more control, override the `render`
-    method.
-
-    @method renderToBuffer
-    @param {Ember.RenderBuffer} buffer the render buffer. If no buffer is
-      passed, a default buffer, using the current view's `tagName`, will
-      be used.
-  */
-  renderToBuffer: function(parentBuffer, bufferOperation) {
-    var buffer;
-
-    Ember.run.sync();
-
-    // Determine where in the parent buffer to start the new buffer.
-    // By default, a new buffer will be appended to the parent buffer.
-    // The buffer operation may be changed if the child views array is
-    // mutated by Ember.ContainerView.
-    bufferOperation = bufferOperation || 'begin';
-
-    // If this is the top-most view, start a new buffer. Otherwise,
-    // create a new buffer relative to the original using the
-    // provided buffer operation (for example, `insertAfter` will
-    // insert a new buffer after the "parent buffer").
-    if (parentBuffer) {
-      var tagName = get(this, 'tagName');
-      if (tagName === null || tagName === undefined) {
-        tagName = 'div';
-      }
-
-      buffer = parentBuffer[bufferOperation](tagName);
-    } else {
-      buffer = this.renderBuffer();
-    }
-
-    this.buffer = buffer;
-    this.transitionTo('inBuffer', false);
-
+  _renderToBuffer: function(parentBuffer, bufferOperation) {
     this.lengthBeforeRender = this._childViews.length;
-
-    this.beforeRender(buffer);
-    this.render(buffer);
-    this.afterRender(buffer);
-
+    var buffer = this._super(parentBuffer, bufferOperation);
     this.lengthAfterRender = this._childViews.length;
 
     return buffer;
   },
 
   renderToBufferIfNeeded: function () {
-    return this.invokeForState('renderToBufferIfNeeded', this);
+    return this.currentState.renderToBufferIfNeeded(this, this);
   },
 
   beforeRender: function(buffer) {
@@ -13956,16 +15045,21 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   applyAttributesToBuffer: function(buffer) {
     // Creates observers for all registered class name and attribute bindings,
     // then adds them to the element.
-    this._applyClassNameBindings();
+    var classNameBindings = get(this, 'classNameBindings');
+    if (classNameBindings.length) {
+      this._applyClassNameBindings(classNameBindings);
+    }
 
     // Pass the render buffer so the method can apply attributes directly.
     // This isn't needed for class name bindings because they use the
     // existing classNames infrastructure.
-    this._applyAttributeBindings(buffer);
+    var attributeBindings = get(this, 'attributeBindings');
+    if (attributeBindings.length) {
+      this._applyAttributeBindings(buffer, attributeBindings);
+    }
 
-
-    a_forEach(get(this, 'classNames'), function(name){ buffer.addClass(name); });
-    buffer.id(get(this, 'elementId'));
+    buffer.setClasses(this.classNames);
+    buffer.id(this.elementId);
 
     var role = get(this, 'ariaRole');
     if (role) {
@@ -13982,8 +15076,8 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   //
 
   /**
-    Tag name for the view's outer element. The tag name is only used when
-    an element is first created. If you change the tagName for an element, you
+    Tag name for the view's outer element. The tag name is only used when an
+    element is first created. If you change the `tagName` for an element, you
     must destroy and recreate the view element.
 
     By default, the render buffer will use a `<div>` tag for views.
@@ -14028,29 +15122,35 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     is a string value, the value of that string will be applied as a class
     name.
 
-        // Applies the 'high' class to the view element
-        Ember.View.create({
-          classNameBindings: ['priority']
-          priority: 'high'
-        });
+    ```javascript
+    // Applies the 'high' class to the view element
+    Ember.View.create({
+      classNameBindings: ['priority']
+      priority: 'high'
+    });
+    ```
 
     If the value of the property is a Boolean, the name of that property is
     added as a dasherized class name.
 
-        // Applies the 'is-urgent' class to the view element
-        Ember.View.create({
-          classNameBindings: ['isUrgent']
-          isUrgent: true
-        });
+    ```javascript
+    // Applies the 'is-urgent' class to the view element
+    Ember.View.create({
+      classNameBindings: ['isUrgent']
+      isUrgent: true
+    });
+    ```
 
     If you would prefer to use a custom value instead of the dasherized
     property name, you can pass a binding like this:
 
-        // Applies the 'urgent' class to the view element
-        Ember.View.create({
-          classNameBindings: ['isUrgent:urgent']
-          isUrgent: true
-        });
+    ```javascript
+    // Applies the 'urgent' class to the view element
+    Ember.View.create({
+      classNameBindings: ['isUrgent:urgent']
+      isUrgent: true
+    });
+    ```
 
     This list of properties is inherited from the view's superclasses as well.
 
@@ -14064,27 +15164,29 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     A list of properties of the view to apply as attributes. If the property is
     a string value, the value of that string will be applied as the attribute.
 
-        // Applies the type attribute to the element
-        // with the value "button", like <div type="button">
-        Ember.View.create({
-          attributeBindings: ['type'],
-          type: 'button'
-        });
+    ```javascript
+    // Applies the type attribute to the element
+    // with the value "button", like <div type="button">
+    Ember.View.create({
+      attributeBindings: ['type'],
+      type: 'button'
+    });
+    ```
 
     If the value of the property is a Boolean, the name of that property is
     added as an attribute.
 
-        // Renders something like <div enabled="enabled">
-        Ember.View.create({
-          attributeBindings: ['enabled'],
-          enabled: true
-        });
+    ```javascript
+    // Renders something like <div enabled="enabled">
+    Ember.View.create({
+      attributeBindings: ['enabled'],
+      enabled: true
+    });
+    ```
 
     @property attributeBindings
   */
   attributeBindings: [],
-
-  state: 'preRender',
 
   // .......................................................
   // CORE DISPLAY METHODS
@@ -14094,18 +15196,16 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @private
 
     Setup a view, but do not finish waking it up.
-    - configure childViews
+    - configure `childViews`
     - register the view with the global views hash, which is used for event
       dispatch
 
     @method init
   */
   init: function() {
-    this._super();
+    this.elementId = this.elementId || guidFor(this);
 
-    // Register the view for event handling. This hash is used by
-    // Ember.EventDispatcher to dispatch incoming events.
-    if (!this.isVirtual) Ember.View.views[get(this, 'elementId')] = this;
+    this._super();
 
     // setup child views. be sure to clone the child views array first
     this._childViews = this._childViews.slice();
@@ -14126,7 +15226,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   },
 
   appendChild: function(view, options) {
-    return this.invokeForState('appendChild', view, options);
+    return this.currentState.appendChild(this, view, options);
   },
 
   /**
@@ -14156,7 +15256,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   },
 
   /**
-    Removes all children from the parentView.
+    Removes all children from the `parentView`.
 
     @method removeAllChildren
     @return {Ember.View} receiver
@@ -14174,14 +15274,14 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   },
 
   /**
-    Removes the view from its parentView, if one is found. Otherwise
+    Removes the view from its `parentView`, if one is found. Otherwise
     does nothing.
 
     @method removeFromParent
     @return {Ember.View} receiver
   */
   removeFromParent: function() {
-    var parent = get(this, '_parentView');
+    var parent = this._parentView;
 
     // Remove DOM element from parent
     this.remove();
@@ -14202,7 +15302,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     // calling this._super() will nuke computed properties and observers,
     // so collect any information we need before calling super.
     var childViews = this._childViews,
-        parent     = get(this, '_parentView'),
+        parent = this._parentView,
         childLen;
 
     // destroy the element -- this will avoid each child view destroying
@@ -14222,7 +15322,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     // the DOM again.
     if (parent) { parent.removeChild(this); }
 
-    this.state = 'destroyed';
+    this.transitionTo('destroyed');
 
     childLen = childViews.length;
     for (var i=childLen-1; i>=0; i--) {
@@ -14237,7 +15337,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   /**
     Instantiates a view to be added to the childViews array during view
     initialization. You generally will not call this method directly unless
-    you are overriding createChildViews(). Note that this method will
+    you are overriding `createChildViews()`. Note that this method will
     automatically configure the correct settings on the new view instance to
     act as a child of the parent.
 
@@ -14247,7 +15347,9 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @return {Ember.View} new instance
   */
   createChildView: function(view, attrs) {
-    if (Ember.View.detect(view)) {
+    if (view.isView && view._parentView === this) { return view; }
+
+    if (Ember.CoreView.detect(view)) {
       attrs = attrs || {};
       attrs._parentView = this;
       attrs.templateData = attrs.templateData || get(this, 'templateData');
@@ -14258,7 +15360,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
       // consumers of the view API
       if (view.viewName) { set(get(this, 'concreteView'), view.viewName, view); }
     } else {
-      Ember.assert('You must pass instance or subclass of View', view instanceof Ember.View);
+      Ember.assert('You must pass instance or subclass of View', view.isView);
       Ember.assert("You can only pass attributes when a class is provided", !attrs);
 
       if (!get(view, 'templateData')) {
@@ -14336,11 +15438,12 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
   clearBuffer: function() {
     this.invokeRecursively(function(view) {
-      this.buffer = null;
+      view.buffer = null;
     });
   },
 
   transitionTo: function(state, children) {
+    this.currentState = this.states[state];
     this.state = state;
 
     if (children !== false) {
@@ -14348,31 +15451,6 @@ Ember.View = Ember.Object.extend(Ember.Evented,
         view.transitionTo(state);
       });
     }
-  },
-
-  /**
-    @private
-
-    Override the default event firing from Ember.Evented to
-    also call methods with the given name.
-
-    @method trigger
-    @param name {String}
-  */
-  trigger: function(name) {
-    this._super.apply(this, arguments);
-    var method = this[name];
-    if (method) {
-      var args = [], i, l;
-      for (i = 1, l = arguments.length; i < l; i++) {
-        args.push(arguments[i]);
-      }
-      return method.apply(this, args);
-    }
-  },
-
-  has: function(name) {
-    return Ember.typeOf(this[name]) === 'function' || this._super(name);
   },
 
   // .......................................................
@@ -14389,7 +15467,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @param evt {Event}
   */
   handleEvent: function(eventName, evt) {
-    return this.invokeForState('handleEvent', eventName, evt);
+    return this.currentState.handleEvent(this, eventName, evt);
   }
 
 });
@@ -14452,7 +15530,6 @@ var DOMManager = {
 };
 
 Ember.View.reopen({
-  states: Ember.View.states,
   domManager: DOMManager
 });
 
@@ -14466,12 +15543,14 @@ Ember.View.reopenClass({
     For example a path like "content.isEnabled:enabled:disabled" wil return the
     following object:
 
-        {
-          path: "content.isEnabled",
-          className: "enabled",
-          falsyClassName: "disabled",
-          classNames: ":enabled:disabled"
-        }
+    ```javascript
+    {
+      path: "content.isEnabled",
+      className: "enabled",
+      falsyClassName: "disabled",
+      classNames: ":enabled:disabled"
+    }
+    ```
 
     @method _parsePropertyPath
     @static
@@ -14503,16 +15582,20 @@ Ember.View.reopenClass({
   /**
     @private
 
-    Get the class name for a given value, based on the path, optional className
-    and optional falsyClassName.
+    Get the class name for a given value, based on the path, optional
+    `className` and optional `falsyClassName`.
 
-    - if a className or falsyClassName has been specified:
-      - if the value is truthy and className has been specified, className is returned
-      - if the value is falsy and falsyClassName has been specified, falsyClassName is returned
-      - otherwise null is returned
-    - if the value is true, the dasherized last part of the supplied path is returned
-    - if the value is not false, undefined or null, the value is returned
-    - if none of the above rules apply, null is returned
+    - if a `className` or `falsyClassName` has been specified:
+      - if the value is truthy and `className` has been specified, 
+        `className` is returned
+      - if the value is falsy and `falsyClassName` has been specified, 
+        `falsyClassName` is returned
+      - otherwise `null` is returned
+    - if the value is `true`, the dasherized last part of the supplied path 
+      is returned
+    - if the value is not `false`, `undefined` or `null`, the `value` 
+      is returned
+    - if none of the above rules apply, `null` is returned
 
     @method _classStringForValue
     @param path
@@ -14587,6 +15670,8 @@ Ember.View.applyAttributeBindings = function(elem, name, value) {
   }
 };
 
+Ember.View.states = states;
+
 })();
 
 
@@ -14599,44 +15684,40 @@ Ember.View.applyAttributeBindings = function(elem, name, value) {
 
 var get = Ember.get, set = Ember.set;
 
-Ember.View.states = {
-  _default: {
-    // appendChild is only legal while rendering the buffer.
-    appendChild: function() {
-      throw "You can't use appendChild outside of the rendering process";
-    },
+Ember.View.states._default = {
+  // appendChild is only legal while rendering the buffer.
+  appendChild: function() {
+    throw "You can't use appendChild outside of the rendering process";
+  },
 
-    $: function() {
-      return undefined;
-    },
+  $: function() {
+    return undefined;
+  },
 
-    getElement: function() {
-      return null;
-    },
+  getElement: function() {
+    return null;
+  },
 
-    // Handle events from `Ember.EventDispatcher`
-    handleEvent: function() {
-      return true; // continue event propagation
-    },
+  // Handle events from `Ember.EventDispatcher`
+  handleEvent: function() {
+    return true; // continue event propagation
+  },
 
-    destroyElement: function(view) {
-      set(view, 'element', null);
-      if (view._scheduledInsert) {
-        Ember.run.cancel(view._scheduledInsert);
-        view._scheduledInsert = null;
-      }
-      return view;
-    },
-
-    renderToBufferIfNeeded: function () {
-      return false;
+  destroyElement: function(view) {
+    set(view, 'element', null);
+    if (view._scheduledInsert) {
+      Ember.run.cancel(view._scheduledInsert);
+      view._scheduledInsert = null;
     }
-  }
-};
+    return view;
+  },
 
-Ember.View.reopen({
-  states: Ember.View.states
-});
+  renderToBufferIfNeeded: function () {
+    return false;
+  },
+
+  rerender: Ember.K
+};
 
 })();
 
@@ -14648,18 +15729,18 @@ Ember.View.reopen({
 @submodule ember-views
 */
 
-Ember.View.states.preRender = {
-  parentState: Ember.View.states._default,
+var preRender = Ember.View.states.preRender = Ember.create(Ember.View.states._default);
 
+Ember.merge(preRender, {
   // a view leaves the preRender state once its element has been
   // created (createElement).
   insertElement: function(view, fn) {
     view.createElement();
-    view._notifyWillInsertElement();
+    view.triggerRecursively('willInsertElement');
     // after createElement, the view will be in the hasElement state.
     fn.call(view);
     view.transitionTo('inDOM');
-    view._notifyDidInsertElement();
+    view.triggerRecursively('didInsertElement');
   },
 
   renderToBufferIfNeeded: function(view) {
@@ -14674,7 +15755,7 @@ Ember.View.states.preRender = {
     }
     return value;
   }
-};
+});
 
 })();
 
@@ -14688,9 +15769,9 @@ Ember.View.states.preRender = {
 
 var get = Ember.get, set = Ember.set, meta = Ember.meta;
 
-Ember.View.states.inBuffer = {
-  parentState: Ember.View.states._default,
+var inBuffer = Ember.View.states.inBuffer = Ember.create(Ember.View.states._default);
 
+Ember.merge(inBuffer, {
   $: function(view, sel) {
     // if we don't have an element yet, someone calling this.$() is
     // trying to update an element that isn't in the DOM. Instead,
@@ -14705,7 +15786,7 @@ Ember.View.states.inBuffer = {
   rerender: function(view) {
     Ember.deprecate("Something you did caused a view to re-render after it rendered but before it was inserted into the DOM. Because this is avoidable and the cause of significant performance issues in applications, this behavior is deprecated. If you want to use the debugger to find out what caused this, you can set ENV.RAISE_ON_DEPRECATION to true.");
 
-    view._notifyWillRerender();
+    view.triggerRecursively('willClearRender');
 
     view.clearRenderedChildren();
     view.renderToBuffer(view.buffer, 'replaceWith');
@@ -14717,7 +15798,7 @@ Ember.View.states.inBuffer = {
   appendChild: function(view, childView, options) {
     var buffer = view.buffer;
 
-    childView = this.createChildView(childView, options);
+    childView = view.createChildView(childView, options);
     view._childViews.push(childView);
 
     childView.renderToBuffer(buffer);
@@ -14762,7 +15843,7 @@ Ember.View.states.inBuffer = {
 
     return value;
   }
-};
+});
 
 
 })();
@@ -14777,9 +15858,9 @@ Ember.View.states.inBuffer = {
 
 var get = Ember.get, set = Ember.set, meta = Ember.meta;
 
-Ember.View.states.hasElement = {
-  parentState: Ember.View.states._default,
+var hasElement = Ember.View.states.hasElement = Ember.create(Ember.View.states._default);
 
+Ember.merge(hasElement, {
   $: function(view, sel) {
     var elem = get(view, 'element');
     return sel ? Ember.$(sel, elem) : Ember.$(elem);
@@ -14805,7 +15886,7 @@ Ember.View.states.hasElement = {
   // once the view has been inserted into the DOM, rerendering is
   // deferred to allow bindings to synchronize.
   rerender: function(view) {
-    view._notifyWillRerender();
+    view.triggerRecursively('willClearRender');
 
     view.clearRenderedChildren();
 
@@ -14849,15 +15930,15 @@ Ember.View.states.hasElement = {
       return true; // continue event propagation
     }
   }
-};
+});
 
-Ember.View.states.inDOM = {
-  parentState: Ember.View.states.hasElement,
+var inDOM = Ember.View.states.inDOM = Ember.create(hasElement);
 
+Ember.merge(inDOM, {
   insertElement: function(view, fn) {
     throw "You can't insert an element into the DOM that has already been inserted";
   }
-};
+});
 
 })();
 
@@ -14871,9 +15952,9 @@ Ember.View.states.inDOM = {
 
 var destroyedError = "You can't call %@ on a destroyed view", fmt = Ember.String.fmt;
 
-Ember.View.states.destroyed = {
-  parentState: Ember.View.states._default,
+var destroyed = Ember.View.states.destroyed = Ember.create(Ember.View.states._default);
 
+Ember.merge(destroyed, {
   appendChild: function() {
     throw fmt(destroyedError, ['appendChild']);
   },
@@ -14898,7 +15979,7 @@ Ember.View.states.destroyed = {
   // Since element insertion is scheduled, don't do anything if
   // the view has been destroyed between scheduling and execution
   insertElement: Ember.K
-};
+});
 
 
 })();
@@ -14912,6 +15993,8 @@ Ember.View.states.destroyed = {
 
 
 (function() {
+var states = {};
+
 /**
 @module ember
 @submodule ember-views
@@ -14922,55 +16005,60 @@ var forEach = Ember.EnumerableUtils.forEach;
 
 var childViewsProperty = Ember.computed(function() {
   return get(this, '_childViews');
-}).property('_childViews').cacheable();
+}).property('_childViews');
 
 /**
-  A `ContainerView` is an `Ember.View` subclass that allows for manual or programatic
-  management of a view's `childViews` array that will correctly update the `ContainerView`
-  instance's rendered DOM representation.
+  A `ContainerView` is an `Ember.View` subclass that allows for manual or
+  programatic management of a view's `childViews` array that will correctly
+  update the `ContainerView` instance's rendered DOM representation.
 
   ## Setting Initial Child Views
-  The initial array of child views can be set in one of two ways. You can provide
-  a `childViews` property at creation time that contains instance of `Ember.View`:
 
-  ``` javascript
+  The initial array of child views can be set in one of two ways. You can
+  provide a `childViews` property at creation time that contains instance of
+  `Ember.View`:
+
+  ```javascript
   aContainer = Ember.ContainerView.create({
     childViews: [Ember.View.create(), Ember.View.create()]
   });
   ```
 
-  You can also provide a list of property names whose values are instances of `Ember.View`:
+  You can also provide a list of property names whose values are instances of
+  `Ember.View`:
 
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     childViews: ['aView', 'bView', 'cView'],
     aView: Ember.View.create(),
-    bView: Ember.View.create()
+    bView: Ember.View.create(),
     cView: Ember.View.create()
   });
   ```
 
   The two strategies can be combined:
 
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     childViews: ['aView', Ember.View.create()],
     aView: Ember.View.create()
   });
   ```
 
-  Each child view's rendering will be inserted into the container's rendered HTML in the same
-  order as its position in the `childViews` property.
+  Each child view's rendering will be inserted into the container's rendered
+  HTML in the same order as its position in the `childViews` property.
 
   ## Adding and Removing Child Views
-  The views in a container's `childViews` array should be added and removed by manipulating
-  the `childViews` property directly.
 
-  To remove a view pass that view into a `removeObject` call on the container's `childViews` property.
+  The views in a container's `childViews` array should be added and removed by
+  manipulating the `childViews` property directly.
+
+  To remove a view pass that view into a `removeObject` call on the container's
+  `childViews` property.
 
   Given an empty `<body>` the following code
 
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     classNames: ['the-container'],
     childViews: ['aView', 'bView'],
@@ -14983,11 +16071,11 @@ var childViewsProperty = Ember.computed(function() {
   });
 
   aContainer.appendTo('body');
-  ``` 
+  ```
 
   Results in the HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
     <div class="ember-view">B</div>
@@ -14996,27 +16084,26 @@ var childViewsProperty = Ember.computed(function() {
 
   Removing a view
 
-  ``` javascript
-  aContainer.get('childViews'); // [aContainer.aView, aContainer.bView]
+  ```javascript
+  aContainer.get('childViews');  // [aContainer.aView, aContainer.bView]
   aContainer.get('childViews').removeObject(aContainer.get('bView'));
-  aContainer.get('childViews'); // [aContainer.aView]
+  aContainer.get('childViews');  // [aContainer.aView]
   ```
 
   Will result in the following HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
   </div>
   ```
-
 
   Similarly, adding a child view is accomplished by adding `Ember.View` instances to the
   container's `childViews` property.
 
   Given an empty `<body>` the following code
 
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     classNames: ['the-container'],
     childViews: ['aView', 'bView'],
@@ -15033,7 +16120,7 @@ var childViewsProperty = Ember.computed(function() {
 
   Results in the HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
     <div class="ember-view">B</div>
@@ -15042,19 +16129,19 @@ var childViewsProperty = Ember.computed(function() {
 
   Adding a view
 
-  ``` javascript
+  ```javascript
   AnotherViewClass = Ember.View.extend({
     template: Ember.Handlebars.compile("Another view")
   });
 
-  aContainer.get('childViews'); // [aContainer.aView, aContainer.bView]
+  aContainer.get('childViews');  // [aContainer.aView, aContainer.bView]
   aContainer.get('childViews').pushObject(AnotherViewClass.create());
-  aContainer.get('childViews'); // [aContainer.aView, aContainer.bView, <AnotherViewClass instance>]
+  aContainer.get('childViews');  // [aContainer.aView, aContainer.bView, <AnotherViewClass instance>]
   ```
 
   Will result in the following HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
     <div class="ember-view">B</div>
@@ -15062,21 +16149,21 @@ var childViewsProperty = Ember.computed(function() {
   </div>
   ```
 
+  Direct manipulation of `childViews` presence or absence in the DOM via calls
+  to `remove` or `removeFromParent` or calls to a container's `removeChild` may
+  not behave correctly.
 
-  Direct manipulation of childViews presence or absence in the DOM via calls to
-  `remove` or `removeFromParent` or calls to a container's `removeChild` may not behave
-  correctly.
+  Calling `remove()` on a child view will remove the view's HTML, but it will
+  remain as part of its container's `childView`s property.
 
-  Calling `remove()` on a child view will remove the view's HTML, but it will remain as part of its
-  container's `childView`s property.
+  Calling `removeChild()` on the container will remove the passed view instance
+  from the container's `childView`s but keep its HTML within the container's
+  rendered view.
 
-  Calling `removeChild()` on the container will remove the passed view instance from the container's
-  `childView`s but keep its HTML within the container's rendered view.
+  Calling `removeFromParent()` behaves as expected but should be avoided in
+  favor of direct manipulation of a container's `childViews` property.
 
-  Calling `removeFromParent()` behaves as expected but should be avoided in favor of direct
-  manipulation of a container's `childViews` property.
-
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     classNames: ['the-container'],
     childViews: ['aView', 'bView'],
@@ -15093,16 +16180,17 @@ var childViewsProperty = Ember.computed(function() {
 
   Results in the HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
     <div class="ember-view">B</div>
   </div>
   ```
 
-  Calling `aContainer.get('aView').removeFromParent()` will result in the following HTML
+  Calling `aContainer.get('aView').removeFromParent()` will result in the
+  following HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">B</div>
   </div>
@@ -15113,24 +16201,25 @@ var childViewsProperty = Ember.computed(function() {
 
   ## Templates and Layout
 
-  A `template`, `templateName`, `defaultTemplate`, `layout`, `layoutName` or `defaultLayout`
-  property on a container view will not result in the template or layout being rendered.
-  The HTML contents of a `Ember.ContainerView`'s DOM representation will only be the rendered HTML
-  of its child views.
+  A `template`, `templateName`, `defaultTemplate`, `layout`, `layoutName` or
+  `defaultLayout` property on a container view will not result in the template
+  or layout being rendered. The HTML contents of a `Ember.ContainerView`'s DOM
+  representation will only be the rendered HTML of its child views.
 
   ## Binding a View to Display
 
-  If you would like to display a single view in your ContainerView, you can set its `currentView`
-  property. When the `currentView` property is set to a view instance, it will be added to the
-  ContainerView's `childViews` array. If the `currentView` property is later changed to a
-  different view, the new view will replace the old view. If `currentView` is set to `null`, the
-  last `currentView` will be removed.
+  If you would like to display a single view in your ContainerView, you can set
+  its `currentView` property. When the `currentView` property is set to a view
+  instance, it will be added to the ContainerView's `childViews` array. If the
+  `currentView` property is later changed to a different view, the new view
+  will replace the old view. If `currentView` is set to `null`, the last
+  `currentView` will be removed.
 
-  This functionality is useful for cases where you want to bind the display of a ContainerView to
-  a controller or state manager. For example, you can bind the `currentView` of a container to
-  a controller like this:
+  This functionality is useful for cases where you want to bind the display of
+  a ContainerView to a controller or state manager. For example, you can bind
+  the `currentView` of a container to a controller like this:
 
-  ``` javascript
+  ```javascript
   App.appController = Ember.Object.create({
     view: Ember.View.create({
       templateName: 'person_template'
@@ -15138,7 +16227,7 @@ var childViewsProperty = Ember.computed(function() {
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.ContainerView currentViewBinding="App.appController.view"}}
   ```
 
@@ -15148,6 +16237,7 @@ var childViewsProperty = Ember.computed(function() {
 */
 
 Ember.ContainerView = Ember.View.extend({
+  states: states,
 
   init: function() {
     this._super();
@@ -15200,6 +16290,8 @@ Ember.ContainerView = Ember.View.extend({
     });
   },
 
+  instrumentName: 'render.container',
+
   /**
     @private
 
@@ -15237,7 +16329,7 @@ Ember.ContainerView = Ember.View.extend({
     var changedViews = views.slice(start, start+removed);
     this.initializeViews(changedViews, null, null);
 
-    this.invokeForState('childViewsWillChange', views, start, removed);
+    this.currentState.childViewsWillChange(this, views, start, removed);
   },
 
   /**
@@ -15246,10 +16338,10 @@ Ember.ContainerView = Ember.View.extend({
     When a child view is added, make sure the DOM gets updated appropriately.
 
     If the view has already rendered an element, we tell the child view to
-    create an element and insert it into the DOM. If the enclosing container view
-    has already written to a buffer, but not yet converted that buffer into an
-    element, we insert the string representation of the child into the appropriate
-    place in the buffer.
+    create an element and insert it into the DOM. If the enclosing container
+    view has already written to a buffer, but not yet converted that buffer
+    into an element, we insert the string representation of the child into the
+    appropriate place in the buffer.
 
     @method childViewsDidChange
     @param {Ember.Array} views the array of child views afte the mutation has occurred
@@ -15267,7 +16359,7 @@ Ember.ContainerView = Ember.View.extend({
     this.initializeViews(changedViews, this, get(this, 'templateData'));
 
     // Let the current state handle the changes
-    this.invokeForState('childViewsDidChange', views, start, added);
+    this.currentState.childViewsDidChange(this, views, start, added);
   },
 
   initializeViews: function(views, parentView, templateData) {
@@ -15302,84 +16394,90 @@ Ember.ContainerView = Ember.View.extend({
   }, 'currentView'),
 
   _ensureChildrenAreInDOM: function () {
-    this.invokeForState('ensureChildrenAreInDOM', this);
+    this.currentState.ensureChildrenAreInDOM(this);
   }
 });
 
-// Ember.ContainerView extends the default view states to provide different
-// behavior for childViewsWillChange and childViewsDidChange.
-Ember.ContainerView.states = {
-  parent: Ember.View.states,
+states._default = {};
+states.preRender = Ember.create(states._default);
+states.destroyed = Ember.create(states._default);
+states.inBuffer = Ember.create(states._default);
+states.hasElement = Ember.create(states._default);
+states.inDOM = Ember.create(states.hasElement);
 
-  inBuffer: {
-    childViewsDidChange: function(parentView, views, start, added) {
-      var buffer = parentView.buffer,
-          startWith, prev, prevBuffer, view;
+var viewStates = Ember.View.states, viewState;
 
-      // Determine where to begin inserting the child view(s) in the
-      // render buffer.
-      if (start === 0) {
-        // If views were inserted at the beginning, prepend the first
-        // view to the render buffer, then begin inserting any
-        // additional views at the beginning.
-        view = views[start];
-        startWith = start + 1;
-        view.renderToBuffer(buffer, 'prepend');
-      } else {
-        // Otherwise, just insert them at the same place as the child
-        // views mutation.
-        view = views[start - 1];
-        startWith = start;
-      }
+for (var stateName in viewStates) {
+  if (!viewStates.hasOwnProperty(stateName)) { continue; }
+  Ember.merge(states[stateName], viewStates[stateName]);
+}
 
-      for (var i=startWith; i<start+added; i++) {
-        prev = view;
-        view = views[i];
-        prevBuffer = prev.buffer;
-        view.renderToBuffer(prevBuffer, 'insertAfter');
-      }
+Ember.merge(states._default, {
+  childViewsWillChange: Ember.K,
+  childViewsDidChange: Ember.K,
+  ensureChildrenAreInDOM: Ember.K
+});
+
+Ember.merge(states.inBuffer, {
+  childViewsDidChange: function(parentView, views, start, added) {
+    var buffer = parentView.buffer,
+        startWith, prev, prevBuffer, view;
+
+    // Determine where to begin inserting the child view(s) in the
+    // render buffer.
+    if (start === 0) {
+      // If views were inserted at the beginning, prepend the first
+      // view to the render buffer, then begin inserting any
+      // additional views at the beginning.
+      view = views[start];
+      startWith = start + 1;
+      view.renderToBuffer(buffer, 'prepend');
+    } else {
+      // Otherwise, just insert them at the same place as the child
+      // views mutation.
+      view = views[start - 1];
+      startWith = start;
+    }
+
+    for (var i=startWith; i<start+added; i++) {
+      prev = view;
+      view = views[i];
+      prevBuffer = prev.buffer;
+      view.renderToBuffer(prevBuffer, 'insertAfter');
+    }
+  }
+});
+
+Ember.merge(states.hasElement, {
+  childViewsWillChange: function(view, views, start, removed) {
+    for (var i=start; i<start+removed; i++) {
+      views[i].remove();
     }
   },
 
-  hasElement: {
-    childViewsWillChange: function(view, views, start, removed) {
-      for (var i=start; i<start+removed; i++) {
-        views[i].remove();
-      }
-    },
+  childViewsDidChange: function(view, views, start, added) {
+    Ember.run.scheduleOnce('render', view, '_ensureChildrenAreInDOM');
+  },
 
-    childViewsDidChange: function(view, views, start, added) {
-      Ember.run.scheduleOnce('render', this, '_ensureChildrenAreInDOM');
-    },
-
-    ensureChildrenAreInDOM: function(view) {
-      var childViews = view.get('childViews'), i, len, childView, previous, buffer;
-      for (i = 0, len = childViews.length; i < len; i++) {
-        childView = childViews[i];
-        buffer = childView.renderToBufferIfNeeded();
-        if (buffer) {
-          childView._notifyWillInsertElement();
-          if (previous) {
-            previous.domManager.after(previous, buffer.string());
-          } else {
-            view.domManager.prepend(view, buffer.string());
-          }
-          childView.transitionTo('inDOM');
-          childView.propertyDidChange('element');
-          childView._notifyDidInsertElement();
+  ensureChildrenAreInDOM: function(view) {
+    var childViews = view.get('childViews'), i, len, childView, previous, buffer;
+    for (i = 0, len = childViews.length; i < len; i++) {
+      childView = childViews[i];
+      buffer = childView.renderToBufferIfNeeded();
+      if (buffer) {
+        childView.triggerRecursively('willInsertElement');
+        if (previous) {
+          previous.domManager.after(previous, buffer.string());
+        } else {
+          view.domManager.prepend(view, buffer.string());
         }
-        previous = childView;
+        childView.transitionTo('inDOM');
+        childView.propertyDidChange('element');
+        childView.triggerRecursively('didInsertElement');
       }
+      previous = childView;
     }
   }
-};
-
-Ember.ContainerView.states.inDOM = {
-  parentState: Ember.ContainerView.states.hasElement
-};
-
-Ember.ContainerView.reopen({
-  states: Ember.ContainerView.states
 });
 
 })();
@@ -15395,17 +16493,18 @@ Ember.ContainerView.reopen({
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
 /**
-  `Ember.CollectionView` is an `Ember.View` descendent responsible for managing a
-  collection (an array or array-like object) by maintaing a child view object and 
-  associated DOM representation for each item in the array and ensuring that child
-  views and their associated rendered HTML are updated when items in the array
-  are added, removed, or replaced.
+  `Ember.CollectionView` is an `Ember.View` descendent responsible for managing
+  a collection (an array or array-like object) by maintaing a child view object
+  and associated DOM representation for each item in the array and ensuring
+  that child views and their associated rendered HTML are updated when items in
+  the array are added, removed, or replaced.
 
   ## Setting content
-  The managed collection of objects is referenced as the `Ember.CollectionView` instance's
-  `content` property.
 
-  ``` javascript
+  The managed collection of objects is referenced as the `Ember.CollectionView`
+  instance's `content` property.
+
+  ```javascript
   someItemsView = Ember.CollectionView.create({
     content: ['A', 'B','C']
   })
@@ -15415,13 +16514,14 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   to the item.
 
   ## Specifying itemViewClass
-  By default the view class for each item in the managed collection will be an instance
-  of `Ember.View`. You can supply a different class by setting the `CollectionView`'s
-  `itemViewClass` property.
+
+  By default the view class for each item in the managed collection will be an
+  instance of `Ember.View`. You can supply a different class by setting the
+  `CollectionView`'s `itemViewClass` property.
 
   Given an empty `<body>` and the following code:
 
-  ``` javascript 
+  ```javascript 
   someItemsView = Ember.CollectionView.create({
     classNames: ['a-collection'],
     content: ['A','B','C'],
@@ -15435,7 +16535,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
   Will result in the following HTML structure
 
-  ``` html
+  ```html
   <div class="ember-view a-collection">
     <div class="ember-view">the letter: A</div>
     <div class="ember-view">the letter: B</div>
@@ -15445,14 +16545,13 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
   ## Automatic matching of parent/child tagNames
 
-  Setting the `tagName` property of a `CollectionView` to any of 
+  Setting the `tagName` property of a `CollectionView` to any of
   "ul", "ol", "table", "thead", "tbody", "tfoot", "tr", or "select" will result
   in the item views receiving an appropriately matched `tagName` property.
 
-
   Given an empty `<body>` and the following code:
 
-  ``` javascript
+  ```javascript
   anUndorderedListView = Ember.CollectionView.create({
     tagName: 'ul',
     content: ['A','B','C'],
@@ -15466,7 +16565,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
   Will result in the following HTML structure
 
-  ``` html
+  ```html
   <ul class="ember-view a-collection">
     <li class="ember-view">the letter: A</li>
     <li class="ember-view">the letter: B</li>
@@ -15474,19 +16573,40 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   </ul>
   ```
 
-  Additional tagName pairs can be provided by adding to `Ember.CollectionView.CONTAINER_MAP `
+  Additional `tagName` pairs can be provided by adding to
+  `Ember.CollectionView.CONTAINER_MAP `
 
-  ``` javascript
+  ```javascript
   Ember.CollectionView.CONTAINER_MAP['article'] = 'section'
   ```
 
+  ## Programatic creation of child views
+
+  For cases where additional customization beyond the use of a single
+  `itemViewClass` or `tagName` matching is required CollectionView's
+  `createChildView` method can be overidden:
+
+  ```javascript
+  CustomCollectionView = Ember.CollectionView.extend({
+    createChildView: function(viewClass, attrs) {
+      if (attrs.content.kind == 'album') {
+        viewClass = App.AlbumView;
+      } else {
+        viewClass = App.SongView;
+      }
+      this._super(viewClass, attrs);
+    }
+  });
+  ```
 
   ## Empty View
-  You can provide an `Ember.View` subclass to the `Ember.CollectionView` instance as its
-  `emptyView` property. If the `content` property of a `CollectionView` is set to `null`
-  or an empty array, an instance of this view will be the `CollectionView`s only child.
 
-  ``` javascript
+  You can provide an `Ember.View` subclass to the `Ember.CollectionView`
+  instance as its `emptyView` property. If the `content` property of a
+  `CollectionView` is set to `null` or an empty array, an instance of this view
+  will be the `CollectionView`s only child.
+
+  ```javascript
   aListWithNothing = Ember.CollectionView.create({
     classNames: ['nothing']
     content: null,
@@ -15500,7 +16620,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
   Will result in the following HTML structure
 
-  ``` html
+  ```html
   <div class="ember-view nothing">
     <div class="ember-view">
       The collection is empty
@@ -15509,13 +16629,16 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   ```
 
   ## Adding and Removing items
-  The `childViews` property of a `CollectionView` should not be directly manipulated. Instead,
-  add, remove, replace items from its `content` property. This will trigger
-  appropriate changes to its rendered HTML.
 
-  ## Use in templates via the `{{collection}}` Ember.Handlebars helper
-  Ember.Handlebars provides a helper specifically for adding `CollectionView`s to templates.
-  See `Ember.Handlebars.collection` for more details
+  The `childViews` property of a `CollectionView` should not be directly
+  manipulated. Instead, add, remove, replace items from its `content` property.
+  This will trigger appropriate changes to its rendered HTML.
+
+  ## Use in templates via the `{{collection}}` `Ember.Handlebars` helper
+
+  `Ember.Handlebars` provides a helper specifically for adding
+  `CollectionView`s to templates. See `Ember.Handlebars.collection` for more
+  details
 
   @class CollectionView
   @namespace Ember
@@ -15526,7 +16649,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
 /** @scope Ember.CollectionView.prototype */ {
 
   /**
-    A list of items to be displayed by the Ember.CollectionView.
+    A list of items to be displayed by the `Ember.CollectionView`.
 
     @property content
     @type Ember.Array
@@ -15622,7 +16745,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
     var removingAll = removedCount === len;
 
     if (removingAll) {
-      this.invokeForState('empty');
+      this.currentState.empty(this);
     }
 
     for (idx = start + removedCount - 1; idx >= start; idx--) {
@@ -15636,9 +16759,9 @@ Ember.CollectionView = Ember.ContainerView.extend(
     Called when a mutation to the underlying content array occurs.
 
     This method will replay that mutation against the views that compose the
-    Ember.CollectionView, ensuring that the view reflects the model.
+    `Ember.CollectionView`, ensuring that the view reflects the model.
 
-    This array observer is added in contentDidChange.
+    This array observer is added in `contentDidChange`.
 
     @method arrayDidChange
     @param {Array} addedObjects the objects that were added to the content
@@ -15785,12 +16908,12 @@ Ember.State = Ember.Object.extend(Ember.Evented,
     }
 
     return path;
-  }).property().cacheable(),
+  }).property(),
 
   /**
     @private
 
-    Override the default event firing from Ember.Evented to
+    Override the default event firing from `Ember.Evented` to
     also call methods with the given name.
 
     @method trigger
@@ -15874,7 +16997,7 @@ Ember.State = Ember.Object.extend(Ember.Evented,
 
   /**
     A Boolean value indicating whether the state is a leaf state
-    in the state hierarchy. This is false if the state has child
+    in the state hierarchy. This is `false` if the state has child
     states; otherwise it is true.
 
     @property isLeaf
@@ -15882,7 +17005,7 @@ Ember.State = Ember.Object.extend(Ember.Evented,
   */
   isLeaf: Ember.computed(function() {
     return !get(this, 'childStates').length;
-  }).cacheable(),
+  }),
 
   /**
     A boolean value indicating whether the state takes a context.
@@ -15920,56 +17043,61 @@ Ember.State = Ember.Object.extend(Ember.Evented,
   exit: Ember.K
 });
 
-var Event = Ember.$ && Ember.$.Event;
-
-Ember.State.reopenClass(
-/** @scope Ember.State */{
+Ember.State.reopenClass({
 
   /**
-  Creates an action function for transitioning to the named state while preserving context.
+    Creates an action function for transitioning to the named state while
+    preserving context.
 
-  The following example StateManagers are equivalent:
+    The following example StateManagers are equivalent:
 
-      aManager = Ember.StateManager.create({
-        stateOne: Ember.State.create({
-          changeToStateTwo: Ember.State.transitionTo('stateTwo')
-        }),
-        stateTwo: Ember.State.create({})
-      })
+    ```javascript
+    aManager = Ember.StateManager.create({
+      stateOne: Ember.State.create({
+        changeToStateTwo: Ember.State.transitionTo('stateTwo')
+      }),
+      stateTwo: Ember.State.create({})
+    })
 
-      bManager = Ember.StateManager.create({
-        stateOne: Ember.State.create({
-          changeToStateTwo: function(manager, context){
-            manager.transitionTo('stateTwo', context)
-          }
-        }),
-        stateTwo: Ember.State.create({})
-      })
+    bManager = Ember.StateManager.create({
+      stateOne: Ember.State.create({
+        changeToStateTwo: function(manager, context){
+          manager.transitionTo('stateTwo', context)
+        }
+      }),
+      stateTwo: Ember.State.create({})
+    })
+    ```
 
-  @method transitionTo
-  @static
-  @param {String} target
+    @method transitionTo
+    @static
+    @param {String} target
   */
+
   transitionTo: function(target) {
-    var event = function(stateManager, context) {
-      if (Event && context instanceof Event) {
-        if (context.hasOwnProperty('context')) {
-          context = context.context;
-        } else {
-          // If we received an event and it doesn't contain
-          // a context, don't pass along a superfluous
-          // context to the target of the event.
-          return stateManager.transitionTo(target);
+
+    var transitionFunction = function(stateManager, contextOrEvent) {
+      var contexts = [], transitionArgs,
+          Event = Ember.$ && Ember.$.Event;
+
+      if (contextOrEvent && (Event && contextOrEvent instanceof Event)) {
+        if (contextOrEvent.hasOwnProperty('contexts')) {
+          contexts = contextOrEvent.contexts.slice();
         }
       }
+      else {
+        contexts = [].slice.call(arguments, 1);
+      }
 
-      stateManager.transitionTo(target, context);
+      contexts.unshift(target);
+      stateManager.transitionTo.apply(stateManager, contexts);
     };
 
-    event.transitionTarget = target;
+    transitionFunction.transitionTarget = target;
 
-    return event;
+    return transitionFunction;
   }
+
 });
 
 })();
@@ -16143,370 +17271,482 @@ Transition.prototype = {
   }
 };
 
+var sendRecursively = function(event, currentState, isUnhandledPass) {
+  var log = this.enableLogging,
+      eventName = isUnhandledPass ? 'unhandledEvent' : event,
+      action = currentState[eventName],
+      contexts, sendRecursiveArguments, actionArguments;
+
+  contexts = [].slice.call(arguments, 3);
+
+  // Test to see if the action is a method that
+  // can be invoked. Don't blindly check just for
+  // existence, because it is possible the state
+  // manager has a child state of the given name,
+  // and we should still raise an exception in that
+  // case.
+  if (typeof action === 'function') {
+    if (log) {
+      if (isUnhandledPass) {
+        Ember.Logger.log(fmt("STATEMANAGER: Unhandled event '%@' being sent to state %@.", [event, get(currentState, 'path')]));
+      } else {
+        Ember.Logger.log(fmt("STATEMANAGER: Sending event '%@' to state %@.", [event, get(currentState, 'path')]));
+      }
+    }
+
+    actionArguments = contexts;
+    if (isUnhandledPass) {
+      actionArguments.unshift(event);
+    }
+    actionArguments.unshift(this);
+
+    return action.apply(currentState, actionArguments);
+  } else {
+    var parentState = get(currentState, 'parentState');
+    if (parentState) {
+
+      sendRecursiveArguments = contexts;
+      sendRecursiveArguments.unshift(event, parentState, isUnhandledPass);
+
+      return sendRecursively.apply(this, sendRecursiveArguments);
+    } else if (!isUnhandledPass) {
+      return sendEvent.call(this, event, contexts, true);
+    }
+  }
+};
+
+var sendEvent = function(eventName, sendRecursiveArguments, isUnhandledPass) {
+  sendRecursiveArguments.unshift(eventName, get(this, 'currentState'), isUnhandledPass);
+  return sendRecursively.apply(this, sendRecursiveArguments);
+};
+
 /**
-  StateManager is part of Ember's implementation of a finite state machine. A StateManager
-  instance manages a number of properties that are instances of `Ember.State`,
+  StateManager is part of Ember's implementation of a finite state machine. A
+  StateManager instance manages a number of properties that are instances of
+  `Ember.State`,
   tracks the current active state, and triggers callbacks when states have changed.
 
   ## Defining States
 
-  The states of StateManager can be declared in one of two ways. First, you can define
-  a `states` property that contains all the states:
+  The states of StateManager can be declared in one of two ways. First, you can
+  define a `states` property that contains all the states:
 
-      managerA = Ember.StateManager.create({
-        states: {
-          stateOne: Ember.State.create(),
-          stateTwo: Ember.State.create()
-        }
-      })
+  ```javascript
+  managerA = Ember.StateManager.create({
+    states: {
+      stateOne: Ember.State.create(),
+      stateTwo: Ember.State.create()
+    }
+  })
 
-      managerA.get('states')
-      // {
-      //   stateOne: Ember.State.create(),
-      //   stateTwo: Ember.State.create()
-      // }
+  managerA.get('states')
+  // {
+  //   stateOne: Ember.State.create(),
+  //   stateTwo: Ember.State.create()
+  // }
+  ```
 
-  You can also add instances of `Ember.State` (or an `Ember.State` subclass) directly as properties
-  of a StateManager. These states will be collected into the `states` property for you.
+  You can also add instances of `Ember.State` (or an `Ember.State` subclass)
+  directly as properties of a StateManager. These states will be collected into
+  the `states` property for you.
 
-      managerA = Ember.StateManager.create({
-        stateOne: Ember.State.create(),
-        stateTwo: Ember.State.create()
-      })
+  ```javascript
+  managerA = Ember.StateManager.create({
+    stateOne: Ember.State.create(),
+    stateTwo: Ember.State.create()
+  })
 
-      managerA.get('states')
-      // {
-      //   stateOne: Ember.State.create(),
-      //   stateTwo: Ember.State.create()
-      // }
+  managerA.get('states')
+  // {
+  //   stateOne: Ember.State.create(),
+  //   stateTwo: Ember.State.create()
+  // }
+  ```
 
   ## The Initial State
+
   When created a StateManager instance will immediately enter into the state
   defined as its `start` property or the state referenced by name in its
   `initialState` property:
 
-      managerA = Ember.StateManager.create({
-        start: Ember.State.create({})
-      })
+  ```javascript
+  managerA = Ember.StateManager.create({
+    start: Ember.State.create({})
+  })
 
-      managerA.get('currentState.name') // 'start'
+  managerA.get('currentState.name') // 'start'
 
-      managerB = Ember.StateManager.create({
-        initialState: 'beginHere',
-        beginHere: Ember.State.create({})
-      })
+  managerB = Ember.StateManager.create({
+    initialState: 'beginHere',
+    beginHere: Ember.State.create({})
+  })
 
-      managerB.get('currentState.name') // 'beginHere'
+  managerB.get('currentState.name') // 'beginHere'
+  ```
 
-  Because it is a property you may also provide a computed function if you wish to derive
-  an `initialState` programmatically:
+  Because it is a property you may also provide a computed function if you wish
+  to derive an `initialState` programmatically:
 
-      managerC = Ember.StateManager.create({
-        initialState: function(){
-          if (someLogic) {
-            return 'active';
-          } else {
-            return 'passive';
-          }
-        }.property(),
-        active: Ember.State.create({}),
-        passive: Ember.State.create({})
-      })
+  ```javascript
+  managerC = Ember.StateManager.create({
+    initialState: function(){
+      if (someLogic) {
+        return 'active';
+      } else {
+        return 'passive';
+      }
+    }.property(),
+    active: Ember.State.create({}),
+    passive: Ember.State.create({})
+  })
+  ```
 
   ## Moving Between States
-  A StateManager can have any number of Ember.State objects as properties
+
+  A StateManager can have any number of `Ember.State` objects as properties
   and can have a single one of these states as its current state.
 
   Calling `transitionTo` transitions between states:
 
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({}),
-        poweredUp: Ember.State.create({})
-      })
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({}),
+    poweredUp: Ember.State.create({})
+  })
 
-      robotManager.get('currentState.name') // 'poweredDown'
-      robotManager.transitionTo('poweredUp')
-      robotManager.get('currentState.name') // 'poweredUp'
+  robotManager.get('currentState.name') // 'poweredDown'
+  robotManager.transitionTo('poweredUp')
+  robotManager.get('currentState.name') // 'poweredUp'
+  ```
 
-  Before transitioning into a new state the existing `currentState` will have its
-  `exit` method called with the StateManager instance as its first argument and
-  an object representing the transition as its second argument.
+  Before transitioning into a new state the existing `currentState` will have
+  its `exit` method called with the StateManager instance as its first argument
+  and an object representing the transition as its second argument.
 
   After transitioning into a new state the new `currentState` will have its
-  `enter` method called with the StateManager instance as its first argument and
-  an object representing the transition as its second argument.
+  `enter` method called with the StateManager instance as its first argument
+  and an object representing the transition as its second argument.
 
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({
-          exit: function(stateManager){
-            console.log("exiting the poweredDown state")
-          }
-        }),
-        poweredUp: Ember.State.create({
-          enter: function(stateManager){
-            console.log("entering the poweredUp state. Destroy all humans.")
-          }
-        })
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({
+      exit: function(stateManager){
+        console.log("exiting the poweredDown state")
+      }
+    }),
+    poweredUp: Ember.State.create({
+      enter: function(stateManager){
+        console.log("entering the poweredUp state. Destroy all humans.")
+      }
+    })
+  })
+
+  robotManager.get('currentState.name') // 'poweredDown'
+  robotManager.transitionTo('poweredUp')
+
+  // will log
+  // 'exiting the poweredDown state'
+  // 'entering the poweredUp state. Destroy all humans.'
+  ```
+
+  Once a StateManager is already in a state, subsequent attempts to enter that
+  state will not trigger enter or exit method calls. Attempts to transition
+  into a state that the manager does not have will result in no changes in the
+  StateManager's current state:
+
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({
+      exit: function(stateManager){
+        console.log("exiting the poweredDown state")
+      }
+    }),
+    poweredUp: Ember.State.create({
+      enter: function(stateManager){
+        console.log("entering the poweredUp state. Destroy all humans.")
+      }
+    })
+  })
+
+  robotManager.get('currentState.name') // 'poweredDown'
+  robotManager.transitionTo('poweredUp')
+  // will log
+  // 'exiting the poweredDown state'
+  // 'entering the poweredUp state. Destroy all humans.'
+  robotManager.transitionTo('poweredUp') // no logging, no state change
+
+  robotManager.transitionTo('someUnknownState') // silently fails
+  robotManager.get('currentState.name') // 'poweredUp'
+  ```
+
+  Each state property may itself contain properties that are instances of
+  `Ember.State`. The StateManager can transition to specific sub-states in a
+  series of transitionTo method calls or via a single transitionTo with the
+  full path to the specific state. The StateManager will also keep track of the
+  full path to its currentState
+
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({
+      charging: Ember.State.create(),
+      charged: Ember.State.create()
+    }),
+    poweredUp: Ember.State.create({
+      mobile: Ember.State.create(),
+      stationary: Ember.State.create()
+    })
+  })
+
+  robotManager.get('currentState.name') // 'poweredDown'
+
+  robotManager.transitionTo('poweredUp')
+  robotManager.get('currentState.name') // 'poweredUp'
+
+  robotManager.transitionTo('mobile')
+  robotManager.get('currentState.name') // 'mobile'
+
+  // transition via a state path
+  robotManager.transitionTo('poweredDown.charging')
+  robotManager.get('currentState.name') // 'charging'
+
+  robotManager.get('currentState.path') // 'poweredDown.charging'
+  ```
+
+  Enter transition methods will be called for each state and nested child state
+  in their hierarchical order. Exit methods will be called for each state and
+  its nested states in reverse hierarchical order.
+
+  Exit transitions for a parent state are not called when entering into one of
+  its child states, only when transitioning to a new section of possible states
+  in the hierarchy.
+
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({
+      enter: function(){},
+      exit: function(){
+        console.log("exited poweredDown state")
+      },
+      charging: Ember.State.create({
+        enter: function(){},
+        exit: function(){}
+      }),
+      charged: Ember.State.create({
+        enter: function(){
+          console.log("entered charged state")
+        },
+        exit: function(){
+          console.log("exited charged state")
+        }
       })
-
-      robotManager.get('currentState.name') // 'poweredDown'
-      robotManager.transitionTo('poweredUp')
-      // will log
-      // 'exiting the poweredDown state'
-      // 'entering the poweredUp state. Destroy all humans.'
-
-
-  Once a StateManager is already in a state, subsequent attempts to enter that state will
-  not trigger enter or exit method calls. Attempts to transition into a state that the
-  manager does not have will result in no changes in the StateManager's current state:
-
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({
-          exit: function(stateManager){
-            console.log("exiting the poweredDown state")
-          }
-        }),
-        poweredUp: Ember.State.create({
-          enter: function(stateManager){
-            console.log("entering the poweredUp state. Destroy all humans.")
-          }
-        })
+    }),
+    poweredUp: Ember.State.create({
+      enter: function(){
+        console.log("entered poweredUp state")
+      },
+      exit: function(){},
+      mobile: Ember.State.create({
+        enter: function(){
+          console.log("entered mobile state")
+        },
+        exit: function(){}
+      }),
+      stationary: Ember.State.create({
+        enter: function(){},
+        exit: function(){}
       })
-
-      robotManager.get('currentState.name') // 'poweredDown'
-      robotManager.transitionTo('poweredUp')
-      // will log
-      // 'exiting the poweredDown state'
-      // 'entering the poweredUp state. Destroy all humans.'
-      robotManager.transitionTo('poweredUp') // no logging, no state change
-
-      robotManager.transitionTo('someUnknownState') // silently fails
-      robotManager.get('currentState.name') // 'poweredUp'
+    })
+  })
 
 
-  Each state property may itself contain properties that are instances of Ember.State.
-  The StateManager can transition to specific sub-states in a series of transitionTo method calls or
-  via a single transitionTo with the full path to the specific state. The StateManager will also
-  keep track of the full path to its currentState
+  robotManager.get('currentState.path') // 'poweredDown'
+  robotManager.transitionTo('charged')
+  // logs 'entered charged state'
+  // but does *not* log  'exited poweredDown state'
+  robotManager.get('currentState.name') // 'charged
 
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({
-          charging: Ember.State.create(),
-          charged: Ember.State.create()
-        }),
-        poweredUp: Ember.State.create({
-          mobile: Ember.State.create(),
-          stationary: Ember.State.create()
-        })
-      })
+  robotManager.transitionTo('poweredUp.mobile')
+  // logs
+  // 'exited charged state'
+  // 'exited poweredDown state'
+  // 'entered poweredUp state'
+  // 'entered mobile state'
+  ```
 
-      robotManager.get('currentState.name') // 'poweredDown'
+  During development you can set a StateManager's `enableLogging` property to
+  `true` to receive console messages of state transitions.
 
-      robotManager.transitionTo('poweredUp')
-      robotManager.get('currentState.name') // 'poweredUp'
-
-      robotManager.transitionTo('mobile')
-      robotManager.get('currentState.name') // 'mobile'
-
-      // transition via a state path
-      robotManager.transitionTo('poweredDown.charging')
-      robotManager.get('currentState.name') // 'charging'
-
-      robotManager.get('currentState.path') // 'poweredDown.charging'
-
-  Enter transition methods will be called for each state and nested child state in their
-  hierarchical order.  Exit methods will be called for each state and its nested states in
-  reverse hierarchical order.
-
-  Exit transitions for a parent state are not called when entering into one of its child states,
-  only when transitioning to a new section of possible states in the hierarchy.
-
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({
-          enter: function(){},
-          exit: function(){
-            console.log("exited poweredDown state")
-          },
-          charging: Ember.State.create({
-            enter: function(){},
-            exit: function(){}
-          }),
-          charged: Ember.State.create({
-            enter: function(){
-              console.log("entered charged state")
-            },
-            exit: function(){
-              console.log("exited charged state")
-            }
-          })
-        }),
-        poweredUp: Ember.State.create({
-          enter: function(){
-            console.log("entered poweredUp state")
-          },
-          exit: function(){},
-          mobile: Ember.State.create({
-            enter: function(){
-              console.log("entered mobile state")
-            },
-            exit: function(){}
-          }),
-          stationary: Ember.State.create({
-            enter: function(){},
-            exit: function(){}
-          })
-        })
-      })
-
-
-      robotManager.get('currentState.path') // 'poweredDown'
-      robotManager.transitionTo('charged')
-      // logs 'entered charged state'
-      // but does *not* log  'exited poweredDown state'
-      robotManager.get('currentState.name') // 'charged
-
-      robotManager.transitionTo('poweredUp.mobile')
-      // logs
-      // 'exited charged state'
-      // 'exited poweredDown state'
-      // 'entered poweredUp state'
-      // 'entered mobile state'
-
-  During development you can set a StateManager's `enableLogging` property to `true` to
-  receive console messages of state transitions.
-
-      robotManager = Ember.StateManager.create({
-        enableLogging: true
-      })
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    enableLogging: true
+  })
+  ```
 
   ## Managing currentState with Actions
-  To control which transitions between states are possible for a given state, StateManager
-  can receive and route action messages to its states via the `send` method.  Calling to `send` with
-  an action name will begin searching for a method with the same name starting at the current state
-  and moving up through the parent states in a state hierarchy until an appropriate method is found
-  or the StateManager instance itself is reached.
 
-  If an appropriately named method is found it will be called with the state manager as the first
-  argument and an optional `context` object as the second argument.
+  To control which transitions are possible for a given state, and
+  appropriately handle external events, the StateManager can receive and
+  route action messages to its states via the `send` method. Calling to
+  `send` with an action name will begin searching for a method with the same
+  name starting at the current state and moving up through the parent states
+  in a state hierarchy until an appropriate method is found or the StateManager
+  instance itself is reached.
 
-      managerA = Ember.StateManager.create({
-        initialState: 'stateOne.substateOne.subsubstateOne',
-        stateOne: Ember.State.create({
-          substateOne: Ember.State.create({
-            anAction: function(manager, context){
-              console.log("an action was called")
-            },
-            subsubstateOne: Ember.State.create({})
-          })
-        })
+  If an appropriately named method is found it will be called with the state
+  manager as the first argument and an optional `context` object as the second
+  argument.
+
+  ```javascript
+  managerA = Ember.StateManager.create({
+    initialState: 'stateOne.substateOne.subsubstateOne',
+    stateOne: Ember.State.create({
+      substateOne: Ember.State.create({
+        anAction: function(manager, context){
+          console.log("an action was called")
+        },
+        subsubstateOne: Ember.State.create({})
       })
+    })
+  })
 
-      managerA.get('currentState.name') // 'subsubstateOne'
-      managerA.send('anAction')
-      // 'stateOne.substateOne.subsubstateOne' has no anAction method
-      // so the 'anAction' method of 'stateOne.substateOne' is called
-      // and logs "an action was called"
-      // with managerA as the first argument
-      // and no second argument
+  managerA.get('currentState.name') // 'subsubstateOne'
+  managerA.send('anAction')
+  // 'stateOne.substateOne.subsubstateOne' has no anAction method
+  // so the 'anAction' method of 'stateOne.substateOne' is called
+  // and logs "an action was called"
+  // with managerA as the first argument
+  // and no second argument
 
-      someObject = {}
-      managerA.send('anAction', someObject)
-      // the 'anAction' method of 'stateOne.substateOne' is called again
-      // with managerA as the first argument and
-      // someObject as the second argument.
-
+  someObject = {}
+  managerA.send('anAction', someObject)
+  // the 'anAction' method of 'stateOne.substateOne' is called again
+  // with managerA as the first argument and
+  // someObject as the second argument.
+  ```
 
   If the StateManager attempts to send an action but does not find an appropriately named
-  method in the current state or while moving upwards through the state hierarchy
-  it will throw a new Ember.Error. Action detection only moves upwards through the state hierarchy
-  from the current state. It does not search in other portions of the hierarchy.
+  method in the current state or while moving upwards through the state hierarchy, it will
+  repeat the process looking for a `unhandledEvent` method. If an `unhandledEvent` method is
+  found, it will be called with the original event name as the second argument. If an
+  `unhandledEvent` method is not found, the StateManager will throw a new Ember.Error.
 
-      managerB = Ember.StateManager.create({
-        initialState: 'stateOne.substateOne.subsubstateOne',
-        stateOne: Ember.State.create({
-          substateOne: Ember.State.create({
-            subsubstateOne: Ember.State.create({})
-          })
-        }),
-        stateTwo: Ember.State.create({
-         anAction: function(manager, context){
-           // will not be called below because it is
-           // not a parent of the current state
-         }
-        })
+  ```javascript
+  managerB = Ember.StateManager.create({
+    initialState: 'stateOne.substateOne.subsubstateOne',
+    stateOne: Ember.State.create({
+      substateOne: Ember.State.create({
+        subsubstateOne: Ember.State.create({}),
+        unhandledEvent: function(manager, eventName, context) {
+          console.log("got an unhandledEvent with name " + eventName);
+        }
       })
+    })
+  })
 
-      managerB.get('currentState.name') // 'subsubstateOne'
-      managerB.send('anAction')
-      // Error: <Ember.StateManager:ember132> could not
-      // respond to event anAction in state stateOne.substateOne.subsubstateOne.
+  managerB.get('currentState.name') // 'subsubstateOne'
+  managerB.send('anAction')
+  // neither `stateOne.substateOne.subsubstateOne` nor any of it's
+  // parent states have a handler for `anAction`. `subsubstateOne`
+  // also does not have a `unhandledEvent` method, but its parent
+  // state, `substateOne`, does, and it gets fired. It will log
+  // "got an unhandledEvent with name anAction"
+  ```
+
+  Action detection only moves upwards through the state hierarchy from the current state.
+  It does not search in other portions of the hierarchy.
+
+  ```javascript
+  managerC = Ember.StateManager.create({
+    initialState: 'stateOne.substateOne.subsubstateOne',
+    stateOne: Ember.State.create({
+      substateOne: Ember.State.create({
+        subsubstateOne: Ember.State.create({})
+      })
+    }),
+    stateTwo: Ember.State.create({
+     anAction: function(manager, context){
+       // will not be called below because it is
+       // not a parent of the current state
+     }
+    })
+  })
+
+  managerC.get('currentState.name') // 'subsubstateOne'
+  managerC.send('anAction')
+  // Error: <Ember.StateManager:ember132> could not
+  // respond to event anAction in state stateOne.substateOne.subsubstateOne.
+  ```
 
   Inside of an action method the given state should delegate `transitionTo` calls on its
   StateManager.
 
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown.charging',
-        poweredDown: Ember.State.create({
-          charging: Ember.State.create({
-            chargeComplete: function(manager, context){
-              manager.transitionTo('charged')
-            }
-          }),
-          charged: Ember.State.create({
-            boot: function(manager, context){
-              manager.transitionTo('poweredUp')
-            }
-          })
-        }),
-        poweredUp: Ember.State.create({
-          beginExtermination: function(manager, context){
-            manager.transitionTo('rampaging')
-          },
-          rampaging: Ember.State.create()
-        })
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown.charging',
+    poweredDown: Ember.State.create({
+      charging: Ember.State.create({
+        chargeComplete: function(manager, context){
+          manager.transitionTo('charged')
+        }
+      }),
+      charged: Ember.State.create({
+        boot: function(manager, context){
+          manager.transitionTo('poweredUp')
+        }
       })
+    }),
+    poweredUp: Ember.State.create({
+      beginExtermination: function(manager, context){
+        manager.transitionTo('rampaging')
+      },
+      rampaging: Ember.State.create()
+    })
+  })
 
-      robotManager.get('currentState.name') // 'charging'
-      robotManager.send('boot') // throws error, no boot action
-                                // in current hierarchy
-      robotManager.get('currentState.name') // remains 'charging'
+  robotManager.get('currentState.name') // 'charging'
+  robotManager.send('boot') // throws error, no boot action
+                            // in current hierarchy
+  robotManager.get('currentState.name') // remains 'charging'
 
-      robotManager.send('beginExtermination') // throws error, no beginExtermination
-                                              // action in current hierarchy
-      robotManager.get('currentState.name') // remains 'charging'
+  robotManager.send('beginExtermination') // throws error, no beginExtermination
+                                          // action in current hierarchy
+  robotManager.get('currentState.name')   // remains 'charging'
 
-      robotManager.send('chargeComplete')
-      robotManager.get('currentState.name') // 'charged'
+  robotManager.send('chargeComplete')
+  robotManager.get('currentState.name')   // 'charged'
 
-      robotManager.send('boot')
-      robotManager.get('currentState.name') // 'poweredUp'
+  robotManager.send('boot')
+  robotManager.get('currentState.name')   // 'poweredUp'
 
-      robotManager.send('beginExtermination', allHumans)
-      robotManager.get('currentState.name') // 'rampaging'
+  robotManager.send('beginExtermination', allHumans)
+  robotManager.get('currentState.name')   // 'rampaging'
+  ```
 
-  Transition actions can also be created using the `transitionTo` method of the Ember.State class. The
+  Transition actions can also be created using the `transitionTo` method of the `Ember.State` class. The
   following example StateManagers are equivalent:
 
-      aManager = Ember.StateManager.create({
-        stateOne: Ember.State.create({
-          changeToStateTwo: Ember.State.transitionTo('stateTwo')
-        }),
-        stateTwo: Ember.State.create({})
-      })
+  ```javascript
+  aManager = Ember.StateManager.create({
+    stateOne: Ember.State.create({
+      changeToStateTwo: Ember.State.transitionTo('stateTwo')
+    }),
+    stateTwo: Ember.State.create({})
+  })
 
-      bManager = Ember.StateManager.create({
-        stateOne: Ember.State.create({
-          changeToStateTwo: function(manager, context){
-            manager.transitionTo('stateTwo', context)
-          }
-        }),
-        stateTwo: Ember.State.create({})
-      })
+  bManager = Ember.StateManager.create({
+    stateOne: Ember.State.create({
+      changeToStateTwo: function(manager, context){
+        manager.transitionTo('stateTwo', context)
+      }
+    }),
+    stateTwo: Ember.State.create({})
+  })
+  ```
 
   @class StateManager
   @namespace Ember
@@ -16561,7 +17801,7 @@ Ember.StateManager = Ember.State.extend({
 
   /**
     The current state from among the manager's possible states. This property should
-    not be set directly.  Use `transitionTo` to move between states by name.
+    not be set directly. Use `transitionTo` to move between states by name.
 
     @property currentState
     @type Ember.State
@@ -16577,7 +17817,7 @@ Ember.StateManager = Ember.State.extend({
   */
   currentPath: Ember.computed('currentState', function() {
     return get(this, 'currentState.path');
-  }).cacheable(),
+  }),
 
   /**
     The name of transitionEvent that this stateManager will dispatch
@@ -16599,31 +17839,14 @@ Ember.StateManager = Ember.State.extend({
   */
   errorOnUnhandledEvent: true,
 
-  send: function(event, context) {
+  send: function(event) {
+    var contexts = [].slice.call(arguments, 1);
     Ember.assert('Cannot send event "' + event + '" while currentState is ' + get(this, 'currentState'), get(this, 'currentState'));
-    return this.sendRecursively(event, get(this, 'currentState'), context);
+    return sendEvent.call(this, event, contexts, false);
   },
-
-  sendRecursively: function(event, currentState, context) {
-    var log = this.enableLogging,
-        action = currentState[event];
-
-    // Test to see if the action is a method that
-    // can be invoked. Don't blindly check just for
-    // existence, because it is possible the state
-    // manager has a child state of the given name,
-    // and we should still raise an exception in that
-    // case.
-    if (typeof action === 'function') {
-      if (log) { Ember.Logger.log(fmt("STATEMANAGER: Sending event '%@' to state %@.", [event, get(currentState, 'path')])); }
-      return action.call(currentState, this, context);
-    } else {
-      var parentState = get(currentState, 'parentState');
-      if (parentState) {
-        return this.sendRecursively(event, parentState, context);
-      } else if (get(this, 'errorOnUnhandledEvent')) {
-        throw new Ember.Error(this.toString() + " could not respond to event " + event + " in state " + get(this, 'currentState.path') + ".");
-      }
+  unhandledEvent: function(manager, event) {
+    if (get(this, 'errorOnUnhandledEvent')) {
+      throw new Ember.Error(this.toString() + " could not respond to event " + event + " in state " + get(this, 'currentState.path') + ".");
     }
   },
 
@@ -16632,15 +17855,17 @@ Ember.StateManager = Ember.State.extend({
 
     Example:
 
-        manager = Ember.StateManager.create({
-          root: Ember.State.create({
-            dashboard: Ember.State.create()
-          })
-        });
+    ```javascript
+    manager = Ember.StateManager.create({
+      root: Ember.State.create({
+        dashboard: Ember.State.create()
+      })
+    });
 
-        manager.getStateByPath(manager, "root.dashboard")
+    manager.getStateByPath(manager, "root.dashboard")
 
-        // returns the dashboard state
+    // returns the dashboard state
+    ```
 
     @method getStateByPath
     @param {Ember.State} root the state to start searching from
@@ -16651,7 +17876,7 @@ Ember.StateManager = Ember.State.extend({
     var parts = path.split('.'),
         state = root;
 
-    for (var i=0, l=parts.length; i<l; i++) {
+    for (var i=0, len=parts.length; i<len; i++) {
       state = get(get(state, 'states'), parts[i]);
       if (!state) { break; }
     }
@@ -16673,32 +17898,32 @@ Ember.StateManager = Ember.State.extend({
   /**
     A state stores its child states in its `states` hash.
     This code takes a path like `posts.show` and looks
-    up `origin.states.posts.states.show`.
+    up `root.states.posts.states.show`.
 
     It returns a list of all of the states from the
-    origin, which is the list of states to call `enter`
+    root, which is the list of states to call `enter`
     on.
 
-    @method findStateByPath
-    @param origin
+    @method getStatesInPath
+    @param root
     @param path
   */
-  findStatesByPath: function(origin, path) {
+  getStatesInPath: function(root, path) {
     if (!path || path === "") { return undefined; }
-    var r = path.split('.'),
-        ret = [];
+    var parts = path.split('.'),
+        result = [],
+        states,
+        state;
 
-    for (var i=0, len = r.length; i < len; i++) {
-      var states = get(origin, 'states');
-
+    for (var i=0, len=parts.length; i<len; i++) {
+      states = get(root, 'states');
       if (!states) { return undefined; }
-
-      var s = get(states, r[i]);
-      if (s) { origin = s; ret.push(s); }
+      state = get(states, parts[i]);
+      if (state) { root = state; result.push(state); }
       else { return undefined; }
     }
 
-    return ret;
+    return result;
   },
 
   goToState: function() {
@@ -16730,7 +17955,7 @@ Ember.StateManager = Ember.State.extend({
     var cache = currentState.pathsCache[path];
     if (cache) { return cache; }
 
-    var enterStates = this.findStatesByPath(currentState, path),
+    var enterStates = this.getStatesInPath(currentState, path),
         exitStates = [],
         resolveState = currentState;
 
@@ -16772,13 +17997,13 @@ Ember.StateManager = Ember.State.extend({
 
       resolveState = get(resolveState, 'parentState');
       if (!resolveState) {
-        enterStates = this.findStatesByPath(this, path);
+        enterStates = this.getStatesInPath(this, path);
         if (!enterStates) {
           Ember.assert('Could not find state for path: "'+path+'"');
           return;
         }
       }
-      enterStates = this.findStatesByPath(resolveState, path);
+      enterStates = this.getStatesInPath(resolveState, path);
     }
 
     // If the path contains some states that are parents of both the
@@ -16886,19 +18111,14 @@ Ember._ResolvedState = Ember.Object.extend({
   state: null,
   match: null,
 
-  object: Ember.computed(function(key, value) {
-    if (arguments.length === 2) {
-      this._object = value;
-      return value;
+  object: Ember.computed(function(key) {
+    if (this._object) {
+      return this._object;
     } else {
-      if (this._object) {
-        return this._object;
-      } else {
-        var state = get(this, 'state'),
-            match = get(this, 'match'),
-            manager = get(this, 'manager');
-        return state.deserialize(manager, match.hash);
-      }
+      var state = get(this, 'state'),
+          match = get(this, 'match'),
+          manager = get(this, 'manager');
+      return state.deserialize(manager, match.hash);
     }
   }).property(),
 
@@ -17051,16 +18271,33 @@ Ember.Routable = Ember.Mixin.create({
 
     @method absoluteRoute
     @param manager {Ember.StateManager}
-    @param hash {Hash}
+    @param hashes {Array}
   */
-  absoluteRoute: function(manager, hash) {
-    var parentState = get(this, 'parentState');
-    var path = '', generated;
+  absoluteRoute: function(manager, hashes) {
+    var parentState = get(this, 'parentState'),
+      path = '',
+      generated,
+      currentHash;
+
+    // check if object passed instead of array
+    // in this case set currentHash = hashes
+    // this allows hashes to be a single hash
+    // (it will be applied to state and all parents)
+    currentHash = null;
+    if (hashes) {
+      if (hashes instanceof Array) {
+        if (hashes.length > 0) {
+          currentHash = hashes.shift();
+        }
+      } else {
+        currentHash = hashes;
+      }
+    }
 
     // If the parent state is routable, use its current path
     // as this route's prefix.
     if (get(parentState, 'isRoutable')) {
-      path = parentState.absoluteRoute(manager, hash);
+      path = parentState.absoluteRoute(manager, hashes);
     }
 
     var matcher = get(this, 'routeMatcher'),
@@ -17068,10 +18305,10 @@ Ember.Routable = Ember.Mixin.create({
 
     // merge the existing serialized object in with the passed
     // in hash.
-    hash = hash || {};
-    merge(hash, serialized);
+    currentHash = currentHash || {};
+    merge(currentHash, serialized);
 
-    generated = matcher && matcher.generate(hash);
+    generated = matcher && matcher.generate(currentHash);
 
     if (generated) {
       path = path + '/' + generated;
@@ -17091,7 +18328,7 @@ Ember.Routable = Ember.Mixin.create({
   */
   isRoutable: Ember.computed(function() {
     return typeof get(this, 'route') === 'string';
-  }).cacheable(),
+  }),
 
   /**
     @private
@@ -17104,12 +18341,12 @@ Ember.Routable = Ember.Mixin.create({
   isLeafRoute: Ember.computed(function() {
     if (get(this, 'isLeaf')) { return true; }
     return !get(this, 'childStates').findProperty('isRoutable');
-  }).cacheable(),
+  }),
 
   /**
     @private
 
-    A _RouteMatcher object generated from the current route's `route`
+    A `_RouteMatcher` object generated from the current route's `route`
     string property.
 
     @property routeMatcher
@@ -17120,7 +18357,7 @@ Ember.Routable = Ember.Mixin.create({
     if (route) {
       return Ember._RouteMatcher.create({ route: route });
     }
-  }).cacheable(),
+  }),
 
   /**
     @private
@@ -17136,7 +18373,7 @@ Ember.Routable = Ember.Mixin.create({
     if (routeMatcher) {
       return routeMatcher.identifiers.length > 0;
     }
-  }).cacheable(),
+  }),
 
   /**
     @private
@@ -17152,11 +18389,11 @@ Ember.Routable = Ember.Mixin.create({
     var modelType = get(this, 'modelType');
 
     if (typeof modelType === 'string') {
-      return Ember.get(window, modelType);
+      return Ember.get(Ember.lookup, modelType);
     } else {
       return modelType;
     }
-  }).cacheable(),
+  }),
 
   /**
     @private
@@ -17238,7 +18475,9 @@ Ember.Routable = Ember.Mixin.create({
     `blog_post_id` and the object is a `BlogPost` with an
     `id` of `12`, the serialize method will produce:
 
-        { blog_post_id: 12 }
+    ```javascript
+    { blog_post_id: 12 }
+    ```
 
     @method serialize
     @param manager {Ember.StateManager}
@@ -17315,8 +18554,8 @@ Ember.Routable = Ember.Mixin.create({
     Once `unroute` has finished unwinding, `routePath` will be called
     with the remainder of the route.
 
-    For example, if you were in the /posts/1/comments state, and you
-    moved into the /posts/2/comments state, `routePath` will be called
+    For example, if you were in the `/posts/1/comments` state, and you
+    moved into the `/posts/2/comments` state, `routePath` will be called
     on the state whose path is `/posts` with the path `/2/comments`.
 
     @method routePath
@@ -17404,14 +18643,12 @@ Ember.Routable = Ember.Mixin.create({
     }
 
     return 'application';
-  }).cacheable(),
+  }),
 
-  _template: Ember.computed(function(key, value) {
-    if (arguments.length > 1) { return value; }
+  _template: Ember.computed(function(key) {
+    var value = get(this, 'template');
 
-    if (value = get(this, 'template')) {
-      return value;
-    }
+    if (value) { return value; }
 
     // If no template was explicitly supplied convert
     // the class name into a template name. For example,
@@ -17422,7 +18659,7 @@ Ember.Routable = Ember.Mixin.create({
       baseName = baseName.replace(/Route$/, '');
       return baseName.charAt(0).toLowerCase() + baseName.substr(1);
     }
-  }).cacheable(),
+  }),
 
   render: function(options) {
     options = options || {};
@@ -17510,9 +18747,14 @@ Ember._RouteMatcher = Ember.Object.extend({
 
     escaped = escapeForRegex(route);
 
-    var regex = escaped.replace(/:([a-z_]+)(?=$|\/)/gi, function(match, id) {
+    var regex = escaped.replace(/(:|(?:\\\*))([a-z_]+)(?=$|\/)/gi, function(match, type, id) {
       identifiers[count++] = id;
-      return "([^/]+)";
+      switch (type) {
+        case ":":
+          return "([^/]+)";
+        case "\\*":
+          return "(.+)";
+      }
     });
 
     this.identifiers = identifiers;
@@ -17541,7 +18783,7 @@ Ember._RouteMatcher = Ember.Object.extend({
     var identifiers = this.identifiers, route = this.route, id;
     for (var i=1, l=identifiers.length; i<l; i++) {
       id = identifiers[i];
-      route = route.replace(new RegExp(":" + id), hash[id]);
+      route = route.replace(new RegExp("(:|(\\*))" + id), hash[id]);
     }
     return route;
   }
@@ -17578,7 +18820,7 @@ var get = Ember.get, set = Ember.set;
   Ember.Location returns an instance of the correct implementation of
   the `location` API.
 
-  You can pass it a `implementation` ('hash', 'history', 'none') to force a
+  You can pass it a `implementation` (`hash`, `history`, `none`) to force a
   particular implementation.
 
   @class Location
@@ -17616,8 +18858,8 @@ Ember.Location = {
 var get = Ember.get, set = Ember.set;
 
 /**
-  Ember.NoneLocation does not interact with the browser. It is useful for
-  testing, or when you need to manage state with your Router, but temporarily
+  `Ember.NoneLocation` does not interact with the browser. It is useful for
+  testing, or when you need to manage state with your router, but temporarily
   don't want it to muck with the URL (for example when you embed your
   application in a larger page).
 
@@ -17663,7 +18905,7 @@ Ember.Location.registerImplementation('none', Ember.NoneLocation);
 var get = Ember.get, set = Ember.set;
 
 /**
-  Ember.HashLocation implements the location API using the browser's
+  `Ember.HashLocation` implements the location API using the browser's
   hash. At present, it relies on a hashchange event existing in the
   browser.
 
@@ -17733,7 +18975,7 @@ Ember.HashLocation = Ember.Object.extend({
     Given a URL, formats it to be placed into the page as part
     of an element's `href` attribute.
 
-    This is used, for example, when using the {{action}} helper
+    This is used, for example, when using the `{{action}}` helper
     to generate a URL based on an event.
 
     @method formatURL
@@ -17763,10 +19005,11 @@ Ember.Location.registerImplementation('hash', Ember.HashLocation);
 */
 
 var get = Ember.get, set = Ember.set;
+var popstateReady = false;
 
 /**
-  Ember.HistoryLocation implements the location API using the browser's
-  history.pushState API.
+  `Ember.HistoryLocation` implements the location API using the browser's
+  `history.pushState` API.
 
   @class HistoryLocation
   @namespace Ember
@@ -17776,7 +19019,19 @@ Ember.HistoryLocation = Ember.Object.extend({
 
   init: function() {
     set(this, 'location', get(this, 'location') || window.location);
-    set(this, '_initialURL', get(this, 'location').pathname);
+    this.initState();
+  },
+
+  /**
+    @private
+
+    Used to set state on first call to `setURL`
+
+    @method initState
+  */
+  initState: function() {
+    this.replaceState(get(this, 'location').pathname);
+    set(this, 'history', window.history);
   },
 
   /**
@@ -17786,16 +19041,6 @@ Ember.HistoryLocation = Ember.Object.extend({
     @default '/'
   */
   rootURL: '/',
-
-  /**
-    @private
-
-    Used to give history a starting reference
-
-    @property _initialURL
-    @default null
-  */
-  _initialURL: null,
 
   /**
     @private
@@ -17817,14 +19062,47 @@ Ember.HistoryLocation = Ember.Object.extend({
     @param path {String}
   */
   setURL: function(path) {
-    var state = window.history.state,
-        initialURL = get(this, '_initialURL');
-
     path = this.formatURL(path);
 
-    if ((initialURL !== path && !state) || (state && state.path !== path)) {
-      window.history.pushState({ path: path }, null, path);
+    if (this.getState() && this.getState().path !== path) {
+      popstateReady = true;
+      this.pushState(path);
     }
+  },
+
+  /**
+   @private
+
+   Get the current `history.state`
+
+   @method getState
+  */
+  getState: function() {
+    return get(this, 'history').state;
+  },
+
+  /**
+   @private
+
+   Pushes a new state
+
+   @method pushState
+   @param path {String}
+  */
+  pushState: function(path) {
+    window.history.pushState({ path: path }, null, path);
+  },
+
+  /**
+   @private
+
+   Replaces the current state
+
+   @method replaceState
+   @param path {String}
+  */
+  replaceState: function(path) {
+    window.history.replaceState({ path: path }, null, path);
   },
 
   /**
@@ -17840,6 +19118,9 @@ Ember.HistoryLocation = Ember.Object.extend({
     var guid = Ember.guidFor(this);
 
     Ember.$(window).bind('popstate.ember-location-'+guid, function(e) {
+      if(!popstateReady) {
+        return;
+      }
       callback(location.pathname);
     });
   },
@@ -17847,7 +19128,7 @@ Ember.HistoryLocation = Ember.Object.extend({
   /**
     @private
 
-    Used when using `{{action}}` helper.  The url is always appended to the rootURL.
+    Used when using `{{action}}` helper. The url is always appended to the rootURL.
 
     @method formatURL
     @param url {String}
@@ -17899,299 +19180,360 @@ var merge = function(original, hash) {
 };
 
 /**
-  `Ember.Router` is the subclass of `Ember.StateManager` responsible for providing URL-based
-  application state detection. The `Ember.Router` instance of an application detects the browser URL
-  at application load time and attempts to match it to a specific application state. Additionally
-  the router will update the URL to reflect an application's state changes over time.
+  `Ember.Router` is the subclass of `Ember.StateManager` responsible for
+  providing URL-based application state detection. The `Ember.Router` instance
+  of an application detects the browser URL at application load time and
+  attempts to match it to a specific application state. Additionally the router
+  will update the URL to reflect an application's state changes over time.
 
   ## Adding a Router Instance to Your Application
-  An instance of Ember.Router can be associated with an instance of Ember.Application in one of two ways:
 
-  You can provide a subclass of Ember.Router as the `Router` property of your application. An instance
-  of this Router class will be instantiated and route detection will be enabled when the application's
-  `initialize` method is called. The Router instance will be available as the `router` property
-  of the application:
+  An instance of `Ember.Router` can be associated with an instance of
+  `Ember.Application` in one of two ways:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({ ... })
-      });
+  You can provide a subclass of `Ember.Router` as the `Router` property of your
+  application. An instance of this `Router` class will be instantiated and
+  route detection will be enabled when the application's `initialize` method is
+  called. The `Router` instance will be available as the `router` property of
+  the application:
 
-      App.initialize();
-      App.get('router') // an instance of App.Router
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({ ... })
+  });
 
-  If you want to define a Router instance elsewhere, you can pass the instance to the application's
-  `initialize` method:
+  App.initialize();
+  App.get('router') // an instance of App.Router
+  ```
 
-      App = Ember.Application.create();
-      aRouter = Ember.Router.create({ ... });
+  If you want to define a `Router` instance elsewhere, you can pass the
+  instance to the application's `initialize` method:
 
-      App.initialize(aRouter);
-      App.get('router') // aRouter
+  ```javascript
+  App = Ember.Application.create();
+  aRouter = Ember.Router.create({ ... });
+
+  App.initialize(aRouter);
+  App.get('router') // aRouter
+  ```
 
   ## Adding Routes to a Router
-  The `initialState` property of Ember.Router instances is named `root`. The state stored in this
-  property must be a subclass of Ember.Route. The `root` route acts as the container for the
-  set of routable states but is not routable itself. It should have states that are also subclasses
-  of Ember.Route which each have a `route` property describing the URL pattern you would like to detect.
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            index: Ember.Route.extend({
-              route: '/'
-            }),
-            ... additional Ember.Routes ...
-          })
-        })
-      });
-      App.initialize();
+  The `initialState` property of `Ember.Router` instances is named `root`. The
+  state stored in this property must be a subclass of `Ember.Route`. The `root`
+  route acts as the container for the set of routable states but is not
+  routable itself. It should have states that are also subclasses of
+  `Ember.Route` which each have a `route` property describing the URL pattern
+  you would like to detect.
 
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        index: Ember.Route.extend({
+          route: '/'
+        }),
+        ... additional Ember.Routes ...
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-  When an application loads, Ember will parse the URL and attempt to find an Ember.Route within
-  the application's states that matches. (The example URL-matching below will use the default
-  'hash syntax' provided by `Ember.HashLocation`.)
+  When an application loads, Ember will parse the URL and attempt to find an
+  Ember.Route within the application's states that matches. (The example
+  URL-matching below will use the default 'hash syntax' provided by
+  `Ember.HashLocation`.)
 
   In the following route structure:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/'
-            }),
-            bRoute: Ember.Route.extend({
-              route: '/alphabeta'
-            })
-          })
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/'
+        }),
+        bRoute: Ember.Route.extend({
+          route: '/alphabeta'
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-  Loading the page at the URL '#/' will detect the route property of 'root.aRoute' ('/') and
-  transition the router first to the state named 'root' and then to the substate 'aRoute'.
+  Loading the page at the URL '#/' will detect the route property of
+  `root.aRoute` ('/') and transition the router first to the state named `root`
+  and then to the substate `aRoute`.
 
-  Respectively, loading the page at the URL '#/alphabeta' would detect the route property of
-  'root.bRoute' ('/alphabeta') and transition the router first to the state named 'root' and
-  then to the substate 'bRoute'.
+  Respectively, loading the page at the URL '#/alphabeta' would detect the
+  route property of `root.bRoute` ('/alphabeta') and transition the router
+  first to the state named `root` and then to the substate `bRoute`.
 
   ## Adding Nested Routes to a Router
-  Routes can contain nested subroutes each with their own `route` property describing the nested
-  portion of the URL they would like to detect and handle. Router, like all instances of StateManager,
-  cannot call `transitonTo` with an intermediary state. To avoid transitioning the Router into an
-  intermediary state when detecting URLs, a Route with nested routes must define both a base `route`
-  property for itself and a child Route with a `route` property of `'/'` which will be transitioned
-  to when the base route is detected in the URL:
+
+  Routes can contain nested subroutes each with their own `route` property
+  describing the nested portion of the URL they would like to detect and
+  handle. `Router`, like all instances of `StateManager`, cannot call
+  `transitonTo` with an intermediary state. To avoid transitioning the Router
+  into an intermediary state when detecting URLs, a Route with nested routes
+  must define both a base `route` property for itself and a child Route with a
+  `route` property of `'/'` which will be transitioned to when the base route
+  is detected in the URL:
 
   Given the following application code:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/theBaseRouteForThisSet',
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/theBaseRouteForThisSet',
 
-              indexSubRoute: Ember.Route.extend({
-                route: '/'
-              }),
+          indexSubRoute: Ember.Route.extend({
+            route: '/'
+          }),
 
-              subRouteOne: Ember.Route.extend({
-                route: '/subroute1'
-              }),
+          subRouteOne: Ember.Route.extend({
+            route: '/subroute1'
+          }),
 
-              subRouteTwo: Ember.Route.extend({
-                route: '/subRoute2'
-              })
-
-            })
+          subRouteTwo: Ember.Route.extend({
+            route: '/subRoute2'
           })
+
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-  When the application is loaded at '/theBaseRouteForThisSet' the Router will transition to the route
-  at path 'root.aRoute' and then transition to state 'indexSubRoute'.
+  When the application is loaded at '/theBaseRouteForThisSet' the Router will
+  transition to the route at path `root.aRoute` and then transition to state
+  `indexSubRoute`.
 
-  When the application is loaded at '/theBaseRouteForThisSet/subRoute1' the Router will transition to
-  the route at path 'root.aRoute' and then transition to state 'subRouteOne'.
+  When the application is loaded at '/theBaseRouteForThisSet/subRoute1' the
+  Router will transition to the route at path `root.aRoute` and then transition
+  to state `subRouteOne`.
 
   ## Route Transition Events
-  Transitioning between Ember.Route instances (including the transition into the detected
-  route when loading the application)  triggers the same transition events as state transitions for
-  base `Ember.State`s. However, the default `setup` transition event is named `connectOutlets` on
-  Ember.Router instances (see 'Changing View Hierarchy in Response To State Change').
+
+  Transitioning between `Ember.Route` instances (including the transition into
+  the detected route when loading the application) triggers the same
+  transition events as state transitions for base `Ember.State`s. However, the
+  default `setup` transition event is named `connectOutlets` on `Ember.Router`
+  instances (see 'Changing View Hierarchy in Response To State Change').
 
   The following route structure when loaded with the URL "#/"
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/',
-              enter: function(router) {
-                console.log("entering root.aRoute from", router.get('currentState.name'));
-              },
-              connectOutlets: function(router) {
-                console.log("entered root.aRoute, fully transitioned to", router.get('currentState.path'));
-              }
-            })
-          })
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/',
+          enter: function(router) {
+            console.log("entering root.aRoute from", router.get('currentState.name'));
+          },
+          connectOutlets: function(router) {
+            console.log("entered root.aRoute, fully transitioned to", router.get('currentState.path'));
+          }
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
   Will result in console output of:
 
-      'entering root.aRoute from root'
-      'entered root.aRoute, fully transitioned to root.aRoute '
+  ```
+  'entering root.aRoute from root'
+  'entered root.aRoute, fully transitioned to root.aRoute '
+  ```
 
-  Ember.Route has two additional callbacks for handling URL serialization and deserialization. See
-  'Serializing/Deserializing URLs'
+  `Ember.Route` has two additional callbacks for handling URL serialization and
+  deserialization. See 'Serializing/Deserializing URLs'
 
   ## Routes With Dynamic Segments
-  An Ember.Route's `route` property can reference dynamic sections of the URL by prefacing a URL segment
-  with the ':' character.  The values of these dynamic segments will be passed as a hash to the
-  `deserialize` method of the matching Route (see 'Serializing/Deserializing URLs').
+
+  An `Ember.Route`'s `route` property can reference dynamic sections of the URL
+  by prefacing a URL segment with the ':' character. The values of these
+  dynamic segments will be passed as a hash to the `deserialize` method of the
+  matching `Route` (see 'Serializing/Deserializing URLs').
 
   ## Serializing/Deserializing URLs
-  Ember.Route has two callbacks for associating a particular object context with a URL: `serialize`
-  for converting an object into a parameters hash to fill dynamic segments of a URL and `deserialize`
-  for converting a hash of dynamic segments from the URL into the appropriate object.
+
+  `Ember.Route` has two callbacks for associating a particular object context
+  with a URL: `serialize` for converting an object into a parameters hash to
+  fill dynamic segments of a URL and `deserialize` for converting a hash of
+  dynamic segments from the URL into the appropriate object.
 
   ### Deserializing A URL's Dynamic Segments
-  When an application is first loaded or the URL is changed manually (e.g. through the browser's
-  back button) the `deserialize` method of the URL's matching Ember.Route will be called with
-  the application's router as its first argument and a hash of the URL's dynamic segments and values
-  as its second argument.
 
-  The following route structure when loaded with the URL "#/fixed/thefirstvalue/anotherFixed/thesecondvalue":
+  When an application is first loaded or the URL is changed manually (e.g.
+  through the browser's back button) the `deserialize` method of the URL's
+  matching `Ember.Route` will be called with the application's router as its
+  first argument and a hash of the URL's dynamic segments and values as its
+  second argument.
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/fixed/:dynamicSectionA/anotherFixed/:dynamicSectionB',
-              deserialize: function(router, params) {}
-            })
-          })
+  The following route structure when loaded with the URL 
+  "#/fixed/thefirstvalue/anotherFixed/thesecondvalue":
+
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/fixed/:dynamicSectionA/anotherFixed/:dynamicSectionB',
+          deserialize: function(router, params) {}
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-  Will call the 'deserialize' method of the Route instance at the path 'root.aRoute' with the
-  following hash as its second argument:
+  Will call the `deserialize` method of the Route instance at the path
+  `root.aRoute` with the following hash as its second argument:
 
-      {
-        dynamicSectionA: 'thefirstvalue',
-        dynamicSectionB: 'thesecondvalue'
-      }
+  ```javascript
+  {
+    dynamicSectionA: 'thefirstvalue',
+    dynamicSectionB: 'thesecondvalue'
+  }
+  ```
 
-  Within `deserialize` you should use this information to retrieve or create an appropriate context
-  object for the given URL (e.g. by loading from a remote API or accessing the browser's
-  `localStorage`). This object must be the `return` value of `deserialize` and will be
-  passed to the Route's `connectOutlets` and `serialize` methods.
+  Within `deserialize` you should use this information to retrieve or create an
+  appropriate context object for the given URL (e.g. by loading from a remote
+      API or accessing the browser's `localStorage`). This object must be the
+  `return` value of `deserialize` and will be passed to the `Route`'s
+  `connectOutlets` and `serialize` methods.
 
-  When an application's state is changed from within the application itself, the context provided for
-  the transition will be passed and `deserialize` is not called (see 'Transitions Between States').
+  When an application's state is changed from within the application itself,
+  the context provided for the transition will be passed and `deserialize` is
+  not called (see 'Transitions Between States').
 
   ### Serializing An Object For URLs with Dynamic Segments
-  When transitioning into a Route whose `route` property contains dynamic segments the Route's
-  `serialize` method is called with the Route's router as the first argument and the Route's
-  context as the second argument.  The return value of `serialize` will be used to populate the
-  dynamic segments and should be an object with keys that match the names of the dynamic sections.
+
+  When transitioning into a Route whose `route` property contains dynamic
+  segments the route's `serialize` method is called with the route's router as
+  the first argument and the route's context as the second argument. The return
+  value of `serialize` will be used to populate the dynamic segments and should
+  be an object with keys that match the names of the dynamic sections.
 
   Given the following route structure:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/'
-            }),
-            bRoute: Ember.Route.extend({
-              route: '/staticSection/:someDynamicSegment',
-              serialize: function(router, context) {
-                return {
-                  someDynamicSegment: context.get('name')
-                }
-              }
-            })
-          })
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/'
+        }),
+        bRoute: Ember.Route.extend({
+          route: '/staticSection/:someDynamicSegment',
+          serialize: function(router, context) {
+            return {
+              someDynamicSegment: context.get('name')
+            }
+          }
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-
-  Transitioning to "root.bRoute" with a context of `Object.create({name: 'Yehuda'})` will call
-  the Route's `serialize` method with the context as its second argument and update the URL to
+  Transitioning to `root.bRoute` with a context of 
+  `Object.create({name: 'Yehuda'})` will call the `Route`'s `serialize` 
+  method with the context as its second argument and update the URL to
   '#/staticSection/Yehuda'.
 
   ## Transitions Between States
-  Once a routed application has initialized its state based on the entry URL, subsequent transitions to other
-  states will update the URL if the entered Route has a `route` property. Given the following route structure
-  loaded at the URL '#/':
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/',
-              moveElsewhere: Ember.Route.transitionTo('bRoute')
-            }),
-            bRoute: Ember.Route.extend({
-              route: '/someOtherLocation'
-            })
-          })
+  Once a routed application has initialized its state based on the entry URL,
+  subsequent transitions to other states will update the URL if the entered
+  Route has a `route` property. Given the following route structure loaded at
+  the URL '#/':
+
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/',
+          moveElsewhere: Ember.Route.transitionTo('bRoute')
+        }),
+        bRoute: Ember.Route.extend({
+          route: '/someOtherLocation'
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
   And application code:
 
-      App.get('router').send('moveElsewhere');
+  ```javascript
+  App.get('router').send('moveElsewhere');
+  ```
 
-  Will transition the application's state to 'root.bRoute' and trigger an update of the URL to
-  '#/someOtherLocation'.
+  Will transition the application's state to `root.bRoute` and trigger an
+  update of the URL to `#/someOtherLocation`.
 
-  For URL patterns with dynamic segments a context can be supplied as the second argument to `send`.
-  The router will match dynamic segments names to keys on this object and fill in the URL with the
-  supplied values. Given the following state structure loaded at the URL '#/':
+  For URL patterns with dynamic segments a context can be supplied as the
+  second argument to `send`. The router will match dynamic segments names to
+  keys on this object and fill in the URL with the supplied values. Given the
+  following state structure loaded at the URL `#/`:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/',
-              moveElsewhere: Ember.Route.transitionTo('bRoute')
-            }),
-            bRoute: Ember.Route.extend({
-              route: '/a/route/:dynamicSection/:anotherDynamicSection',
-              connectOutlets: function(router, context) {},
-            })
-          })
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/',
+          moveElsewhere: Ember.Route.transitionTo('bRoute')
+        }),
+        bRoute: Ember.Route.extend({
+          route: '/a/route/:dynamicSection/:anotherDynamicSection',
+          connectOutlets: function(router, context) {},
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```javascript
 
   And application code:
 
-      App.get('router').send('moveElsewhere', {
-        dynamicSection: '42',
-        anotherDynamicSection: 'Life'
-      });
+  ```javascript
+  App.get('router').send('moveElsewhere', {
+    dynamicSection: '42',
+    anotherDynamicSection: 'Life'
+  });
+  ```
 
-  Will transition the application's state to 'root.bRoute' and trigger an update of the URL to
-  '#/a/route/42/Life'.
+  Will transition the application's state to `root.bRoute` and trigger an
+  update of the URL to `#/a/route/42/Life`.
 
-  The context argument will also be passed as the second argument to the `serialize` method call.
+  The context argument will also be passed as the second argument to the
+  `serialize` method call.
 
   ## Injection of Controller Singletons
-  During application initialization Ember will detect properties of the application ending in 'Controller',
-  create singleton instances of each class, and assign them as properties on the router.  The property name
-  will be the UpperCamel name converted to lowerCamel format. These controller classes should be subclasses
-  of Ember.ObjectController, Ember.ArrayController, Ember.Controller, or a custom Ember.Object that includes the
-  Ember.ControllerMixin mixin.
 
-  ``` javascript
+  During application initialization Ember will detect properties of the
+  application ending in 'Controller', create singleton instances of each class,
+  and assign them as properties on the router. The property name will be the
+  UpperCamel name converted to lowerCamel format. These controller classes
+  should be subclasses of `Ember.ObjectController`, `Ember.ArrayController`,
+  `Ember.Controller`, or a custom `Ember.Object` that includes the
+  `Ember.ControllerMixin` mixin.
+
+  ```javascript
   App = Ember.Application.create({
     FooController: Ember.Object.create(Ember.ControllerMixin),
     Router: Ember.Router.extend({ ... })
@@ -18200,18 +19542,23 @@ var merge = function(original, hash) {
   App.get('router.fooController'); // instance of App.FooController
   ```
 
-  The controller singletons will have their `namespace` property set to the application and their `target`
-  property set to the application's router singleton for easy integration with Ember's user event system.
-  See 'Changing View Hierarchy in Response To State Change' and 'Responding to User-initiated Events.'
+  The controller singletons will have their `namespace` property set to the
+  application and their `target` property set to the application's router
+  singleton for easy integration with Ember's user event system. See 'Changing
+  View Hierarchy in Response To State Change' and 'Responding to User-initiated
+  Events.'
 
   ## Responding to User-initiated Events
-  Controller instances injected into the router at application initialization have their `target` property
-  set to the application's router instance. These controllers will also be the default `context` for their
-  associated views.  Uses of the `{{action}}` helper will automatically target the application's router.
 
-  Given the following application entered at the URL '#/':
+  Controller instances injected into the router at application initialization
+  have their `target` property set to the application's router instance. These
+  controllers will also be the default `context` for their associated views.
+  Uses of the `{{action}}` helper will automatically target the application's
+  router.
 
-  ``` javascript
+  Given the following application entered at the URL `#/`:
+
+  ```javascript
   App = Ember.Application.create({
     Router: Ember.Router.extend({
       root: Ember.Route.extend({
@@ -18235,20 +19582,22 @@ var merge = function(original, hash) {
 
   The following template:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name="aView">
       <h1><a {{action anActionOnTheRouter}}>{{title}}</a></h1>
   </script>
   ```
 
-  Will delegate `click` events on the rendered `h1` to the application's router instance. In this case the
-  `anActionOnTheRouter` method of the state at 'root.aRoute' will be called with the view's controller
-  as the context argument. This context will be passed to the `connectOutlets` as its second argument.
+  Will delegate `click` events on the rendered `h1` to the application's router
+  instance. In this case the `anActionOnTheRouter` method of the state at
+  'root.aRoute' will be called with the view's controller as the context
+  argument. This context will be passed to the `connectOutlets` as its second
+  argument.
 
-  Different `context` can be supplied from within the `{{action}}` helper, allowing specific context passing
-  between application states:
+  Different `context` can be supplied from within the `{{action}}` helper,
+  allowing specific context passing between application states:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name="photos">
     {{#each photo in controller}}
       <h1><a {{action showPhoto photo}}>{{title}}</a></h1>
@@ -18258,14 +19607,14 @@ var merge = function(original, hash) {
 
   See `Handlebars.helpers.action` for additional usage examples.
 
-
   ## Changing View Hierarchy in Response To State Change
 
-  Changes in application state that change the URL should be accompanied by associated changes in view
-  hierarchy.  This can be accomplished by calling 'connectOutlet' on the injected controller singletons from
-  within the 'connectOutlets' event of an Ember.Route:
+  Changes in application state that change the URL should be accompanied by
+  associated changes in view hierarchy. This can be accomplished by calling
+  `connectOutlet` on the injected controller singletons from within the
+  'connectOutlets' event of an `Ember.Route`:
 
-  ``` javascript
+  ```javascript
   App = Ember.Application.create({
     OneController: Ember.ObjectController.extend(),
     OneView: Ember.View.extend(),
@@ -18287,15 +19636,17 @@ var merge = function(original, hash) {
   App.initialize();
   ```
 
+  This will detect the `{{outlet}}` portion of `oneController`'s view (an
+  instance of `App.OneView`) and fill it with a rendered instance of
+  `App.AnotherView` whose `context` will be the single instance of
+  `App.AnotherController` stored on the router in the `anotherController`
+  property.
 
-  This will detect the '{{outlet}}' portion of `oneController`'s view (an instance of `App.OneView`) and
-  fill it with a rendered instance of `App.AnotherView` whose `context` will be the single instance of
-  `App.AnotherController` stored on the router in the `anotherController` property.
-
-  For more information about Outlets, see `Ember.Handlebars.helpers.outlet`. For additional information on
-  the `connectOutlet` method, see `Ember.Controller.connectOutlet`. For more information on
-  controller injections, see `Ember.Application#initialize()`. For additional information about view context,
-  see `Ember.View`.
+  For more information about Outlets, see `Ember.Handlebars.helpers.outlet`.
+  For additional information on the `connectOutlet` method, see
+  `Ember.Controller.connectOutlet`. For more information on controller
+  injections, see `Ember.Application#initialize()`. For additional information
+  about view context, see `Ember.View`.
 
   @class Router
   @namespace Ember
@@ -18315,11 +19666,11 @@ Ember.Router = Ember.StateManager.extend(
     The `Ember.Location` implementation to be used to manage the application
     URL state. The following values are supported:
 
-    * 'hash': Uses URL fragment identifiers (like #/blog/1) for routing.
-    * 'history': Uses the browser's history.pushstate API for routing. Only works in
-       modern browsers with pushstate support.
-    * 'none': Does not read or set the browser URL, but still allows for
-      routing to happen. Useful for testing.
+    * `hash`: Uses URL fragment identifiers (like #/blog/1) for routing.
+    * `history`: Uses the browser's history.pushstate API for routing. Only
+       works in modern browsers with pushstate support.
+    * `none`: Does not read or set the browser URL, but still allows for
+       routing to happen. Useful for testing.
 
     @property location
     @type String
@@ -18379,44 +19730,50 @@ Ember.Router = Ember.StateManager.extend(
     }
   },
 
-  urlFor: function(path, hash) {
+  urlFor: function(path, hashes) {
     var currentState = get(this, 'currentState') || this,
         state = this.findStateByPath(currentState, path);
 
-    Ember.assert(Ember.String.fmt("Could not find route with path '%@'", [path]), !!state);
-    Ember.assert("To get a URL for a state, it must have a `route` property.", !!get(state, 'routeMatcher'));
+    Ember.assert(Ember.String.fmt("Could not find route with path '%@'", [path]), state);
+    Ember.assert(Ember.String.fmt("To get a URL for the state '%@', it must have a `route` property.", [path]), get(state, 'routeMatcher'));
 
     var location = get(this, 'location'),
-        absoluteRoute = state.absoluteRoute(this, hash);
+        absoluteRoute = state.absoluteRoute(this, hashes);
 
     return location.formatURL(absoluteRoute);
   },
 
   urlForEvent: function(eventName) {
-    var contexts = Array.prototype.slice.call(arguments, 1);
-    var currentState = get(this, 'currentState');
-    var targetStateName = currentState.lookupEventTransition(eventName);
+    var contexts = Array.prototype.slice.call(arguments, 1),
+      currentState = get(this, 'currentState'),
+      targetStateName = currentState.lookupEventTransition(eventName),
+      targetState,
+      hashes;
 
-    Ember.assert(Ember.String.fmt("You must specify a target state for event '%@' in order to link to it in the current state '%@'.", [eventName, get(currentState, 'path')]), !!targetStateName);
+    Ember.assert(Ember.String.fmt("You must specify a target state for event '%@' in order to link to it in the current state '%@'.", [eventName, get(currentState, 'path')]), targetStateName);
 
-    var targetState = this.findStateByPath(currentState, targetStateName);
+    targetState = this.findStateByPath(currentState, targetStateName);
 
-    Ember.assert("Your target state name " + targetStateName + " for event " + eventName + " did not resolve to a state", !!targetState);
+    Ember.assert("Your target state name " + targetStateName + " for event " + eventName + " did not resolve to a state", targetState);
 
-    var hash = this.serializeRecursively(targetState, contexts, {});
 
-    return this.urlFor(targetStateName, hash);
+    hashes = this.serializeRecursively(targetState, contexts, []);
+
+    return this.urlFor(targetStateName, hashes);
   },
 
-  serializeRecursively: function(state, contexts, hash) {
+  serializeRecursively: function(state, contexts, hashes) {
     var parentState,
-        context = get(state, 'hasContext') ? contexts.pop() : null;
-    merge(hash, state.serialize(this, context));
-    parentState = state.get("parentState");
-    if (parentState && parentState instanceof Ember.Route) {
-      return this.serializeRecursively(parentState, contexts, hash);
+			context = get(state, 'hasContext') ? contexts.pop() : null,
+      hash = context ? state.serialize(this, context) : null;
+
+		hashes.push(hash);
+		parentState = state.get("parentState");
+
+		if (parentState && parentState instanceof Ember.Route) {
+      return this.serializeRecursively(parentState, contexts, hashes);
     } else {
-      return hash;
+      return hashes;
     }
   },
 
@@ -18456,7 +19813,26 @@ Ember.Router = Ember.StateManager.extend(
     }).start();
   },
 
+  moveStatesIntoRoot: function() {
+    this.root = Ember.Route.extend();
+
+    for (var name in this) {
+      if (name === "constructor") { continue; }
+
+      var state = this[name];
+
+      if (state instanceof Ember.Route || Ember.Route.detect(state)) {
+        this.root[name] = state;
+        delete this[name];
+      }
+    }
+  },
+
   init: function() {
+    if (!this.root) {
+      this.moveStatesIntoRoot();
+    }
+
     this._super();
 
     var location = get(this, 'location'),
@@ -18909,7 +20285,6 @@ Ember Routing
 })();
 
 (function() {
-/*globals Handlebars */
 /**
 @module ember
 @submodule ember-handlebars
@@ -18917,19 +20292,19 @@ Ember Routing
 
 var objectCreate = Ember.create;
 
-
-Ember.assert("Ember Handlebars requires Handlebars 1.0.beta.5 or greater", window.Handlebars && window.Handlebars.VERSION.match(/^1\.0\.beta\.[56789]$|^1\.0\.rc\.[123456789]+/));
+var Handlebars = Ember.imports.Handlebars;
+Ember.assert("Ember Handlebars requires Handlebars 1.0.beta.5 or greater", Handlebars && Handlebars.VERSION.match(/^1\.0\.beta\.[56789]$|^1\.0\.rc\.[123456789]+/));
 
 /**
   Prepares the Handlebars templating library for use inside Ember's view
   system.
 
-  The Ember.Handlebars object is the standard Handlebars library, extended to use
-  Ember's get() method instead of direct property access, which allows
+  The `Ember.Handlebars` object is the standard Handlebars library, extended to
+  use Ember's `get()` method instead of direct property access, which allows
   computed properties to be used inside templates.
 
-  To create an Ember.Handlebars template, call Ember.Handlebars.compile().  This will
-  return a function that can be used by Ember.View for rendering.
+  To create an `Ember.Handlebars` template, call `Ember.Handlebars.compile()`.
+  This will return a function that can be used by `Ember.View` for rendering.
 
   @class Handlebars
   @namespace Ember
@@ -18951,7 +20326,12 @@ Ember.Handlebars.helpers = objectCreate(Handlebars.helpers);
   @constructor
 */
 Ember.Handlebars.Compiler = function() {};
-Ember.Handlebars.Compiler.prototype = objectCreate(Handlebars.Compiler.prototype);
+
+// Handlebars.Compiler doesn't exist in runtime-only
+if (Handlebars.Compiler) {
+  Ember.Handlebars.Compiler.prototype = objectCreate(Handlebars.Compiler.prototype);
+}
+
 Ember.Handlebars.Compiler.prototype.compiler = Ember.Handlebars.Compiler;
 
 /**
@@ -18961,8 +20341,14 @@ Ember.Handlebars.Compiler.prototype.compiler = Ember.Handlebars.Compiler;
   @constructor
 */
 Ember.Handlebars.JavaScriptCompiler = function() {};
-Ember.Handlebars.JavaScriptCompiler.prototype = objectCreate(Handlebars.JavaScriptCompiler.prototype);
-Ember.Handlebars.JavaScriptCompiler.prototype.compiler = Ember.Handlebars.JavaScriptCompiler;
+
+// Handlebars.JavaScriptCompiler doesn't exist in runtime-only
+if (Handlebars.JavaScriptCompiler) {
+  Ember.Handlebars.JavaScriptCompiler.prototype = objectCreate(Handlebars.JavaScriptCompiler.prototype);
+  Ember.Handlebars.JavaScriptCompiler.prototype.compiler = Ember.Handlebars.JavaScriptCompiler;
+}
+
+
 Ember.Handlebars.JavaScriptCompiler.prototype.namespace = "Ember.Handlebars";
 
 
@@ -18973,9 +20359,9 @@ Ember.Handlebars.JavaScriptCompiler.prototype.initializeBuffer = function() {
 /**
   @private
 
-  Override the default buffer for Ember Handlebars. By default, Handlebars creates
-  an empty String at the beginning of each invocation and appends to it. Ember's
-  Handlebars overrides this to append to a single shared buffer.
+  Override the default buffer for Ember Handlebars. By default, Handlebars
+  creates an empty String at the beginning of each invocation and appends to
+  it. Ember's Handlebars overrides this to append to a single shared buffer.
 
   @method appendToBuffer
   @param string {String}
@@ -18987,9 +20373,9 @@ Ember.Handlebars.JavaScriptCompiler.prototype.appendToBuffer = function(string) 
 /**
   @private
 
-  Rewrite simple mustaches from `{{foo}}` to `{{bind "foo"}}`. This means that all simple
-  mustaches in Ember's Handlebars will also set up an observer to keep the DOM
-  up to date when the underlying property changes.
+  Rewrite simple mustaches from `{{foo}}` to `{{bind "foo"}}`. This means that
+  all simple mustaches in Ember's Handlebars will also set up an observer to
+  keep the DOM up to date when the underlying property changes.
 
   @method mustache
   @for Ember.Handlebars.Compiler
@@ -19014,8 +20400,8 @@ Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
 };
 
 /**
-  Used for precompilation of Ember Handlebars templates. This will not be used during normal
-  app execution.
+  Used for precompilation of Ember Handlebars templates. This will not be used
+  during normal app execution.
 
   @method precompile
   @for Ember.Handlebars
@@ -19042,24 +20428,28 @@ Ember.Handlebars.precompile = function(string) {
   return new Ember.Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
 };
 
-/**
-  The entry point for Ember Handlebars. This replaces the default Handlebars.compile and turns on
-  template-local data and String parameters.
+// We don't support this for Handlebars runtime-only
+if (Handlebars.compile) {
+  /**
+    The entry point for Ember Handlebars. This replaces the default
+    `Handlebars.compile` and turns on template-local data and String
+    parameters.
 
-  @method compile
-  @for Ember.Handlebars
-  @static
-  @param {String} string The template to compile
-  @return {Function}
-*/
-Ember.Handlebars.compile = function(string) {
-  var ast = Handlebars.parse(string);
-  var options = { data: true, stringParams: true };
-  var environment = new Ember.Handlebars.Compiler().compile(ast, options);
-  var templateSpec = new Ember.Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
+    @method compile
+    @for Ember.Handlebars
+    @static
+    @param {String} string The template to compile
+    @return {Function}
+  */
+  Ember.Handlebars.compile = function(string) {
+    var ast = Handlebars.parse(string);
+    var options = { data: true, stringParams: true };
+    var environment = new Ember.Handlebars.Compiler().compile(ast, options);
+    var templateSpec = new Ember.Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
 
-  return Handlebars.template(templateSpec);
-};
+    return Handlebars.template(templateSpec);
+  };
+}
 
 /**
   @private
@@ -19109,13 +20499,13 @@ var normalizePath = Ember.Handlebars.normalizePath = function(root, path, data) 
   a keyword, the corresponding object will be looked up in the
   template's data hash and used to resolve the path.
 
-  @method getPath
+  @method get
   @for Ember.Handlebars
   @param {Object} root The object to look up the property on
   @param {String} path The path to be lookedup
   @param {Object} options The template's option hash
 */
-Ember.Handlebars.getPath = function(root, path, options) {
+Ember.Handlebars.get = function(root, path, options) {
   var data = options && options.data,
       normalizedPath = normalizePath(root, path, data),
       value;
@@ -19128,11 +20518,14 @@ Ember.Handlebars.getPath = function(root, path, options) {
 
   value = Ember.get(root, path);
 
-  if (value === undefined && root !== window && Ember.isGlobalPath(path)) {
-    value = Ember.get(window, path);
+  // If the path starts with a capital letter, look it up on Ember.lookup,
+  // which defaults to the `window` object in browsers.
+  if (value === undefined && root !== Ember.lookup && Ember.isGlobalPath(path)) {
+    value = Ember.get(Ember.lookup, path);
   }
   return value;
 };
+Ember.Handlebars.getPath = Ember.deprecateFunc('`Ember.Handlebars.getPath` has been changed to `Ember.Handlebars.get` for consistency.', Ember.Handlebars.get);
 
 /**
   @private
@@ -19176,7 +20569,7 @@ Ember.String.htmlSafe = function(str) {
 
 var htmlSafe = Ember.String.htmlSafe;
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
   /**
     See {{#crossLink "Ember.String/htmlSafe"}}{{/crossLink}}
@@ -19187,7 +20580,6 @@ if (Ember.EXTEND_PROTOTYPES) {
   String.prototype.htmlSafe = function() {
     return htmlSafe(this);
   };
-
 }
 
 })();
@@ -19231,11 +20623,13 @@ var DOMManager = {
 
     Ember.run.schedule('render', this, function() {
       if (get(view, 'isDestroyed')) { return; }
-      view.invalidateRecursively('element');
-      view._notifyWillInsertElement();
+      view.invokeRecursively(function(view) {
+        view.propertyDidChange('element');
+      });
+      view.triggerRecursively('willInsertElement');
       morph.replaceWith(buffer.string());
       view.transitionTo('inDOM');
-      view._notifyDidInsertElement();
+      view.triggerRecursively('didInsertElement');
     });
   },
 
@@ -19256,6 +20650,8 @@ var DOMManager = {
 Ember._Metamorph = Ember.Mixin.create({
   isVirtual: true,
   tagName: '',
+
+  instrumentName: 'render.metamorph',
 
   init: function() {
     this._super();
@@ -19288,6 +20684,15 @@ Ember._Metamorph = Ember.Mixin.create({
 */
 Ember._MetamorphView = Ember.View.extend(Ember._Metamorph);
 
+/**
+  @class _SimpleMetamorphView
+  @namespace Ember
+  @extends Ember.View
+  @uses Ember._Metamorph
+  @private
+*/
+Ember._SimpleMetamorphView = Ember.CoreView.extend(Ember._Metamorph);
+
 
 })();
 
@@ -19295,21 +20700,120 @@ Ember._MetamorphView = Ember.View.extend(Ember._Metamorph);
 
 (function() {
 /*globals Handlebars */
-
+/*jshint newcap:false*/
 /**
 @module ember
 @submodule ember-handlebars
 */
 
-var get = Ember.get, set = Ember.set, getPath = Ember.Handlebars.getPath;
+var get = Ember.get, set = Ember.set, handlebarsGet = Ember.Handlebars.get;
+function SimpleHandlebarsView(path, pathRoot, isEscaped, templateData) {
+  this.path = path;
+  this.pathRoot = pathRoot;
+  this.isEscaped = isEscaped;
+  this.templateData = templateData;
+
+  this.morph = Metamorph();
+  this.state = 'preRender';
+}
+
+Ember._SimpleHandlebarsView = SimpleHandlebarsView;
+
+SimpleHandlebarsView.prototype = {
+  isVirtual: true,
+  isView: true,
+
+  destroy: Ember.K,
+  propertyDidChange: Ember.K,
+
+  normalizedValue: function() {
+    var path = this.path,
+        pathRoot = this.pathRoot,
+        result, templateData;
+
+    // Use the pathRoot as the result if no path is provided. This
+    // happens if the path is `this`, which gets normalized into
+    // a `pathRoot` of the current Handlebars context and a path
+    // of `''`.
+    if (path === '') {
+      result = pathRoot;
+    } else {
+      templateData = this.templateData;
+      result = handlebarsGet(pathRoot, path, { data: templateData });
+    }
+
+    return result;
+  },
+
+  renderToBuffer: function(parentBuffer) {
+    var name = 'render-to-buffer.simpleHandlebars',
+        details = { object: '<Ember._SimpleHandlebarsView>' };
+
+    return Ember.instrument(name, details, function() {
+      return this._renderToBuffer(parentBuffer);
+    }, this);
+  },
+
+  _renderToBuffer: function(buffer) {
+    var string = '';
+
+    string += this.morph.startTag();
+    string += this.render();
+    string += this.morph.endTag();
+
+    buffer.push(string);
+  },
+
+  render: function() {
+    // If not invoked via a triple-mustache ({{{foo}}}), escape
+    // the content of the template.
+    var escape = this.isEscaped;
+    var result = this.normalizedValue();
+
+    if (result === null || result === undefined) {
+      result = "";
+    } else if (!(result instanceof Handlebars.SafeString)) {
+      result = String(result);
+    }
+
+    if (escape) { result = Handlebars.Utils.escapeExpression(result); }
+    return result;
+  },
+
+  rerender: function() {
+    switch(this.state) {
+      case 'preRender':
+      case 'destroyed':
+        break;
+      case 'inBuffer':
+        throw new Error("Something you did tried to replace an {{expression}} before it was inserted into the DOM.");
+      case 'hasElement':
+      case 'inDOM':
+        var morph = this.morph;
+
+        Ember.run.schedule('render', this, function() {
+          if (get(this, 'isDestroyed')) { return; }
+          morph.html(this.render());
+        });
+        break;
+    }
+
+    return this;
+  },
+
+  transitionTo: function(state) {
+    this.state = state;
+  }
+};
+
 /**
-  Ember._HandlebarsBoundView is a private view created by the Handlebars `{{bind}}`
-  helpers that is used to keep track of bound properties.
+  `Ember._HandlebarsBoundView` is a private view created by the Handlebars
+  `{{bind}}` helpers that is used to keep track of bound properties.
 
   Every time a property is bound using a `{{mustache}}`, an anonymous subclass
-  of Ember._HandlebarsBoundView is created with the appropriate sub-template and
-  context set up. When the associated property changes, just the template for
-  this view will re-render.
+  of `Ember._HandlebarsBoundView` is created with the appropriate sub-template
+  and context set up. When the associated property changes, just the template
+  for this view will re-render.
 
   @class _HandlebarsBoundView
   @namespace Ember
@@ -19317,6 +20821,7 @@ var get = Ember.get, set = Ember.set, getPath = Ember.Handlebars.getPath;
   @private
 */
 Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
+  instrumentName: 'render.boundHandlebars',
 
   /**
     The function used to determine if the `displayTemplate` or
@@ -19336,7 +20841,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
 
     For example, this is true when using the `{{#if}}` helper, because the
     template inside the helper should look up properties relative to the same
-    object as outside the block. This would be false when used with `{{#with
+    object as outside the block. This would be `false` when used with `{{#with
     foo}}` because the template should receive the object found by evaluating
     `foo`.
 
@@ -19356,7 +20861,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
   previousContext: null,
 
   /**
-    The template to render when `shouldDisplayFunc` evaluates to true.
+    The template to render when `shouldDisplayFunc` evaluates to `true`.
 
     @property displayTemplate
     @type Function
@@ -19365,7 +20870,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
   displayTemplate: null,
 
   /**
-    The template to render when `shouldDisplayFunc` evaluates to false.
+    The template to render when `shouldDisplayFunc` evaluates to `false`.
 
     @property inverseTemplate
     @type Function
@@ -19378,7 +20883,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
     The path to look up on `pathRoot` that is passed to
     `shouldDisplayFunc` to determine which template to render.
 
-    In addition, if `preserveContext` is false, the object at this path will
+    In addition, if `preserveContext` is `false,` the object at this path will
     be passed to the template when rendering.
 
     @property path
@@ -19389,9 +20894,9 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
 
   /**
     The object from which the `path` will be looked up. Sometimes this is the
-    same as the `previousContext`, but in cases where this view has been generated
-    for paths that start with a keyword such as `view` or `controller`, the
-    path root will be that resolved object.
+    same as the `previousContext`, but in cases where this view has been
+    generated for paths that start with a keyword such as `view` or
+    `controller`, the path root will be that resolved object.
 
     @property pathRoot
     @type Object
@@ -19412,7 +20917,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
       result = pathRoot;
     } else {
       templateData = get(this, 'templateData');
-      result = getPath(pathRoot, path, { data: templateData });
+      result = handlebarsGet(pathRoot, path, { data: templateData });
     }
 
     return valueNormalizer ? valueNormalizer(result) : result;
@@ -19426,15 +20931,15 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
 
   /**
     Determines which template to invoke, sets up the correct state based on
-    that logic, then invokes the default Ember.View `render` implementation.
+    that logic, then invokes the default `Ember.View` `render` implementation.
 
     This method will first look up the `path` key on `pathRoot`,
     then pass that value to the `shouldDisplayFunc` function. If that returns
-    true, the `displayTemplate` function will be rendered to DOM. Otherwise,
+    `true,` the `displayTemplate` function will be rendered to DOM. Otherwise,
     `inverseTemplate`, if specified, will be rendered.
 
-    For example, if this Ember._HandlebarsBoundView represented the `{{#with foo}}`
-    helper, it would look up the `foo` property of its context, and
+    For example, if this `Ember._HandlebarsBoundView` represented the `{{#with
+    foo}}` helper, it would look up the `foo` property of its context, and
     `shouldDisplayFunc` would always return true. The object found by looking
     up `foo` would be passed to `displayTemplate`.
 
@@ -19511,7 +21016,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
 */
 
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
-var getPath = Ember.Handlebars.getPath, normalizePath = Ember.Handlebars.normalizePath;
+var handlebarsGet = Ember.Handlebars.get, normalizePath = Ember.Handlebars.normalizePath;
 var forEach = Ember.ArrayPolyfills.forEach;
 
 var EmberHandlebars = Ember.Handlebars, helpers = EmberHandlebars.helpers;
@@ -19523,8 +21028,10 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
       fn = options.fn,
       inverse = options.inverse,
       view = data.view,
+      instrumentName = view.instrumentName,
       currentContext = this,
-      pathRoot, path, normalized;
+      pathRoot, path, normalized,
+      observer;
 
   normalized = normalizePath(currentContext, property, data);
 
@@ -19533,27 +21040,52 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
 
   // Set up observers for observable objects
   if ('object' === typeof this) {
-    // Create the view that will wrap the output of this template/property
-    // and add it to the nearest view's childViews array.
-    // See the documentation of Ember._HandlebarsBoundView for more.
-    var bindView = view.createChildView(Ember._HandlebarsBoundView, {
-      preserveContext: preserveContext,
-      shouldDisplayFunc: shouldDisplay,
-      valueNormalizerFunc: valueNormalizer,
-      displayTemplate: fn,
-      inverseTemplate: inverse,
-      path: path,
-      pathRoot: pathRoot,
-      previousContext: currentContext,
-      isEscaped: !options.hash.unescaped,
-      templateData: options.data
-    });
+    if (data.insideGroup) {
+      observer = function() {
+        Ember.run.once(view, 'rerender');
+      };
 
-    view.appendChild(bindView);
+      var template, context, result = handlebarsGet(pathRoot, path, options);
 
-    var observer = function() {
-      Ember.run.scheduleOnce('render', bindView, 'rerenderIfNeeded');
-    };
+      result = valueNormalizer(result);
+
+      context = preserveContext ? currentContext : result;
+      if (shouldDisplay(result)) {
+        template = fn;
+      } else if (inverse) {
+        template = inverse;
+      }
+
+      template(context, { data: options.data });
+    } else {
+      var bindView = Ember.instrument('bind-view.' + instrumentName,
+        { object: view.toString() },
+        function() {
+          // Create the view that will wrap the output of this template/property
+          // and add it to the nearest view's childViews array.
+          // See the documentation of Ember._HandlebarsBoundView for more.
+          var bindView = view.createChildView(Ember._HandlebarsBoundView, {
+            preserveContext: preserveContext,
+            shouldDisplayFunc: shouldDisplay,
+            valueNormalizerFunc: valueNormalizer,
+            displayTemplate: fn,
+            inverseTemplate: inverse,
+            path: path,
+            pathRoot: pathRoot,
+            previousContext: currentContext,
+            isEscaped: !options.hash.unescaped,
+            templateData: options.data
+          });
+
+          view.appendChild(bindView);
+          return bindView;
+        });
+
+      /** @private */
+      observer = function() {
+        Ember.run.scheduleOnce('render', bindView, 'rerenderIfNeeded');
+      };
+    }
 
     // Observes the given property on the context and
     // tells the Ember._HandlebarsBoundView to re-render. If property
@@ -19561,11 +21093,74 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
     // object ({{this}}) so updating it is not our responsibility.
     if (path !== '') {
       Ember.addObserver(pathRoot, path, observer);
+
+      view.one('willClearRender', function() {
+        Ember.removeObserver(pathRoot, path, observer);
+      });
     }
   } else {
     // The object is not observable, so just render it out and
     // be done with it.
-    data.buffer.push(getPath(pathRoot, path, options));
+    data.buffer.push(handlebarsGet(pathRoot, path, options));
+  }
+}
+
+function simpleBind(property, options) {
+  var data = options.data,
+      view = data.view,
+      instrumentName = view.instrumentName,
+      currentContext = this,
+      pathRoot, path, normalized,
+      observer;
+
+  normalized = normalizePath(currentContext, property, data);
+
+  pathRoot = normalized.root;
+  path = normalized.path;
+
+  // Set up observers for observable objects
+  if ('object' === typeof this) {
+    if (data.insideGroup) {
+      observer = function() {
+        Ember.run.once(view, 'rerender');
+      };
+
+      var result = handlebarsGet(pathRoot, path, options);
+      if (result === null || result === undefined) { result = ""; }
+      data.buffer.push(result);
+    } else {
+      var bindView = Ember.instrument('simple-bind-view.' + instrumentName,
+        { object: view.toString() },
+        function() {
+          var bindView = new Ember._SimpleHandlebarsView(
+            path, pathRoot, !options.hash.unescaped, options.data
+          );
+
+          bindView._parentView = view;
+          view.appendChild(bindView);
+          return bindView;
+        });
+
+      observer = function() {
+        Ember.run.scheduleOnce('render', bindView, 'rerender');
+      };
+    }
+
+    // Observes the given property on the context and
+    // tells the Ember._HandlebarsBoundView to re-render. If property
+    // is an empty string, we are printing the current context
+    // object ({{this}}) so updating it is not our responsibility.
+    if (path !== '') {
+      Ember.addObserver(pathRoot, path, observer);
+
+      view.one('willClearRender', function() {
+        Ember.removeObserver(pathRoot, path, observer);
+      });
+    }
+  } else {
+    // The object is not observable, so just render it out and
+    // be done with it.
+    data.buffer.push(handlebarsGet(pathRoot, path, options));
   }
 }
 
@@ -19602,16 +21197,16 @@ EmberHandlebars.registerHelper('_triageMustache', function(property, fn) {
   changes. For example, if you wanted to print the `title` property of
   `content`:
 
-  ``` handlebars
+  ```handlebars
   {{bind "content.title"}}
   ```
 
-  This will return the `title` property as a string, then create a new
-  observer at the specified path. If it changes, it will update the value in
-  DOM. Note that if you need to support IE7 and IE8 you must modify the
-  model objects properties using Ember.get() and Ember.set() for this to work as
-  it relies on Ember's KVO system.  For all other browsers this will be handled
-  for you automatically.
+  This will return the `title` property as a string, then create a new observer
+  at the specified path. If it changes, it will update the value in DOM. Note
+  that if you need to support IE7 and IE8 you must modify the model objects
+  properties using `Ember.get()` and `Ember.set()` for this to work as it
+  relies on Ember's KVO system. For all other browsers this will be handled for
+  you automatically.
 
   @method bind
   @for Ember.Handlebars.helpers
@@ -19619,12 +21214,16 @@ EmberHandlebars.registerHelper('_triageMustache', function(property, fn) {
   @param {Function} fn Context to provide for rendering
   @return {String} HTML string
 */
-EmberHandlebars.registerHelper('bind', function(property, fn) {
+EmberHandlebars.registerHelper('bind', function(property, options) {
   Ember.assert("You cannot pass more than one argument to the bind helper", arguments.length <= 2);
 
-  var context = (fn.contexts && fn.contexts[0]) || this;
+  var context = (options.contexts && options.contexts[0]) || this;
 
-  return bind.call(context, property, fn, false, function(result) {
+  if (!options.fn) {
+    return simpleBind.call(context, property, options);
+  }
+
+  return bind.call(context, property, options, false, function(result) {
     return !Ember.none(result);
   });
 });
@@ -19633,9 +21232,9 @@ EmberHandlebars.registerHelper('bind', function(property, fn) {
   @private
 
   Use the `boundIf` helper to create a conditional that re-evaluates
-  whenever the bound value changes.
+  whenever the truthiness of the bound value changes.
 
-  ``` handlebars
+  ```handlebars
   {{#boundIf "content.shouldDisplayTitle"}}
     {{content.title}}
   {{/boundIf}}
@@ -19707,6 +21306,8 @@ EmberHandlebars.registerHelper('with', function(context, options) {
 
 
 /**
+  See `boundIf`
+
   @method if
   @for Ember.Handlebars.helpers
   @param {Function} context
@@ -19743,8 +21344,118 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
   `bindAttr` allows you to create a binding between DOM element attributes and
   Ember objects. For example:
 
-  ``` handlebars
+  ```handlebars
   <img {{bindAttr src="imageUrl" alt="imageTitle"}}>
+  ```
+
+  The above handlebars template will fill the `<img>`'s `src` attribute will
+  the value of the property referenced with `"imageUrl"` and its `alt`
+  attribute with the value of the property referenced with `"imageTitle"`.
+
+  If the rendering context of this template is the following object:
+
+  ```javascript
+  {
+    imageUrl: 'http://lolcats.info/haz-a-funny',
+    imageTitle: 'A humorous image of a cat'
+  }
+  ```
+
+  The resulting HTML output will be:
+
+  ```html
+  <img src="http://lolcats.info/haz-a-funny" alt="A humorous image of a cat">
+  ```
+
+  `bindAttr` cannot redeclare existing DOM element attributes. The use of `src`
+  in the following `bindAttr` example will be ignored and the hard coded value
+  of `src="/failwhale.gif"` will take precedence:
+
+  ```handlebars
+  <img src="/failwhale.gif" {{bindAttr src="imageUrl" alt="imageTitle"}}>
+  ```
+
+  ### `bindAttr` and the `class` attribute
+
+  `bindAttr` supports a special syntax for handling a number of cases unique
+  to the `class` DOM element attribute. The `class` attribute combines
+  multiple discreet values into a single attribute as a space-delimited
+  list of strings. Each string can be:
+
+  * a string return value of an object's property.
+  * a boolean return value of an object's property
+  * a hard-coded value
+
+  A string return value works identically to other uses of `bindAttr`. The
+  return value of the property will become the value of the attribute. For
+  example, the following view and template:
+
+  ```javascript
+    AView = Ember.View.extend({
+      someProperty: function(){
+        return "aValue";
+      }.property()
+    })
+  ```
+
+  ```handlebars
+  <img {{bindAttr class="view.someProperty}}>
+  ```
+
+  Result in the following rendered output:
+
+  ```html 
+  <img class="aValue">
+  ```
+
+  A boolean return value will insert a specified class name if the property
+  returns `true` and remove the class name if the property returns `false`.
+
+  A class name is provided via the syntax 
+  `somePropertyName:class-name-if-true`.
+
+  ```javascript
+  AView = Ember.View.extend({
+    someBool: true
+  })
+  ```
+
+  ```handlebars
+  <img {{bindAttr class="view.someBool:class-name-if-true"}}>
+  ```
+
+  Result in the following rendered output:
+
+  ```html
+  <img class="class-name-if-true">
+  ```
+
+  An additional section of the binding can be provided if you want to
+  replace the existing class instead of removing it when the boolean
+  value changes:
+
+  ```handlebars
+  <img {{bindAttr class="view.someBool:class-name-if-true:class-name-if-false"}}>
+  ```
+
+  A hard-coded value can be used by prepending `:` to the desired
+  class name: `:class-name-to-always-apply`.
+
+  ```handlebars
+  <img {{bindAttr class=":class-name-to-always-apply"}}>
+  ```
+
+  Results in the following rendered output:
+
+  ```html
+  <img class=":class-name-to-always-apply">
+  ```
+
+  All three strategies - string return value, boolean return value, and
+  hard-coded value – can be combined in a single declaration:
+
+  ```handlebars
+  <img {{bindAttr class=":class-name-to-always-apply view.someBool:class-name-if-true view.someProperty"}}>
   ```
 
   @method bindAttr
@@ -19758,19 +21469,24 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
 
   Ember.assert("You must specify at least one hash argument to bindAttr", !!Ember.keys(attrs).length);
 
-  var view = options.data.view;
+  var view = options.data.view, instrumentName = view.instrumentName;
   var ret = [];
   var ctx = this;
 
   // Generate a unique id for this element. This will be added as a
   // data attribute to the element so it can be looked up when
   // the bound property changes.
-  var dataId = ++Ember.$.uuid;
+  var dataId = ++Ember.uuid;
 
   // Handle classes differently, as we can bind multiple classes
   var classBindings = attrs['class'];
   if (classBindings !== null && classBindings !== undefined) {
-    var classResults = EmberHandlebars.bindClasses(this, classBindings, view, dataId, options);
+    var classResults = Ember.instrument('class-bindings.' + instrumentName,
+      { object: view.toString() },
+      function() {
+        return EmberHandlebars.bindClasses(this, classBindings, view, dataId, options);
+      }, this);
+
     ret.push('class="' + Handlebars.Utils.escapeExpression(classResults.join(' ')) + '"');
     delete attrs['class'];
   }
@@ -19790,7 +21506,7 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
     pathRoot = normalized.root;
     path = normalized.path;
 
-    var value = (path === 'this') ? pathRoot : getPath(pathRoot, path, options),
+    var value = (path === 'this') ? pathRoot : handlebarsGet(pathRoot, path, options),
         type = Ember.typeOf(value);
 
     Ember.assert(fmt("Attributes must be numbers, strings or booleans, not %@", [value]), value === null || value === undefined || type === 'number' || type === 'string' || type === 'boolean');
@@ -19798,7 +21514,7 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
     var observer, invoker;
 
     observer = function observer() {
-      var result = getPath(pathRoot, path, options);
+      var result = handlebarsGet(pathRoot, path, options);
 
       Ember.assert(fmt("Attributes must be numbers, strings or booleans, not %@", [result]), result === null || result === undefined || typeof result === 'number' || typeof result === 'string' || typeof result === 'boolean');
 
@@ -19825,6 +21541,10 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
     // unique data id and update the attribute to the new value.
     if (path !== 'this') {
       Ember.addObserver(pathRoot, path, invoker);
+
+      view.one('willClearRender', function() {
+        Ember.removeObserver(pathRoot, path, invoker);
+      });
     }
 
     // if this changes, also change the logic in ember-views/lib/views/view.js
@@ -19859,8 +21579,10 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
   @method bindClasses
   @for Ember.Handlebars
   @param {Ember.Object} context The context from which to lookup properties
-  @param {String} classBindings A string, space-separated, of class bindings to use
-  @param {Ember.View} view The view in which observers should look for the element to update
+  @param {String} classBindings A string, space-separated, of class bindings 
+    to use
+  @param {Ember.View} view The view in which observers should look for the 
+    element to update
   @param {Srting} bindAttrId Optional bindAttr id used to lookup elements
   @return {Array} An array of class names to add
 */
@@ -19879,7 +21601,7 @@ EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId,
     } else if (path === '') {
       val = true;
     } else {
-      val = getPath(root, path, options);
+      val = handlebarsGet(root, path, options);
     }
 
     return Ember.View._classStringForValue(path, val, parsedPath.className, parsedPath.falsyClassName);
@@ -19942,6 +21664,10 @@ EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId,
 
     if (path !== '' && path !== 'this') {
       Ember.addObserver(pathRoot, path, invoker);
+
+      view.one('willClearRender', function() {
+        Ember.removeObserver(pathRoot, path, invoker);
+      });
     }
 
     // We've already setup the observer; now we just need to figure out the
@@ -19977,7 +21703,6 @@ EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId,
 var get = Ember.get, set = Ember.set;
 var PARENT_VIEW_PATH = /^parentView\./;
 var EmberHandlebars = Ember.Handlebars;
-var VIEW_PRESERVES_CONTEXT = Ember.VIEW_PRESERVES_CONTEXT;
 
 EmberHandlebars.ViewHelper = Ember.Object.create({
 
@@ -20049,17 +21774,13 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
           //
           // is converted to this:
           //
-          //     classNameBinding="bindingContext.isGreen:green"
+          //     classNameBinding="context.isGreen:green"
           var parsedPath = Ember.View._parsePropertyPath(full);
           path = this.contextualizeBindingPath(parsedPath.path, data);
           if (path) { extensions.classNameBindings[b] = path + parsedPath.classNames; }
         }
       }
     }
-
-    // Make the current template context available to the view
-    // for the bindings set up above.
-    extensions.bindingContext = thisContext;
 
     return Ember.$.extend(hash, extensions);
   },
@@ -20075,9 +21796,9 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
     } else if (Ember.isGlobalPath(path)) {
       return null;
     } else if (path === 'this') {
-      return 'bindingContext';
+      return 'context';
     } else {
-      return 'bindingContext.' + path;
+      return 'context.' + path;
     }
   },
 
@@ -20090,7 +21811,7 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
         newView;
 
     if ('string' === typeof path) {
-      newView = EmberHandlebars.getPath(thisContext, path, options);
+      newView = EmberHandlebars.get(thisContext, path, options);
       Ember.assert("Unable to find view at path '" + path + "'", !!newView);
     } else {
       newView = path;
@@ -20109,7 +21830,7 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 
     // We only want to override the `_context` computed property if there is
     // no specified controller. See View#_context for more information.
-    if (VIEW_PRESERVES_CONTEXT && !newView.proto().controller && !newView.proto().controllerBinding && !viewOptions.controller && !viewOptions.controllerBinding) {
+    if (!newView.proto().controller && !newView.proto().controllerBinding && !viewOptions.controller && !viewOptions.controllerBinding) {
       viewOptions._context = thisContext;
     }
 
@@ -20118,25 +21839,24 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 });
 
 /**
-  `{{view}}` inserts a new instance of `Ember.View` into a template passing its options
-  to the `Ember.View`'s `create` method and using the supplied block as the view's own template.
+  `{{view}}` inserts a new instance of `Ember.View` into a template passing its
+  options to the `Ember.View`'s `create` method and using the supplied block as
+  the view's own template.
 
   An empty `<body>` and the following template:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    A span:
-    {{#view tagName="span"}}
-      hello.
-    {{/view}}
-  </script>
+  ```handlebars
+  A span:
+  {{#view tagName="span"}}
+    hello.
+  {{/view}}
   ```
 
   Will result in HTML structure:
 
-  ``` html
+  ```html
   <body>
-    <!-- Note: the handlebars template script 
+    <!-- Note: the handlebars template script
          also results in a rendered Ember.View
          which is the outer <div> here -->
 
@@ -20149,22 +21869,23 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
   </body>
   ```
 
-  ### parentView setting
+  ### `parentView` setting
 
-  The `parentView` property of the new `Ember.View` instance created through `{{view}}`
-  will be set to the `Ember.View` instance of the template where `{{view}}` was called.
+  The `parentView` property of the new `Ember.View` instance created through
+  `{{view}}` will be set to the `Ember.View` instance of the template where
+  `{{view}}` was called.
 
-  ``` javascript
+  ```javascript
   aView = Ember.View.create({
     template: Ember.Handlebars.compile("{{#view}} my parent: {{parentView.elementId}} {{/view}}")
   });
 
   aView.appendTo('body');
   ```
-    
+
   Will result in HTML structure:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">
     <div id="ember2" class="ember-view">
       my parent: ember1
@@ -20174,20 +21895,18 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 
   ### Setting CSS id and class attributes
 
-  The HTML `id` attribute can be set on the `{{view}}`'s resulting element with the `id` option.
-  This option will _not_ be passed to `Ember.View.create`.
+  The HTML `id` attribute can be set on the `{{view}}`'s resulting element with
+  the `id` option. This option will _not_ be passed to `Ember.View.create`.
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#view tagName="span" id="a-custom-id"}}
-      hello.
-    {{/view}}
-  </script>
+  ```handlebars
+  {{#view tagName="span" id="a-custom-id"}}
+    hello.
+  {{/view}}
   ```
 
   Results in the following HTML structure:
 
-  ``` html
+  ```html
   <div class="ember-view">
     <span id="a-custom-id" class="ember-view">
       hello.
@@ -20195,23 +21914,21 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
   </div>
   ```
 
-  The HTML `class` attribute can be set on the `{{view}}`'s resulting element with
-  the `class` or `classNameBindings` options. The `class` option
-  will directly set the CSS `class` attribute and will not be passed to
+  The HTML `class` attribute can be set on the `{{view}}`'s resulting element
+  with the `class` or `classNameBindings` options. The `class` option will
+  directly set the CSS `class` attribute and will not be passed to
   `Ember.View.create`. `classNameBindings` will be passed to `create` and use
   `Ember.View`'s class name binding functionality:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#view tagName="span" class="a-custom-class"}}
-      hello.
-    {{/view}}
-  </script>
+  ```handlebars
+  {{#view tagName="span" class="a-custom-class"}}
+    hello.
+  {{/view}}
   ```
 
   Results in the following HTML structure:
 
-  ``` html
+  ```html
   <div class="ember-view">
     <span id="ember2" class="ember-view a-custom-class">
       hello.
@@ -20221,21 +21938,20 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 
   ### Supplying a different view class
 
-  `{{view}}` can take an optional first argument before its supplied options to specify a
-  path to a custom view class.
+  `{{view}}` can take an optional first argument before its supplied options to
+  specify a path to a custom view class.
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#view "MyApp.CustomView"}}
-      hello.
-    {{/view}}
-  </script>
+  ```handlebars
+  {{#view "MyApp.CustomView"}}
+    hello.
+  {{/view}}
   ```
 
-  The first argument can also be a relative path. Ember will search for the view class
-  starting at the `Ember.View` of the template where `{{view}}` was used as the root object:
+  The first argument can also be a relative path. Ember will search for the
+  view class starting at the `Ember.View` of the template where `{{view}}` was
+  used as the root object:
 
-  ``` javascript
+  ```javascript
   MyApp = Ember.Application.create({});
   MyApp.OuterView = Ember.View.extend({
     innerViewClass: Ember.View.extend({
@@ -20249,9 +21965,9 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 
   Will result in the following HTML:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">
-    <div id="ember2" class="ember-view a-custom-view-class-as-property"> 
+    <div id="ember2" class="ember-view a-custom-view-class-as-property">
       hi
     </div>
   </div>
@@ -20260,21 +21976,20 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
   ### Blockless use
 
   If you supply a custom `Ember.View` subclass that specifies its own template
-  or provide a `templateName` option to `{{view}}` it can be used without supplying a block.
-  Attempts to use both a `templateName` option and supply a block will throw an error.
+  or provide a `templateName` option to `{{view}}` it can be used without
+  supplying a block. Attempts to use both a `templateName` option and supply a
+  block will throw an error.
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{view "MyApp.ViewWithATemplateDefined"}}
-  </script>
+  ```handlebars
+  {{view "MyApp.ViewWithATemplateDefined"}}
   ```
 
-  ### viewName property
+  ### `viewName` property
 
-  You can supply a `viewName` option to `{{view}}`. The `Ember.View` instance will
-  be referenced as a property of its parent view by this name.
+  You can supply a `viewName` option to `{{view}}`. The `Ember.View` instance
+  will be referenced as a property of its parent view by this name.
 
-  ``` javascript
+  ```javascript
   aView = Ember.View.create({
     template: Ember.Handlebars.compile('{{#view viewName="aChildByName"}} hi {{/view}}')
   });
@@ -20315,33 +22030,32 @@ EmberHandlebars.registerHelper('view', function(path, options) {
 @submodule ember-handlebars
 */
 
-var get = Ember.get, getPath = Ember.Handlebars.getPath, fmt = Ember.String.fmt;
+var get = Ember.get, handlebarsGet = Ember.Handlebars.get, fmt = Ember.String.fmt;
 
 /**
   `{{collection}}` is a `Ember.Handlebars` helper for adding instances of
-  `Ember.CollectionView` to a template.  See `Ember.CollectionView` for additional
-  information on how a `CollectionView` functions.
+  `Ember.CollectionView` to a template. See `Ember.CollectionView` for
+  additional information on how a `CollectionView` functions.
 
-  `{{collection}}`'s primary use is as a block helper with a `contentBinding` option
-  pointing towards an `Ember.Array`-compatible object.  An `Ember.View` instance will
-  be created for each item in its `content` property. Each view will have its own
-  `content` property set to the appropriate item in the collection.
+  `{{collection}}`'s primary use is as a block helper with a `contentBinding`
+  option pointing towards an `Ember.Array`-compatible object. An `Ember.View`
+  instance will be created for each item in its `content` property. Each view
+  will have its own `content` property set to the appropriate item in the
+  collection.
 
   The provided block will be applied as the template for each item's view.
 
   Given an empty `<body>` the following template:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#collection contentBinding="App.items"}}
-      Hi {{view.content.name}}
-    {{/collection}}
-  </script>
+  ```handlebars
+  {{#collection contentBinding="App.items"}}
+    Hi {{view.content.name}}
+  {{/collection}}
   ```
 
   And the following application code
 
-  ``` javascript
+  ```javascript
   App = Ember.Application.create()
   App.items = [
     Ember.Object.create({name: 'Dave'}),
@@ -20352,7 +22066,7 @@ var get = Ember.get, getPath = Ember.Handlebars.getPath, fmt = Ember.String.fmt;
 
   Will result in the HTML structure below
 
-  ``` html
+  ```html
   <div class="ember-view">
     <div class="ember-view">Hi Dave</div>
     <div class="ember-view">Hi Mary</div>
@@ -20361,20 +22075,19 @@ var get = Ember.get, getPath = Ember.Handlebars.getPath, fmt = Ember.String.fmt;
   ```
 
   ### Blockless Use
-  If you provide an `itemViewClass` option that has its own `template` you can omit
-  the block.
+
+  If you provide an `itemViewClass` option that has its own `template` you can
+  omit the block.
 
   The following template:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{collection contentBinding="App.items" itemViewClass="App.AnItemView"}}
-  </script>
+  ```handlebars
+  {{collection contentBinding="App.items" itemViewClass="App.AnItemView"}}
   ```
 
   And application code
 
-  ``` javascript
+  ```javascript
   App = Ember.Application.create();
   App.items = [
     Ember.Object.create({name: 'Dave'}),
@@ -20389,7 +22102,7 @@ var get = Ember.get, getPath = Ember.Handlebars.getPath, fmt = Ember.String.fmt;
 
   Will result in the HTML structure below
 
-  ``` html
+  ```html
   <div class="ember-view">
     <div class="ember-view">Greetings Dave</div>
     <div class="ember-view">Greetings Mary</div>
@@ -20399,38 +22112,34 @@ var get = Ember.get, getPath = Ember.Handlebars.getPath, fmt = Ember.String.fmt;
 
   ### Specifying a CollectionView subclass
 
-  By default the `{{collection}}` helper will create an instance of `Ember.CollectionView`.
-  You can supply a `Ember.CollectionView` subclass to the helper by passing it
-  as the first argument:
+  By default the `{{collection}}` helper will create an instance of
+  `Ember.CollectionView`. You can supply a `Ember.CollectionView` subclass to
+  the helper by passing it as the first argument:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#collection App.MyCustomCollectionClass contentBinding="App.items"}}
-      Hi {{view.content.name}}
-    {{/collection}}
-  </script>
+  ```handlebars
+  {{#collection App.MyCustomCollectionClass contentBinding="App.items"}}
+    Hi {{view.content.name}}
+  {{/collection}}
   ```
-
 
   ### Forwarded `item.*`-named Options
 
-  As with the `{{view}}`, helper options passed to the `{{collection}}` will be set on
-  the resulting `Ember.CollectionView` as properties. Additionally, options prefixed with
-  `item` will be applied to the views rendered for each item (note the camelcasing):
+  As with the `{{view}}`, helper options passed to the `{{collection}}` will be
+  set on the resulting `Ember.CollectionView` as properties. Additionally,
+  options prefixed with `item` will be applied to the views rendered for each
+  item (note the camelcasing):
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#collection contentBinding="App.items"
-                  itemTagName="p"
-                  itemClassNames="greeting"}}
-      Howdy {{view.content.name}}
-    {{/collection}}
-  </script>
+  ```handlebars
+  {{#collection contentBinding="App.items"
+                itemTagName="p"
+                itemClassNames="greeting"}}
+    Howdy {{view.content.name}}
+  {{/collection}}
   ```
 
   Will result in the following HTML structure:
 
-  ``` html
+  ```html
   <div class="ember-view">
     <p class="ember-view greeting">Howdy Dave</p>
     <p class="ember-view greeting">Howdy Mary</p>
@@ -20443,8 +22152,11 @@ var get = Ember.get, getPath = Ember.Handlebars.getPath, fmt = Ember.String.fmt;
   @param {String} path
   @param {Hash} options
   @return {String} HTML string
+  @deprecated Use `{{each}}` helper instead.
 */
 Ember.Handlebars.registerHelper('collection', function(path, options) {
+  Ember.deprecate("Using the {{collection}} helper without specifying a class has been deprecated as the {{each}} helper now supports the same functionality.", path !== 'collection');
+
   // If no path is provided, treat path param as options.
   if (path && path.data && path.data.isRenderData) {
     options = path;
@@ -20457,11 +22169,13 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
   var fn = options.fn;
   var data = options.data;
   var inverse = options.inverse;
+  var view = options.data.view;
+  var instrumentName = view.instrumentName;
 
   // If passed a path string, convert that into an object.
   // Otherwise, just default to the standard class.
   var collectionClass;
-  collectionClass = path ? getPath(this, path, options) : Ember.CollectionView;
+  collectionClass = path ? handlebarsGet(this, path, options) : Ember.CollectionView;
   Ember.assert(fmt("%@ #collection: Could not find collection class %@", [data.view, path]), !!collectionClass);
 
   var hash = options.hash, itemHash = {}, match;
@@ -20470,7 +22184,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
   var itemViewClass, itemViewPath = hash.itemViewClass;
   var collectionPrototype = collectionClass.proto();
   delete hash.itemViewClass;
-  itemViewClass = itemViewPath ? getPath(collectionPrototype, itemViewPath, options) : collectionPrototype.itemViewClass;
+  itemViewClass = itemViewPath ? handlebarsGet(collectionPrototype, itemViewPath, options) : collectionPrototype.itemViewClass;
   Ember.assert(fmt("%@ #collection: Could not find itemViewClass %@", [data.view, itemViewPath]), !!itemViewClass);
 
   // Go through options passed to the {{collection}} helper and extract options
@@ -20504,7 +22218,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
           tagName: itemHash.tagName
     });
   } else if (hash.emptyViewClass) {
-    emptyViewClass = getPath(this, hash.emptyViewClass, options);
+    emptyViewClass = handlebarsGet(this, hash.emptyViewClass, options);
   }
   hash.emptyView = emptyViewClass;
 
@@ -20515,10 +22229,21 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
     delete hash.eachHelper;
   }
 
-  var viewOptions = Ember.Handlebars.ViewHelper.propertiesFromHTMLOptions({ data: data, hash: itemHash }, this);
-  hash.itemViewClass = itemViewClass.extend(viewOptions);
+  var viewString = view.toString();
 
-  return Ember.Handlebars.helpers.view.call(this, collectionClass, options);
+  Ember.instrument('collection-setup.' + instrumentName,
+    { object: viewString },
+    function() {
+      var viewOptions = Ember.Handlebars.ViewHelper.propertiesFromHTMLOptions({ data: data, hash: itemHash }, this);
+      viewOptions._anonymous = true;
+      hash.itemViewClass = itemViewClass.extend(viewOptions);
+    });
+
+  return Ember.instrument('collection-view.' + instrumentName,
+    { object: viewString },
+    function() {
+      return Ember.Handlebars.helpers.view.call(this, collectionClass, options);
+    }, this);
 });
 
 
@@ -20533,13 +22258,13 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
 @submodule ember-handlebars
 */
 
-var getPath = Ember.Handlebars.getPath;
+var handlebarsGet = Ember.Handlebars.get;
 
 /**
   `unbound` allows you to output a property without binding. *Important:* The
   output will not be updated if the property changes. Use with caution.
 
-  ``` handlebars
+  ```handlebars
   <div>{{unbound somePropertyThatDoesntChange}}</div>
   ```
 
@@ -20550,7 +22275,7 @@ var getPath = Ember.Handlebars.getPath;
 */
 Ember.Handlebars.registerHelper('unbound', function(property, fn) {
   var context = (fn.contexts && fn.contexts[0]) || this;
-  return getPath(context, property, fn);
+  return handlebarsGet(context, property, fn);
 });
 
 })();
@@ -20564,13 +22289,13 @@ Ember.Handlebars.registerHelper('unbound', function(property, fn) {
 @submodule ember-handlebars
 */
 
-var getPath = Ember.Handlebars.getPath, normalizePath = Ember.Handlebars.normalizePath;
+var handlebarsGet = Ember.Handlebars.get, normalizePath = Ember.Handlebars.normalizePath;
 
 /**
   `log` allows you to output the value of a value in the current rendering
   context.
 
-  ``` handlebars
+  ```handlebars
   {{log myVariable}}
   ```
 
@@ -20583,15 +22308,14 @@ Ember.Handlebars.registerHelper('log', function(property, options) {
       normalized = normalizePath(context, property, options.data),
       pathRoot = normalized.root,
       path = normalized.path,
-      value = (path === 'this') ? pathRoot : getPath(pathRoot, path, options);
+      value = (path === 'this') ? pathRoot : handlebarsGet(pathRoot, path, options);
   Ember.Logger.log(value);
 });
 
 /**
-  The `debugger` helper executes the `debugger` statement in the current
-  context.
+  Execute the `debugger` statement in the current context.
 
-  ``` handlebars
+  ```handlebars
   {{debugger}}
   ```
 
@@ -20645,14 +22369,103 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
   }
 });
 
-/**
-  The `{{#each}}` helper loops over elements in a collection, rendering its block once for each item:
+var GroupedEach = Ember.Handlebars.GroupedEach = function(context, path, options) {
+  var self = this,
+      normalized = Ember.Handlebars.normalizePath(context, path, options.data);
 
-  ``` javascript
+  this.context = context;
+  this.path = path;
+  this.options = options;
+  this.template = options.fn;
+  this.containingView = options.data.view;
+  this.normalizedRoot = normalized.root;
+  this.normalizedPath = normalized.path;
+  this.content = this.lookupContent();
+
+  this.addContentObservers();
+  this.addArrayObservers();
+
+  this.containingView.on('willClearRender', function() {
+    self.destroy();
+  });
+};
+
+GroupedEach.prototype = {
+  contentWillChange: function() {
+    this.removeArrayObservers();
+  },
+
+  contentDidChange: function() {
+    this.content = this.lookupContent();
+    this.addArrayObservers();
+    this.rerenderContainingView();
+  },
+
+  contentArrayWillChange: Ember.K,
+
+  contentArrayDidChange: function() {
+    this.rerenderContainingView();
+  },
+
+  lookupContent: function() {
+    return Ember.Handlebars.get(this.normalizedRoot, this.normalizedPath, this.options);
+  },
+
+  addArrayObservers: function() {
+    this.content.addArrayObserver(this, {
+      willChange: 'contentArrayWillChange',
+      didChange: 'contentArrayDidChange'
+    });
+  },
+
+  removeArrayObservers: function() {
+    this.content.removeArrayObserver(this, {
+      willChange: 'contentArrayWillChange',
+      didChange: 'contentArrayDidChange'
+    });
+  },
+
+  addContentObservers: function() {
+    Ember.addBeforeObserver(this.normalizedRoot, this.normalizedPath, this, this.contentWillChange);
+    Ember.addObserver(this.normalizedRoot, this.normalizedPath, this, this.contentDidChange);
+  },
+
+  removeContentObservers: function() {
+    Ember.removeBeforeObserver(this.normalizedRoot, this.normalizedPath, this.contentWillChange);
+    Ember.removeObserver(this.normalizedRoot, this.normalizedPath, this.contentDidChange);
+  },
+
+  render: function() {
+    var content = this.content,
+        contentLength = get(content, 'length'),
+        data = this.options.data,
+        template = this.template;
+
+    data.insideEach = true;
+    for (var i = 0; i < contentLength; i++) {
+      template(content.objectAt(i), { data: data });
+    }
+  },
+
+  rerenderContainingView: function() {
+    Ember.run.scheduleOnce('render', this.containingView, 'rerender');
+  },
+
+  destroy: function() {
+    this.removeContentObservers();
+    this.removeArrayObservers();
+  }
+};
+
+/**
+  The `{{#each}}` helper loops over elements in a collection, rendering its
+  block once for each item:
+
+  ```javascript
   Developers = [{name: 'Yehuda'},{name: 'Tom'}, {name: 'Paul'}];
   ```
 
-  ``` handlebars
+  ```handlebars
   {{#each Developers}}
     {{name}}
   {{/each}}
@@ -20660,19 +22473,20 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
 
   `{{each}}` supports an alternative syntax with element naming:
 
-  ``` handlebars
+  ```handlebars
   {{#each person in Developers}}
     {{person.name}}
   {{/each}}
   ```
 
-  When looping over objects that do not have properties, `{{this}}` can be used to render the object:
+  When looping over objects that do not have properties, `{{this}}` can be used
+  to render the object:
 
-  ``` javascript
+  ```javascript
   DeveloperNames = ['Yehuda', 'Tom', 'Paul']
   ```
 
-  ``` handlebars
+  ```handlebars
   {{#each DeveloperNames}}
     {{this}}
   {{/each}}
@@ -20680,22 +22494,21 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
 
   ### Blockless Use
 
-  If you provide an `itemViewClass` option that has its own `template` you can omit
-  the block in a similar way to how it can be done with the collection helper.
+  If you provide an `itemViewClass` option that has its own `template` you can
+  omit the block in a similar way to how it can be done with the collection
+  helper.
 
   The following template:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#view App.MyView }}
-      {{each view.items itemViewClass="App.AnItemView"}} 
-    {{/view}}
-  </script>
+  ```handlebars
+  {{#view App.MyView }}
+    {{each view.items itemViewClass="App.AnItemView"}} 
+  {{/view}}
   ```
 
   And application code
 
-  ``` javascript
+  ```javascript
   App = Ember.Application.create({
     MyView: Ember.View.extend({
       items: [
@@ -20709,20 +22522,19 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
   App.AnItemView = Ember.View.extend({
     template: Ember.Handlebars.compile("Greetings {{name}}")
   });
-      
+
   App.initialize();
   ```
-      
+
   Will result in the HTML structure below
 
-  ``` html
+  ```html
   <div class="ember-view">
     <div class="ember-view">Greetings Dave</div>
     <div class="ember-view">Greetings Mary</div>
     <div class="ember-view">Greetings Sara</div>
   </div>
   ```
-
 
   @method each
   @for Ember.Handlebars.helpers
@@ -20748,7 +22560,11 @@ Ember.Handlebars.registerHelper('each', function(path, options) {
   // Set up emptyView as a metamorph with no tag
   //options.hash.emptyViewClass = Ember._MetamorphView;
 
-  return Ember.Handlebars.helpers.collection.call(this, 'Ember.Handlebars.EachView', options);
+  if (options.data.insideGroup && !options.hash.groupedRows && !options.hash.itemViewClass) {
+    new Ember.Handlebars.GroupedEach(this, path, options).render();
+  } else {
+    return Ember.Handlebars.helpers.collection.call(this, 'Ember.Handlebars.EachView', options);
+  }
 });
 
 })();
@@ -20765,27 +22581,29 @@ Ember.Handlebars.registerHelper('each', function(path, options) {
   `template` allows you to render a template from inside another template.
   This allows you to re-use the same template in multiple places. For example:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
+  ```handlebars
+  <script type="text/x-handlebars" data-template-name="logged_in_user">
     {{#with loggedInUser}}
       Last Login: {{lastLogin}}
       User Info: {{template "user_info"}}
     {{/with}}
   </script>
+  ```
 
+  ```handlebars
   <script type="text/x-handlebars" data-template-name="user_info">
     Name: <em>{{name}}</em>
     Karma: <em>{{karma}}</em>
   </script>
   ```
 
-  This helper looks for templates in the global Ember.TEMPLATES hash. If you
-  add &lt;script&gt; tags to your page with the `data-template-name` attribute set,
+  This helper looks for templates in the global `Ember.TEMPLATES` hash. If you
+  add `<script>` tags to your page with the `data-template-name` attribute set,
   they will be compiled and placed in this hash automatically.
 
   You can also manually register templates by adding them to the hash:
 
-  ``` javascript
+  ```javascript
   Ember.TEMPLATES["my_cool_template"] = Ember.Handlebars.compile('<b>{{user}}</b>');
   ```
 
@@ -20813,7 +22631,7 @@ Ember.Handlebars.registerHelper('template', function(name, options) {
 */
 
 var EmberHandlebars = Ember.Handlebars,
-    getPath = EmberHandlebars.getPath,
+    handlebarsGet = EmberHandlebars.get,
     get = Ember.get,
     a_slice = Array.prototype.slice;
 
@@ -20822,7 +22640,7 @@ var ActionHelper = EmberHandlebars.ActionHelper = {
 };
 
 ActionHelper.registerAction = function(actionName, options) {
-  var actionId = (++Ember.$.uuid).toString();
+  var actionId = (++Ember.uuid).toString();
 
   ActionHelper.registeredActions[actionId] = {
     eventName: options.eventName,
@@ -20860,7 +22678,7 @@ ActionHelper.registerAction = function(actionName, options) {
     }
   };
 
-  options.view.on('willRerender', function() {
+  options.view.on('willClearRender', function() {
     delete ActionHelper.registeredActions[actionId];
   });
 
@@ -20868,18 +22686,19 @@ ActionHelper.registerAction = function(actionName, options) {
 };
 
 /**
-  The `{{action}}` helper registers an HTML element within a template for
-  DOM event handling and forwards that interaction to the Application's router,
-  the template's `Ember.View` instance, or supplied `target` option (see 'Specifying a Target').
-  
+  The `{{action}}` helper registers an HTML element within a template for DOM
+  event handling and forwards that interaction to the view's
+  `controller.target` or supplied `target` option (see 'Specifying a Target').
+  By default the `controller.target` is set to the application's router.
+
   User interaction with that element will invoke the supplied action name on
   the appropriate target.
 
   Given the following Handlebars template on the page
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
-    <div {{action anActionName}}>
+    <div {{action anActionName target="view"}}>
       click me
     </div>
   </script>
@@ -20887,9 +22706,9 @@ ActionHelper.registerAction = function(actionName, options) {
 
   And application code
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
-    templateName; 'a-template',
+    templateName: 'a-template',
     anActionName: function(event){}
   });
 
@@ -20899,7 +22718,7 @@ ActionHelper.registerAction = function(actionName, options) {
 
   Will results in the following rendered HTML
 
-  ``` html
+  ```html
   <div class="ember-view">
     <div data-ember-action="1">
       click me
@@ -20920,15 +22739,15 @@ ActionHelper.registerAction = function(actionName, options) {
   handler.
 
   If you need the default handler to trigger you should either register your
-  own event handler, or use event methods on your view class. See Ember.View
+  own event handler, or use event methods on your view class. See `Ember.View`
   'Responding to Browser Events' for more information.
-  
+
   ### Specifying DOM event type
 
   By default the `{{action}}` helper registers for DOM `click` events. You can
   supply an `on` option to the helper to specify a different DOM event name:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName on="doubleClick"}}>
       click me
@@ -20936,7 +22755,7 @@ ActionHelper.registerAction = function(actionName, options) {
   </script>
   ```
 
-  See Ember.View 'Responding to Browser Events' for a list of
+  See `Ember.View` 'Responding to Browser Events' for a list of
   acceptable DOM event names.
 
   Because `{{action}}` depends on Ember's event dispatch system it will only
@@ -20944,28 +22763,30 @@ ActionHelper.registerAction = function(actionName, options) {
   `Ember.EventDispatcher` instance will be created when a new
   `Ember.Application` is created. Having an instance of `Ember.Application`
   will satisfy this requirement.
-  
-  
+
   ### Specifying a Target
+
   There are several possible target objects for `{{action}}` helpers:
-  
+
   In a typical `Ember.Router`-backed Application where views are managed
   through use of the `{{outlet}}` helper, actions will be forwarded to the
-  current state of the Applications's Router. See Ember.Router 'Responding
+  current state of the Applications's Router. See `Ember.Router` 'Responding
   to User-initiated Events' for more information.
-  
-  If you manually set the `target` property on the controller of a template's
-  `Ember.View` instance, the specifed `controller.target` will become the target
-  for any actions. Likely custom values for a controller's `target` are the
-  controller itself or a StateManager other than the Application's Router.
-  
-  If the templates's view lacks a controller property the view itself is the target.
-  
-  Finally, a `target` option can be provided to the helper to change which object
-  will receive the method call. This option must be a string representing a
-  path to an object:
 
-  ``` handlebars
+  If you manually set the `target` property on the controller of a template's
+  `Ember.View` instance, the specifed `controller.target` will become the
+  target for any actions. Likely custom values for a controller's `target` are
+  the controller itself or a StateManager other than the Application's
+  router.
+
+  If the templates's view lacks a controller property the view itself is the
+  target.
+
+  Finally, a `target` option can be provided to the helper to change which
+  object will receive the method call. This option must be a string
+  representing a path to an object:
+
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName target="MyApplication.someObject"}}>
       click me
@@ -20981,7 +22802,7 @@ ActionHelper.registerAction = function(actionName, options) {
   A path relative to the template's `Ember.View` instance can also be used as
   a target:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName target="parentView"}}>
       click me
@@ -21000,7 +22821,7 @@ ActionHelper.registerAction = function(actionName, options) {
   If an action's target does not implement a method that matches the supplied
   action name an error will be thrown.
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action aMethodNameThatIsMissing}}>
       click me
@@ -21010,7 +22831,7 @@ ActionHelper.registerAction = function(actionName, options) {
 
   With the following application code
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     templateName; 'a-template',
     // note: no method 'aMethodNameThatIsMissing'
@@ -21023,14 +22844,15 @@ ActionHelper.registerAction = function(actionName, options) {
 
   Will throw `Uncaught TypeError: Cannot call method 'call' of undefined` when
   "click me" is clicked.
-  
+
   ### Specifying a context
 
-  By default the `{{action}}` helper passes the current Handlebars context
-  along in the `jQuery.Event` object. You may specify an alternate object to
-  pass as the context by providing a property path:
+  You may optionally specify objects to pass as contexts to the `{{action}}`
+  helper by providing property paths as the subsequent parameters. These
+  objects are made available as the `contexts` (also `context` if there is only
+  one) properties in the `jQuery.Event` object:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     {{#each person in people}}
       <div {{action edit person}}>
@@ -21039,6 +22861,9 @@ ActionHelper.registerAction = function(actionName, options) {
     {{/each}}
   </script>
   ```
+
+  Clicking "click me" will trigger the `edit` method of the view's context with
+  a `jQuery.Event` object containing the person object as its context.
 
   @method action
   @for Ember.Handlebars.helpers
@@ -21062,7 +22887,7 @@ EmberHandlebars.registerHelper('action', function(actionName) {
   action.view = view = get(view, 'concreteView');
 
   if (hash.target) {
-    target = getPath(this, hash.target, options);
+    target = handlebarsGet(this, hash.target, options);
   } else if (controller = options.data.keywords.controller) {
     target = get(controller, 'target');
   }
@@ -21071,7 +22896,7 @@ EmberHandlebars.registerHelper('action', function(actionName) {
 
   if (contexts.length) {
     action.contexts = contexts = Ember.EnumerableUtils.map(contexts, function(context) {
-      return getPath(this, context, options);
+      return handlebarsGet(this, context, options);
     }, this);
     action.context = contexts[0];
   }
@@ -21103,17 +22928,16 @@ EmberHandlebars.registerHelper('action', function(actionName) {
 var get = Ember.get, set = Ember.set;
 
 /**
-
-  When used in a Handlebars template that is assigned to an `Ember.View` instance's
-  `layout` property Ember will render the layout template first, inserting the view's
-  own rendered output at the `{{ yield }}` location.
+  When used in a Handlebars template that is assigned to an `Ember.View`
+  instance's `layout` property Ember will render the layout template first,
+  inserting the view's own rendered output at the `{{yield}}` location.
 
   An empty `<body>` and the following application code:
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     classNames: ['a-view-with-layout'],
-    layout: Ember.Handlebars.compile('<div class="wrapper">{{ yield }}</div>'),
+    layout: Ember.Handlebars.compile('<div class="wrapper">{{yield}}</div>'),
     template: Ember.Handlebars.compile('<span>I am wrapped</span>')
   });
 
@@ -21123,7 +22947,7 @@ var get = Ember.get, set = Ember.set;
 
   Will result in the following HTML output:
 
-  ``` html
+  ```html
   <body>
     <div class='ember-view a-view-with-layout'>
       <div class="wrapper">
@@ -21133,10 +22957,10 @@ var get = Ember.get, set = Ember.set;
   </body>
   ```
 
-  The yield helper cannot be used outside of a template assigned to an `Ember.View`'s `layout` property
-  and will throw an error if attempted.
+  The `yield` helper cannot be used outside of a template assigned to an
+  `Ember.View`'s `layout` property and will throw an error if attempted.
 
-  ``` javascript
+  ```javascript
   BView = Ember.View.extend({
     classNames: ['a-view-with-layout'],
     template: Ember.Handlebars.compile('{{yield}}')
@@ -21184,31 +23008,34 @@ Ember.Handlebars.OutletView = Ember.ContainerView.extend(Ember._Metamorph);
   The `outlet` helper allows you to specify that the current
   view's controller will fill in the view for a given area.
 
-  ``` handlebars
+  ```handlebars
   {{outlet}}
   ```
 
-  By default, when the the current controller's `view`
-  property changes, the outlet will replace its current
-  view with the new view.
+  By default, when the the current controller's `view` property changes, the
+  outlet will replace its current view with the new view. You can set the
+  `view` property directly, but it's normally best to use `connectOutlet`.
 
-  ``` javascript
-  controller.set('view', someView);
+  ```javascript
+  # Instantiate App.PostsView and assign to `view`, so as to render into outlet.
+  controller.connectOutlet('posts');
   ```
 
-  You can also specify a particular name, other than view:
+  You can also specify a particular name other than `view`:
 
-  ``` handlebars
+  ```handlebars
   {{outlet masterView}}
   {{outlet detailView}}
   ```
 
-  Then, you can control several outlets from a single
-  controller:
+  Then, you can control several outlets from a single controller.
 
-  ``` javascript
-  controller.set('masterView', postsView);
-  controller.set('detailView', postView);
+  ```javascript
+  # Instantiate App.PostsView and assign to controller.masterView.
+  controller.connectOutlet('masterView', 'posts');
+
+  # Also, instantiate App.PostInfoView and assign to controller.detailView.
+  controller.connectOutlet('detailView', 'postInfo');
   ```
 
   @method outlet
@@ -21222,7 +23049,7 @@ Ember.Handlebars.registerHelper('outlet', function(property, options) {
     property = 'view';
   }
 
-  options.hash.currentViewBinding = "controller." + property;
+  options.hash.currentViewBinding = "view.context." + property;
 
   return Ember.Handlebars.helpers.view.call(this, Ember.Handlebars.OutletView, options);
 });
@@ -21252,33 +23079,38 @@ Ember.Handlebars.registerHelper('outlet', function(property, options) {
 var set = Ember.set, get = Ember.get;
 
 /**
-  The `Ember.Checkbox` view class renders a checkbox [input](https://developer.mozilla.org/en/HTML/Element/Input) 
-  element. It allows for binding an Ember property (`checked`) to the status of the checkbox.
+  The `Ember.Checkbox` view class renders a checkbox
+  [input](https://developer.mozilla.org/en/HTML/Element/Input) element. It
+  allows for binding an Ember property (`checked`) to the status of the
+  checkbox.
 
   Example:
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Checkbox checkedBinding="receiveEmail"}}
   ```
 
-  You can add a `label` tag yourself in the template where the Ember.Checkbox is being used.
+  You can add a `label` tag yourself in the template where the `Ember.Checkbox`
+  is being used.
 
-  ``` html
-  <label>        
+  ```html
+  <label>
     {{view Ember.Checkbox classNames="applicaton-specific-checkbox"}}
     Some Title
   </label>
   ```
 
-
-  The `checked` attribute of an Ember.Checkbox object should always be set
-  through the Ember object or by interacting with its rendered element representation
-  via the mouse, keyboard, or touch.  Updating the value of the checkbox via jQuery will
-  result in the checked value of the object and its element losing synchronization.
+  The `checked` attribute of an `Ember.Checkbox` object should always be set
+  through the Ember object or by interacting with its rendered element
+  representation via the mouse, keyboard, or touch. Updating the value of the
+  checkbox via jQuery will result in the checked value of the object and its
+  element losing synchronization.
 
   ## Layout and LayoutName properties
-  Because HTML `input` elements are self closing `layout` and `layoutName` properties will
-  not be applied. See `Ember.View`'s layout section for more information.
+
+  Because HTML `input` elements are self closing `layout` and `layoutName`
+  properties will not be applied. See `Ember.View`'s layout section for more
+  information.
 
   @class Checkbox
   @namespace Ember
@@ -21318,7 +23150,7 @@ Ember.Checkbox = Ember.View.extend({
 var get = Ember.get, set = Ember.set;
 
 /**
-  Shared mixin used by Ember.TextField and Ember.TextArea.
+  Shared mixin used by `Ember.TextField` and `Ember.TextArea`.
 
   @class TextSupport
   @namespace Ember
@@ -21382,13 +23214,31 @@ var get = Ember.get, set = Ember.set;
 
   Example:
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.TextField valueBinding="firstName"}}
   ```
 
   ## Layout and LayoutName properties
-  Because HTML `input` elements are self closing `layout` and `layoutName` properties will
-  not be applied. See `Ember.View`'s layout section for more information.
+
+  Because HTML `input` elements are self closing `layout` and `layoutName`
+  properties will not be applied. See `Ember.View`'s layout section for more
+  information.
+
+  ## HTML Attributes
+
+  By default `Ember.TextField` provides support for `type`, `value`, `size`,
+  `placeholder`, `disabled`, `maxlength` and `tabindex` attributes on a
+  test field. If you need to support more attributes have a look at the
+  `attributeBindings` property in `Ember.View`'s HTML Attributes section.
+
+  To globally add support for additional attributes you can reopen
+  `Ember.TextField` or `Ember.TextSupport`.
+
+  ```javascript
+  Ember.TextSupport.reopen({
+    attributeBindings: ["required"]
+  })
+  ```
 
   @class TextField
   @namespace Ember
@@ -21403,7 +23253,7 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
   attributeBindings: ['type', 'value', 'size'],
 
   /**
-    The value attribute of the input element. As the user inputs text, this
+    The `value` attribute of the input element. As the user inputs text, this
     property is updated live.
 
     @property value
@@ -21413,7 +23263,7 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
   value: "",
 
   /**
-    The type attribute of the input element.
+    The `type` attribute of the input element.
 
     @property type
     @type String
@@ -21422,7 +23272,7 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
   type: "text",
 
   /**
-    The size of the text field in characters.
+    The `size` of the text field in characters.
 
     @property size
     @type String
@@ -21463,7 +23313,7 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
   /**
     @private
 
-    Overrides TargetActionSupport's targetObject computed
+    Overrides `TargetActionSupport`'s `targetObject` computed
     property to use Handlebars-specific path resolution.
 
     @property targetObject
@@ -21475,23 +23325,21 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
 
     if (typeof target !== 'string') { return target; }
 
-    return Ember.Handlebars.getPath(root, target, { data: data });
-  }).property('target').cacheable(),
+    return Ember.Handlebars.get(root, target, { data: data });
+  }).property('target'),
 
   // Defaults to 'button' if tagName is 'input' or 'button'
-  type: Ember.computed(function(key, value) {
-    var tagName = this.get('tagName');
-    if (value !== undefined) { this._type = value; }
-    if (this._type !== undefined) { return this._type; }
+  type: Ember.computed(function(key) {
+    var tagName = this.tagName;
     if (tagName === 'input' || tagName === 'button') { return 'button'; }
-  }).property('tagName').cacheable(),
+  }).property(),
 
   disabled: false,
 
   // Allow 'a' tags to act like buttons
   href: Ember.computed(function() {
-    return this.get('tagName') === 'a' ? '#' : null;
-  }).property('tagName').cacheable(),
+    return this.tagName === 'a' ? '#' : null;
+  }).property(),
 
   mouseDown: function() {
     if (!get(this, 'disabled')) {
@@ -21543,7 +23391,7 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
     }
   },
 
-  // TODO: Handle proper touch behavior.  Including should make inactive when
+  // TODO: Handle proper touch behavior. Including should make inactive when
   // finger moves more than 20x outside of the edge of the button (vs mouse
   // which goes inactive as soon as mouse goes out of edges.)
 
@@ -21581,8 +23429,25 @@ var get = Ember.get, set = Ember.set;
 
   ## Layout and LayoutName properties
 
-  Because HTML `textarea` elements do not contain inner HTML the `layout` and `layoutName` 
-  properties will not be applied. See `Ember.View`'s layout section for more information.
+  Because HTML `textarea` elements do not contain inner HTML the `layout` and
+  `layoutName` properties will not be applied. See `Ember.View`'s layout
+  section for more information.
+
+  ## HTML Attributes
+
+  By default `Ember.TextArea` provides support for `rows`, `cols`,
+  `placeholder`, `disabled`, `maxlength` and `tabindex` attributes on a
+  textarea. If you need to support  more attributes have a look at the
+  `attributeBindings` property in `Ember.View`'s HTML Attributes section.
+
+  To globally add support for additional attributes you can reopen
+  `Ember.TextArea` or `Ember.TextSupport`.
+
+  ```javascript
+  Ember.TextSupport.reopen({
+    attributeBindings: ["required"]
+  })
+  ```
 
   @class TextArea
   @namespace Ember
@@ -21656,7 +23521,7 @@ var get = Ember.get;
 */
 Ember.TabPaneView = Ember.View.extend({
   tabsContainer: Ember.computed(function() {
-    return this.nearestInstanceOf(Ember.TabContainerView);
+    return this.nearestOfType(Ember.TabContainerView);
   }).property().volatile(),
 
   isVisible: Ember.computed(function() {
@@ -21720,102 +23585,108 @@ Ember.TabView = Ember.View.extend({
 @submodule ember-handlebars
 */
 
-var set = Ember.set, get = Ember.get;
-var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.indexesOf;
+var set = Ember.set,
+    get = Ember.get,
+    indexOf = Ember.EnumerableUtils.indexOf,
+    indexesOf = Ember.EnumerableUtils.indexesOf,
+    replace = Ember.EnumerableUtils.replace,
+    isArray = Ember.isArray;
 
 /**
-  The Ember.Select view class renders a
+  The `Ember.Select` view class renders a
   [select](https://developer.mozilla.org/en/HTML/Element/select) HTML element,
-  allowing the user to choose from a list of options. 
+  allowing the user to choose from a list of options.
 
-  The text and `value` property of each `<option>` element within the `<select>` element
-  are populated from the objects in the Element.Select's `content` property. The
-  underlying data object of the selected `<option>` is stored in the
-  Element.Select's `value` property.
+  The text and `value` property of each `<option>` element within the
+  `<select>` element are populated from the objects in the `Element.Select`'s
+  `content` property. The underlying data object of the selected `<option>` is
+  stored in the `Element.Select`'s `value` property.
 
   ### `content` as an array of Strings
-  The simplest version of an Ember.Select takes an array of strings as its `content` property.
-  The string will be used as both the `value` property and the inner text of each `<option>`
-  element inside the rendered `<select>`.
+
+  The simplest version of an `Ember.Select` takes an array of strings as its
+  `content` property. The string will be used as both the `value` property and
+  the inner text of each `<option>` element inside the rendered `<select>`.
 
   Example:
 
-  ``` javascript
-  App.Names = ["Yehuda", "Tom"];
+  ```javascript
+  App.names = ["Yehuda", "Tom"];
   ```
 
-  ``` handlebars
-  {{view Ember.Select contentBinding="App.Names"}}
+  ```handlebars
+  {{view Ember.Select contentBinding="App.names"}}
   ```
 
   Would result in the following HTML:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value="Yehuda">Yehuda</option>
     <option value="Tom">Tom</option>
   </select>
   ```
 
-  You can control which `<option>` is selected through the Ember.Select's
+  You can control which `<option>` is selected through the `Ember.Select`'s
   `value` property directly or as a binding:
 
-  ``` javascript
-  App.Names = Ember.Object.create({
+  ```javascript
+  App.names = Ember.Object.create({
     selected: 'Tom',
     content: ["Yehuda", "Tom"]
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
-         contentBinding="App.controller.content"
-         valueBinding="App.controller.selected"
+         contentBinding="App.names.content"
+         valueBinding="App.names.selected"
   }}
   ```
 
   Would result in the following HTML with the `<option>` for 'Tom' selected:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value="Yehuda">Yehuda</option>
     <option value="Tom" selected="selected">Tom</option>
   </select>
   ```
 
-  A user interacting with the rendered `<select>` to choose "Yehuda" would update
-  the value of `App.controller.selected` to "Yehuda". 
+  A user interacting with the rendered `<select>` to choose "Yehuda" would
+  update the value of `App.names.selected` to "Yehuda".
 
   ### `content` as an Array of Objects
-  An Ember.Select can also take an array of JavaScript or Ember objects
-  as its `content` property.
 
-  When using objects you need to tell the Ember.Select which property should be
-  accessed on each object to supply the `value` attribute of the `<option>`
+  An `Ember.Select` can also take an array of JavaScript or Ember objects as
+  its `content` property.
+
+  When using objects you need to tell the `Ember.Select` which property should
+  be accessed on each object to supply the `value` attribute of the `<option>`
   and which property should be used to supply the element text.
 
   The `optionValuePath` option is used to specify the path on each object to
-  the desired property for the `value` attribute.  The `optionLabelPath` 
-  specifies the path on each object to the desired property for the 
-  element's text. Both paths must reference each object itself as 'content':
+  the desired property for the `value` attribute. The `optionLabelPath`
+  specifies the path on each object to the desired property for the
+  element's text. Both paths must reference each object itself as `content`:
 
-  ``` javascript
-  App.Programmers = [
-      Ember.Object.create({firstName: "Yehuda", id: 1}),
-      Ember.Object.create({firstName: "Tom",    id: 2})
-    ];
+  ```javascript
+  App.programmers = [
+    Ember.Object.create({firstName: "Yehuda", id: 1}),
+    Ember.Object.create({firstName: "Tom",    id: 2})
+  ];
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
-         contentBinding="App.Programmers"
+         contentBinding="App.programmers"
          optionValuePath="content.id"
          optionLabelPath="content.firstName"}}
   ```
 
   Would result in the following HTML:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value>Please Select</option>
     <option value="1">Yehuda</option>
@@ -21823,25 +23694,24 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
   </select>
   ```
 
-
-  The `value` attribute of the selected `<option>` within an Ember.Select
+  The `value` attribute of the selected `<option>` within an `Ember.Select`
   can be bound to a property on another object by providing a
   `valueBinding` option:
 
-  ``` javascript
-  App.Programmers = [
-      Ember.Object.create({firstName: "Yehuda", id: 1}),
-      Ember.Object.create({firstName: "Tom",    id: 2})
-    ];
+  ```javascript
+  App.programmers = [
+    Ember.Object.create({firstName: "Yehuda", id: 1}),
+    Ember.Object.create({firstName: "Tom",    id: 2})
+  ];
 
   App.currentProgrammer = Ember.Object.create({
     id: 2
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
-         contentBinding="App.controller.content"
+         contentBinding="App.programmers"
          optionValuePath="content.id"
          optionLabelPath="content.firstName"
          valueBinding="App.currentProgrammer.id"}}
@@ -21849,7 +23719,7 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
 
   Would result in the following HTML with a selected option:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value>Please Select</option>
     <option value="1">Yehuda</option>
@@ -21865,9 +23735,9 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
   used to render each object providing a `selectionBinding`. When the selected
   `<option>` is changed, the property path provided to `selectionBinding`
   will be updated to match the content object of the rendered `<option>`
-  element: 
+  element:
 
-  ``` javascript
+  ```javascript
   App.controller = Ember.Object.create({
     selectedPerson: null,
     content: [
@@ -21877,7 +23747,7 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
          contentBinding="App.controller.content"
          optionValuePath="content.id"
@@ -21887,7 +23757,7 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
 
   Would result in the following HTML with a selected option:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value>Please Select</option>
     <option value="1">Yehuda</option>
@@ -21895,18 +23765,17 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
   </select>
   ```
 
-
   Interacting with the rendered element by selecting the first option
   ('Yehuda') will update the `selectedPerson` value of `App.controller`
   to match the content object of the newly selected `<option>`. In this
-  case it is the first object in the `App.content.content` 
+  case it is the first object in the `App.content.content`
 
   ### Supplying a Prompt
 
-  A `null` value for the Ember.Select's `value` or `selection` property
+  A `null` value for the `Ember.Select`'s `value` or `selection` property
   results in there being no `<option>` with a `selected` attribute:
 
-  ``` javascript
+  ```javascript
   App.controller = Ember.Object.create({
     selected: null,
     content: [
@@ -21925,7 +23794,7 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
 
   Would result in the following HTML:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value="Yehuda">Yehuda</option>
     <option value="Tom">Tom</option>
@@ -21935,10 +23804,10 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
   Although `App.controller.selected` is `null` and no `<option>`
   has a `selected` attribute the rendered HTML will display the
   first item as though it were selected. You can supply a string
-  value for the Ember.Select to display when there is no selection
+  value for the `Ember.Select` to display when there is no selection
   with the `prompt` option:
 
-  ``` javascript
+  ```javascript
   App.controller = Ember.Object.create({
     selected: null,
     content: [
@@ -21948,7 +23817,7 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
          contentBinding="App.controller.content"
          valueBinding="App.controller.selected"
@@ -21958,7 +23827,7 @@ var indexOf = Ember.EnumerableUtils.indexOf, indexesOf = Ember.EnumerableUtils.i
 
   Would result in the following HTML:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option>Please select a name</option>
     <option value="Yehuda">Yehuda</option>
@@ -21976,7 +23845,7 @@ Ember.Select = Ember.View.extend(
   tagName: 'select',
   classNames: ['ember-select'],
   defaultTemplate: Ember.Handlebars.compile('{{#if view.prompt}}<option value>{{view.prompt}}</option>{{/if}}{{#each view.content}}{{view Ember.SelectOption contentBinding="this"}}{{/each}}'),
-  attributeBindings: ['multiple', 'tabindex'],
+  attributeBindings: ['multiple', 'disabled', 'tabindex'],
 
   /**
     The `multiple` attribute of the select element. Indicates whether multiple
@@ -21988,6 +23857,8 @@ Ember.Select = Ember.View.extend(
   */
   multiple: false,
 
+  disabled: false,
+
   /**
     The list of options.
 
@@ -21996,12 +23867,16 @@ Ember.Select = Ember.View.extend(
 
     Otherwise, this should be a list of objects. For instance:
 
-        content: Ember.A([
-            { id: 1, firstName: 'Yehuda' },
-            { id: 2, firstName: 'Tom' }
-          ]),
-        optionLabelPath: 'content.firstName',
-        optionValuePath: 'content.id'
+    ```javascript
+    Ember.Select.create({
+      content: Ember.A([
+          { id: 1, firstName: 'Yehuda' },
+          { id: 2, firstName: 'Tom' }
+        ]),
+      optionLabelPath: 'content.firstName',
+      optionValuePath: 'content.id'
+    });
+    ```
 
     @property content
     @type Array
@@ -22010,10 +23885,10 @@ Ember.Select = Ember.View.extend(
   content: null,
 
   /**
-    When `multiple` is false, the element of `content` that is currently
+    When `multiple` is `false`, the element of `content` that is currently
     selected, if any.
 
-    When `multiple` is true, an array of such elements.
+    When `multiple` is `true`, an array of such elements.
 
     @property selection
     @type Object or Array
@@ -22022,8 +23897,8 @@ Ember.Select = Ember.View.extend(
   selection: null,
 
   /**
-    In single selection mode (when `multiple` is false), value can be used to get
-    the current selection's value or set the selection by it's value.
+    In single selection mode (when `multiple` is `false`), value can be used to
+    get the current selection's value or set the selection by it's value.
 
     It is not currently supported in multiple selection mode.
 
@@ -22031,12 +23906,10 @@ Ember.Select = Ember.View.extend(
     @type String
     @default null
   */
-  value: Ember.computed(function(key, value) {
-    if (arguments.length === 2) { return value; }
-
+  value: Ember.computed(function(key) {
     var valuePath = get(this, 'optionValuePath').replace(/^content\.?/, '');
     return valuePath ? get(this, 'selection.' + valuePath) : get(this, 'selection');
-  }).property('selection').cacheable(),
+  }).property('selection'),
 
   /**
     If given, a top-most dummy option will be rendered to serve as a user
@@ -22075,10 +23948,9 @@ Ember.Select = Ember.View.extend(
   },
 
   selectionDidChange: Ember.observer(function() {
-    var selection = get(this, 'selection'),
-        isArray = Ember.isArray(selection);
+    var selection = get(this, 'selection');
     if (get(this, 'multiple')) {
-      if (!isArray) {
+      if (!isArray(selection)) {
         set(this, 'selection', Ember.A([selection]));
         return;
       }
@@ -22086,7 +23958,7 @@ Ember.Select = Ember.View.extend(
     } else {
       this._selectionDidChangeSingle();
     }
-  }, 'selection'),
+  }, 'selection.@each'),
 
   valueDidChange: Ember.observer(function() {
     var content = get(this, 'content'),
@@ -22127,18 +23999,26 @@ Ember.Select = Ember.View.extend(
     set(this, 'selection', content.objectAt(selectedIndex));
   },
 
+
   _changeMultiple: function() {
     var options = this.$('option:selected'),
         prompt = get(this, 'prompt'),
         offset = prompt ? 1 : 0,
-        content = get(this, 'content');
+        content = get(this, 'content'),
+        selection = get(this, 'selection');
 
     if (!content){ return; }
     if (options) {
       var selectedIndexes = options.map(function(){
         return this.index - offset;
       }).toArray();
-      set(this, 'selection', content.objectsAt(selectedIndexes));
+      var newSelection = content.objectsAt(selectedIndexes);
+
+      if (isArray(selection)) {
+        replace(selection, 0, get(selection, 'length'), newSelection);
+      } else {
+        set(this, 'selection', newSelection);
+      }
     }
   },
 
@@ -22214,7 +24094,7 @@ Ember.SelectOption = Ember.View.extend({
 
     Ember.defineProperty(this, 'label', Ember.computed(function() {
       return get(this, labelPath);
-    }).property(labelPath).cacheable());
+    }).property(labelPath));
   }, 'parentView.optionLabelPath'),
 
   valuePathDidChange: Ember.observer(function() {
@@ -22224,7 +24104,7 @@ Ember.SelectOption = Ember.View.extend({
 
     Ember.defineProperty(this, 'value', Ember.computed(function() {
       return get(this, valuePath);
-    }).property(valuePath).cacheable());
+    }).property(valuePath));
   }, 'parentView.optionValuePath')
 });
 
@@ -22249,12 +24129,12 @@ Ember.SelectOption = Ember.View.extend({
   @private
 
   Find templates stored in the head tag as script tags and make them available
-  to Ember.CoreView in the global Ember.TEMPLATES object. This will be run as as
-  jQuery DOM-ready callback.
+  to `Ember.CoreView` in the global `Ember.TEMPLATES` object. This will be run
+  as as jQuery DOM-ready callback.
 
-  Script tags with "text/x-handlebars" will be compiled
+  Script tags with `text/x-handlebars` will be compiled
   with Ember's Handlebars and are suitable for use as a view's template.
-  Those with type="text/x-raw-handlebars" will be compiled with regular
+  Those with type `text/x-raw-handlebars` will be compiled with regular
   Handlebars and are suitable for use in views' computed properties.
 
   @method bootstrap
@@ -22320,8 +24200,10 @@ Ember Handlebars
 
 })();
 
-// Version: v1.0.pre-151-gb993a76
-// Last commit: b993a76 (2012-09-18 21:53:28 -0700)
+
+})();
+// Version: v1.0.0-pre.2-103-g9fc4d5d
+// Last commit: 9fc4d5d (2012-12-09 11:22:46 -0800)
 
 
 (function() {

--- a/lib/giddyup/records.rb
+++ b/lib/giddyup/records.rb
@@ -64,4 +64,8 @@ class Scorecard < ActiveRecord::Base
   def tests
     project.tests.for_version(name)
   end
+
+  def test_ids
+    tests.pluck(:id)
+  end
 end

--- a/lib/giddyup/resources.rb
+++ b/lib/giddyup/resources.rb
@@ -205,10 +205,37 @@ module GiddyUp
     end
   end
 
+  class TestsResource < Resource
+    def resource_exists?
+      @tests = Test.find(query_ids)
+    rescue ActiveRecord::RecordNotFound
+      false
+    else
+      true
+    end
+
+    def to_json
+      ActiveModel::ArraySerializer(@tests, {:root => "tests"}).to_json
+    end
+  end
+
+  class TestResource < Resource
+    def resource_exists?
+      @test = Test.find(request.path_info[:id])
+      @test.present?
+    end
+
+    def to_json
+      TestSerializer.new(@test, {}).to_json
+    end
+  end
+
   Application.routes do
     add ['scorecards', :id], ScorecardResource
     add ['scorecards'], ScorecardsResource
     add ['logs', :id], LogResource
+    add ['tests', :id], TestResource
+    add ['tests'], TestsResource
     add ['test_results', :id], TestResultResource
     add ['test_results'], TestResultResource do |request|
       request.post?

--- a/lib/giddyup/resources.rb
+++ b/lib/giddyup/resources.rb
@@ -215,7 +215,7 @@ module GiddyUp
     end
 
     def to_json
-      ActiveModel::ArraySerializer(@tests, {:root => "tests"}).to_json
+      ActiveModel::ArraySerializer.new(@tests, {:root => "tests"}).to_json
     end
   end
 

--- a/lib/giddyup/serializers.rb
+++ b/lib/giddyup/serializers.rb
@@ -15,9 +15,12 @@ class TestResultSerializer < ActiveModel::Serializer
   attributes :id, :status, :log_url, :test_id, :scorecard_id, :created_at, :long_version
 end
 
+class TestSerializer < ActiveModel::Serializer
+  attributes :id, :name, :tags
+end
+
 class ScorecardSerializer < ActiveModel::Serializer
-  attributes :id, :name, :project, :test_result_ids
-  has_many :tests
+  attributes :id, :name, :project, :test_result_ids, :test_ids
 
   def project
     # We key the project off the name


### PR DESCRIPTION
It appears the following is broken:
- hasMany where the parent object contains the children keys are not triggering load when accessing the RecordArray.
- primaryKey is no longer working on objects with the latest Ember Data.  When loading a series of objects (/projects) where name is supposed to be the primary key, an array of 4 objects get loaded as one object, with only the last name persisting.
