### PR TITLE
Clean up, and ensure we always load record into RA.

### DIFF
--- a/assets/javascripts/app/events.js
+++ b/assets/javascripts/app/events.js
@@ -4,23 +4,19 @@ GiddyUp.EventProcessor = Ember.Object.extend({
 
     this.source.addEventListener('test_result', function(e) {
       var parsedResponse = JSON.parse(e.data);
-      var testResult     = parsedResponse.test_result;
-
-      // Load the new test result into the store.
-      //
-      GiddyUp.store.load(GiddyUp.TestResult, testResult);
+      var rawTestResult  = parsedResponse.test_result;
+      var testResult     = GiddyUp.TestResult.loadRawTestResult(
+                            rawTestResult);
 
       // Notification handling.
       //
       if (window.webkitNotifications &&
           window.webkitNotifications.checkPermission() === 0) {
-
-          var result  = GiddyUp.TestResult.find(testResult.id);
-          var message = result.get('notification');
+          var message = testResult.get('notification');
 
           window.webkitNotifications.createNotification(
-            "icon.png", message.title, message.message
-          ).show();
+            "icon.png", message.title, message.message).
+          show();
       }
     });
   }

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -90,6 +90,20 @@ GiddyUp.TestResult = DS.Model.extend({
   }.property()
 });
 
+GiddyUp.TestResult.reopenClass({
+  /** Load record, immediately materialize, and force listening array
+   ** proxies to reference object. */
+  loadRawTestResult: function(rawTestResult) {
+    var newTestResult = GiddyUp.store.load(GiddyUp.TestResult,
+                                           rawTestResult);
+    var testResult    = GiddyUp.TestResult.find(newTestResult.id);
+
+    testResult.get('test_instance.test_results').pushObject(testResult);
+
+    return testResult;
+  }
+});
+
 GiddyUp.Log = DS.Model.extend({
   body: DS.attr('string'),
 


### PR DESCRIPTION
This fixes a problem with SSE where a record doesn't show up if the association record-array already exists with a fixed set of identifiers.
