### PR TITLE
More Riak 1.4 tests

### DIFF
--- a/db/migrate/2013060714121370632344_fix_level_db_backend_name.rb
+++ b/db/migrate/2013060714121370632344_fix_level_db_backend_name.rb
@@ -1,0 +1,19 @@
+require 'set'
+class FixLevelDbBackendName < ActiveRecord::Migration
+  def up
+    say_with_time "Fixing LevelDB backend name 'leveldb' -> 'eleveldb'" do
+      tests = Hash.new {|h,k| h[k] = 0 }
+      Test.where(['tests.tags::hstore @> ?',
+                  HstoreSerializer.dump('backend' => 'leveldb')]).each do |test|
+        tests[test.name] += 1
+        test.tags['backend'] = 'eleveldb'
+        test.save!
+      end
+      tests.each {|k,v| say "#{k}: #{v} instances", true }
+    end
+  end
+
+  def down
+    # don't do this
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 2013053112051370019910) do
+ActiveRecord::Schema.define(:version => 2013060714121370632344) do
 
   create_table "artifacts", :force => true do |t|
     t.string   "url"

--- a/db/seed.rb
+++ b/db/seed.rb
@@ -140,6 +140,13 @@ platforms.each do |p|
   backends.each do |b|
     create_riak_test 'verify_dynamic_ring', tags.merge('backend' => b)
   end
+  # New 2I tests
+  %w{eleveldb memory}.each do |b|
+    %w{verify_2i_stream verify_2i_limit verify_2i_returnterms
+       verify_cs_bucket}.each do |t|
+      create_riak_test t, tags.merge('backend' => b)
+    end
+  end
 end
 
 ## Riak EE-only tests

--- a/db/seed.rb
+++ b/db/seed.rb
@@ -19,7 +19,7 @@ platforms = %w{
 
 backends = %w{
   bitcask
-  leveldb
+  eleveldb
   memory
 }
 


### PR DESCRIPTION
Also fixes a bug with previous round where the backend on `verify_dynamic_ring` said `leveldb` instead of `eleveldb`.  Please ping me if you need a SQL dump to test against.
