### PR TITLE
Clean up the scorecard navigation

### DIFF
--- a/assets/javascripts/app/controllers.js
+++ b/assets/javascripts/app/controllers.js
@@ -1,6 +1,7 @@
 /* global $ */
 require('matrix');
 require('progress');
+require('dropdown');
 
 GiddyUp.ApplicationController = Ember.Controller.extend({
   toggleHelp: function(){
@@ -12,8 +13,12 @@ GiddyUp.ProjectsController = Ember.ArrayController.extend({
   sortProperties: ['name']
 });
 
-GiddyUp.ScorecardsController = Ember.ArrayController.extend({
-  sortProperties: ['name'],
+GiddyUp.ScorecardsController = GiddyUp.MatrixController.extend(
+  GiddyUp.ProgressMixin,
+  GiddyUp.DropdownMixin,
+  {
+  dimensions: ['version'],
+  orderByProperties: ['name'],
   sortAscending: false
 });
 

--- a/assets/javascripts/app/controllers.js
+++ b/assets/javascripts/app/controllers.js
@@ -17,10 +17,15 @@ GiddyUp.ScorecardsController = GiddyUp.MatrixController.extend(
   GiddyUp.ProgressMixin,
   GiddyUp.DropdownMixin,
   {
-  dimensions: ['version'],
-  orderByProperties: ['name'],
-  sortAscending: false
-});
+    dimensions: ['version'],
+    orderByProperties: ['name'],
+    matrix: function(){
+      var index = this._super();
+      index.set('sortAscending', false);
+      return index;
+    }.property('content', 'dimensions', 'dimensionValues')
+  }
+);
 
 GiddyUp.TestInstancesController = GiddyUp.MatrixController.extend(
   GiddyUp.ProgressMixin,

--- a/assets/javascripts/app/dropdown.js
+++ b/assets/javascripts/app/dropdown.js
@@ -1,0 +1,18 @@
+/* global $ */
+GiddyUp.DropdownMixin = Ember.Mixin.create({
+  toggleDropdown: function(){
+    var $dropdown = $(event.target).parents('li.dropdown');
+    $('li.dropdown.open').not($dropdown).removeClass('open');
+    $dropdown.toggleClass('open');
+  }
+});
+
+// I don't really like putting this here, but I seem not to have any
+// option. Thanks Ember.
+$(function(){
+  $('html').click(function(event){
+    if($(event.target).is('a.dropdown-toggle'))
+      return false;
+    $('li.dropdown.open').removeClass('open');
+  })
+});

--- a/assets/javascripts/app/matrix.js
+++ b/assets/javascripts/app/matrix.js
@@ -22,7 +22,10 @@ var Vector = Ember.ArrayController.extend({
     } else {
       return subtree.findByKeys(keys.slice(1));
     }
-  }
+  },
+  hasOneChild: function(){
+    return this.get('content.length') === 1;
+  }.property('content.length')
 });
 
 var createIndex = function(props, values, obp, container, target) {

--- a/assets/javascripts/app/matrix.js
+++ b/assets/javascripts/app/matrix.js
@@ -25,20 +25,21 @@ var Vector = Ember.ArrayController.extend({
   }
 });
 
-var createIndex = function(props, values, obp, container) {
+var createIndex = function(props, values, obp, container, target) {
   if (props.length === 0) {
     return [];
   } else {
     var prop = props.get('firstObject');
     var range = values.get('firstObject');
     return range.map(function(key) {
-      var subtree = createIndex(props.slice(1), values.slice(1), obp, container);
+      var subtree = createIndex(props.slice(1), values.slice(1), obp, container, target);
       return Vector.create({
         key: key,
         indexProperty: prop,
         orderByProperties: obp,
         content: subtree,
-        container: container
+        container: container,
+        target: target
       });
     });
   }
@@ -67,7 +68,7 @@ GiddyUp.MatrixController = Ember.ArrayController.extend({
     // Recursively build the index buckets
     index = Vector.create({
       container: container,
-      content: createIndex(dimensions, dimensionValues, obp, container)
+      content: createIndex(dimensions, dimensionValues, obp, container, this)
     });
 
     // Now insert the items

--- a/assets/javascripts/app/models.js
+++ b/assets/javascripts/app/models.js
@@ -7,7 +7,22 @@ GiddyUp.Project = DS.Model.extend({
 GiddyUp.Scorecard = DS.Model.extend({
   name: DS.attr('string'),
   project: DS.belongsTo('GiddyUp.Project'),
-  testInstances: DS.hasMany('GiddyUp.TestInstance')
+  testInstances: DS.hasMany('GiddyUp.TestInstance'),
+  version: function(){
+    var name = this.get('name'),
+        num_version = /\d+(?:\.\d+)+/.exec(name);
+
+    if(num_version === undefined || num_version === null){
+      return name;
+    } else {
+      num_version = num_version[0];
+      digits = num_version.split('.');
+      for(var i = 0; i < (3 - digits.length); i++){
+          num_version += ".0";
+      }
+      return num_version;
+    }
+  }.property('name')
 });
 
 GiddyUp.TestInstance = DS.Model.extend({

--- a/assets/javascripts/app/progress.js
+++ b/assets/javascripts/app/progress.js
@@ -2,8 +2,8 @@
 // progress of proxied models.
 GiddyUp.ProgressMixin = Ember.Mixin.create({
   isLoaded: function(){
-    return this.get('progressTotal') === this.get('progressComplete');
-  }.property('progressTotal', 'progressComplete'),
+    return this.get('content').everyProperty('isLoaded');
+  }.property('content', 'content.@each', 'content.@each.isLoaded'),
 
   progressTotal: Ember.computed.alias('content.length'),
 

--- a/assets/javascripts/app/templates/scorecards.hbs
+++ b/assets/javascripts/app/templates/scorecards.hbs
@@ -3,19 +3,10 @@
     <div class="navbar-inner scorecards">
       <ul class="nav">
         {{#each row in matrix}}
-          {{#if row.hasOneChild}}
-            {{#view GiddyUp.ScorecardItemView controllerBinding="row.target" contentBinding="row.firstObject"}}
-            {{#linkTo "scorecard" row.firstObject}}{{ row.firstObject.name }}{{/linkTo}}
-            {{/view}}
+          {{#if hasOneChild}}
+            {{ partial "scorecards/nav_link" }}
           {{else}}
-            <li class="dropdown">
-              <a class="dropdown-toggle" href="" {{action "toggleDropdown"}}>{{ key }}&nbsp;<b class="caret"></b></a>
-              <ul class="dropdown-menu">
-                {{#each scorecard in row}}
-                  <li>{{#linkTo "scorecard" scorecard}}{{ scorecard.name }}{{/linkTo}}
-                {{/each}}
-              </ul>
-            </li>
+            {{ partial "scorecards/dropdown" }}
           {{/if}}
         {{/each}}
       </ul>

--- a/assets/javascripts/app/templates/scorecards.hbs
+++ b/assets/javascripts/app/templates/scorecards.hbs
@@ -1,9 +1,18 @@
-<div class="navbar">
-  <div class="navbar-inner scorecards">
-    <ul class="nav">
-      {{#each controller itemViewClass="GiddyUp.ScorecardItemView"}}
-      {{#linkTo "scorecard" this}}{{name}}{{/linkTo}}
-      {{/each}}
-    </ul>
+{{#if isLoaded}}
+  <div class="navbar">
+    <div class="navbar-inner scorecards">
+      <ul class="nav">
+        {{#each row in matrix}}
+          <li class="dropdown">
+            <a class="dropdown-toggle" href="" {{action "toggleDropdown"}}>{{ key }}&nbsp;<b class="caret"></b></a>
+            <ul class="dropdown-menu">
+              {{#each scorecard in row}}
+                <li>{{#linkTo "scorecard" scorecard}}{{ scorecard.name }}{{/linkTo}}
+              {{/each}}
+            </ul>
+          </li>
+        {{/each}}
+      </ul>
+    </div>
   </div>
-</div>
+{{/if}}

--- a/assets/javascripts/app/templates/scorecards.hbs
+++ b/assets/javascripts/app/templates/scorecards.hbs
@@ -3,14 +3,20 @@
     <div class="navbar-inner scorecards">
       <ul class="nav">
         {{#each row in matrix}}
-          <li class="dropdown">
-            <a class="dropdown-toggle" href="" {{action "toggleDropdown"}}>{{ key }}&nbsp;<b class="caret"></b></a>
-            <ul class="dropdown-menu">
-              {{#each scorecard in row}}
-                <li>{{#linkTo "scorecard" scorecard}}{{ scorecard.name }}{{/linkTo}}
-              {{/each}}
-            </ul>
-          </li>
+          {{#if row.hasOneChild}}
+            {{#view GiddyUp.ScorecardItemView controllerBinding="row.target" contentBinding="row.firstObject"}}
+            {{#linkTo "scorecard" row.firstObject}}{{ row.firstObject.name }}{{/linkTo}}
+            {{/view}}
+          {{else}}
+            <li class="dropdown">
+              <a class="dropdown-toggle" href="" {{action "toggleDropdown"}}>{{ key }}&nbsp;<b class="caret"></b></a>
+              <ul class="dropdown-menu">
+                {{#each scorecard in row}}
+                  <li>{{#linkTo "scorecard" scorecard}}{{ scorecard.name }}{{/linkTo}}
+                {{/each}}
+              </ul>
+            </li>
+          {{/if}}
         {{/each}}
       </ul>
     </div>

--- a/assets/javascripts/app/templates/scorecards/_dropdown.hbs
+++ b/assets/javascripts/app/templates/scorecards/_dropdown.hbs
@@ -1,8 +1,8 @@
-<li class="dropdown">
+{{#view GiddyUp.DropdownSelectableView contentBinding="row" controllerBinding="row.target"}}
   <a class="dropdown-toggle" href="" {{action "toggleDropdown"}}>{{ row.key }}&nbsp;<b class="caret"></b></a>
   <ul class="dropdown-menu">
     {{#each scorecard in row}}
       <li>{{#linkTo "scorecard" scorecard}}{{ scorecard.name }}{{/linkTo}}
     {{/each}}
   </ul>
-</li>
+{{/view}}

--- a/assets/javascripts/app/templates/scorecards/_dropdown.hbs
+++ b/assets/javascripts/app/templates/scorecards/_dropdown.hbs
@@ -1,0 +1,8 @@
+<li class="dropdown">
+  <a class="dropdown-toggle" href="" {{action "toggleDropdown"}}>{{ row.key }}&nbsp;<b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    {{#each scorecard in row}}
+      <li>{{#linkTo "scorecard" scorecard}}{{ scorecard.name }}{{/linkTo}}
+    {{/each}}
+  </ul>
+</li>

--- a/assets/javascripts/app/templates/scorecards/_dropdown.hbs
+++ b/assets/javascripts/app/templates/scorecards/_dropdown.hbs
@@ -1,5 +1,8 @@
-{{#view GiddyUp.DropdownSelectableView contentBinding="row" controllerBinding="row.target"}}
-  <a class="dropdown-toggle" href="" {{action "toggleDropdown"}}>{{ row.key }}&nbsp;<b class="caret"></b></a>
+{{#view GiddyUp.DropdownSelectableView contentBinding="row"
+                                       controllerBinding="row.target"
+                                       selectedTextProperty="name"
+                                       unselectedTextBinding="row.key"}}
+  <a class="dropdown-toggle" href="" {{action "toggleDropdown"}}>{{ view.togglerText }}&nbsp;<b class="caret"></b></a>
   <ul class="dropdown-menu">
     {{#each scorecard in row}}
       <li>{{#linkTo "scorecard" scorecard}}{{ scorecard.name }}{{/linkTo}}

--- a/assets/javascripts/app/templates/scorecards/_dropdown.hbs
+++ b/assets/javascripts/app/templates/scorecards/_dropdown.hbs
@@ -5,7 +5,9 @@
   <a class="dropdown-toggle" href="" {{action "toggleDropdown"}}>{{ view.togglerText }}&nbsp;<b class="caret"></b></a>
   <ul class="dropdown-menu">
     {{#each scorecard in row}}
-      <li>{{#linkTo "scorecard" scorecard}}{{ scorecard.name }}{{/linkTo}}
+      {{#view GiddyUp.ScorecardItemView controllerBinding="row.target" contentBinding="scorecard"}}
+      {{#linkTo "scorecard" scorecard}}{{ scorecard.name }}{{/linkTo}}
+      {{/view}}
     {{/each}}
   </ul>
 {{/view}}

--- a/assets/javascripts/app/templates/scorecards/_nav_link.hbs
+++ b/assets/javascripts/app/templates/scorecards/_nav_link.hbs
@@ -1,0 +1,3 @@
+{{#view GiddyUp.ScorecardItemView controllerBinding="row.target" contentBinding="row.firstObject"}}
+  {{#linkTo "scorecard" row.firstObject}}{{ row.firstObject.name }}{{/linkTo}}
+{{/view}}

--- a/assets/javascripts/app/views.js
+++ b/assets/javascripts/app/views.js
@@ -51,10 +51,25 @@ GiddyUp.DropdownSelectableView = Ember.View.extend({
   tagName: 'li',
   dropdown: true,
   classNameBindings: ['dropdown', 'isActive:active'],
+  selectedTextProperty: null,
+  unselectedText: null,
 
   isActive: function(){
     var content = this.get('content'),
         item = this.get('controller.selectedItem');
     return !Ember.isNone(item) && content.contains(item);
-  }.property('controller.selectedItem', 'content')
+  }.property('controller.selectedItem', 'content'),
+
+  togglerText: function(){
+    var active = this.get('isActive'),
+        textProp = this.get('selectedTextProperty'),
+        unselected = this.get('unselectedText'),
+        selectedItem = this.get('controller.selectedItem');
+
+    if(active){
+      return selectedItem.get(textProp);
+    } else {
+      return unselected;
+    }
+  }.property('isActive', 'selectedTextProperty', 'unselectedText')
 });

--- a/assets/javascripts/app/views.js
+++ b/assets/javascripts/app/views.js
@@ -46,3 +46,15 @@ GiddyUp.BubbleView = Ember.View.extend({
     return classes.join(' ');
   }.property('content.status')
 });
+
+GiddyUp.DropdownSelectableView = Ember.View.extend({
+  tagName: 'li',
+  dropdown: true,
+  classNameBindings: ['dropdown', 'isActive:active'],
+
+  isActive: function(){
+    var content = this.get('content'),
+        item = this.get('controller.selectedItem');
+    return !Ember.isNone(item) && content.contains(item);
+  }.property('controller.selectedItem', 'content')
+});


### PR DESCRIPTION
This groups similar scorecards in the nav into dropdowns by version, so we turn this:

![screen shot 2013-06-12 at 9 55 41 am](https://f.cloud.github.com/assets/1772/643158/3a3adb5a-d370-11e2-9d1a-73efce6490f3.png)

into this:

![screen shot 2013-06-12 at 9 56 26 am](https://f.cloud.github.com/assets/1772/643163/4f254e06-d370-11e2-8905-c49b69bca76b.png)

@cmeiklejohn @jgnewman @bkerley 
