### PR TITLE
Change the event stream to use ActiveSupport::Notifications.

### DIFF
--- a/lib/giddyup/bootstrap.rb
+++ b/lib/giddyup/bootstrap.rb
@@ -38,17 +38,10 @@ GiddyUp::LogBucket = ENV['S3_BUCKET']
 GiddyUp::AUTH_USER = ENV['AUTH_USER']
 GiddyUp::AUTH_PASSWORD = ENV['AUTH_PASSWORD']
 
-### RedisToGo Setup
-require 'redis'
-REDISURL = URI.parse(ENV['REDISTOGO_URL'])
+### EVENTS SETUP
 
-module GiddyUp
-  module Redis
-    def self.new
-      ::Redis.new(:host     => REDISURL.host,
-                  :port     => REDISURL.port,
-                  :password => REDISURL.password
-                  )
-    end
-  end
-end
+# We can change this later to use whatever as long as we can make the
+# API similar. Redis on Heroku is flakey and we only have one server
+# process right now.
+require 'active_support/notifications'
+GiddyUp::Events = ActiveSupport::Notifications

--- a/lib/giddyup/contexts.rb
+++ b/lib/giddyup/contexts.rb
@@ -4,7 +4,6 @@ module GiddyUp
   class CreateTestResult
     def initialize
       @test_result = TestResult.new
-      @redis = GiddyUp::Redis.new
     end
 
     def id
@@ -33,11 +32,9 @@ module GiddyUp
     def publish_test_result
       result = TestResultSerializer.new(@test_result)
 
-      @redis.publish 'events', JSON.generate({
-        :id    => id,
-        :event => 'test_result',
-        :data  => { :test_result => result.serializable_hash }
-      })
+      GiddyUp::Events.publish('events', 'id' => id,
+                              'event' => 'test_result',
+                              'data' => {test_result: result.serializable_hash})
     end
 
     def create_log(data)


### PR DESCRIPTION
This allows us to get rid of Redis for the narrow use-case in which we are employing it. Since we have only one dyno on Heroku, ActiveSupport works for now. Later on we can build out that API if we like to make it more generic and hook in something real like RabbitMQ.
