### PR TITLE
Use CSS gradients for bubble background on mixed results.

### DIFF
--- a/assets/javascripts/app/controllers.js
+++ b/assets/javascripts/app/controllers.js
@@ -46,27 +46,28 @@ GiddyUp.TestInstanceController = Ember.ObjectController.extend({
   status: function(){
     var length = this.get('content.testResults.length'),
         isLoaded = this.get('content.testResults').everyProperty('isLoaded'),
-        allSuccess = this.get('testResults').everyProperty('status');
-        anySuccess = this.get('testResults').someProperty('status');
+        allSuccess, anySuccess;
     if(length === 0){
       return null;
     } else if(isLoaded === true){
-        if (allSuccess) {
-            // all test runs succeeded
-            return true;
-        }
-        if (anySuccess) {
-            // some runs succeeded, some failed
-            return 'warning';
-        }
-        // all runs failed
-        return false;
+      allSuccess = this.get('testResults').everyProperty('status');
+      anySuccess = this.get('testResults').someProperty('status');
+      if (allSuccess) {
+        // all test runs succeeded
+        return true;
+      }
+      if (anySuccess) {
+          // some runs succeeded, some failed
+        return 'warning';
+      }
+      // all runs failed
+      return false;
     } else {
       return undefined;
     }
   }.property('content.testResults.length',
              'content.testResults.@each.isLoaded',
-             'testResults.firstObject.status'),
+             'content.testResults.@each.status'),
 
   descriptor: function(){
     var name = this.get('name'),

--- a/assets/javascripts/app/templates/test_instances/_bubble.hbs
+++ b/assets/javascripts/app/templates/test_instances/_bubble.hbs
@@ -1,3 +1,3 @@
 {{#view "GiddyUp.BubbleView" contentBinding="this"}}
-<span {{bindAttr class="view.statusClasses"}}>{{#linkTo "test_instance" this}}{{testInstanceAbbr backend upgradeVersion}}{{/linkTo}}</span>
+<span {{bindAttr class="view.statusClasses"}} {{bindAttr style="view.backgroundStyle"}}>{{#linkTo "test_instance" this}}{{testInstanceAbbr backend upgradeVersion}}{{/linkTo}}</span>
 {{/view}}

--- a/assets/javascripts/app/views.js
+++ b/assets/javascripts/app/views.js
@@ -30,6 +30,27 @@ GiddyUp.ArtifactView = Ember.View.extend({
 
 GiddyUp.BubbleView = Ember.View.extend({
   tagName: 'div',
+  backgroundStyle: function(){
+    var status = this.get('content.status'),
+        testResults, gradient, stepSize,
+        red = "#b94a48", green = "#468847";
+    if(status === 'warning'){
+      testResults = this.get('content.testResults').getEach('status').slice(0,4);
+      stepSize = 100 / testResults.get('length');
+      gradient = "linear-gradient(right";
+      testResults.forEach(function(st, idx){
+        var color = (st === true) ? green : red;
+        gradient += ", " + color + " " + (stepSize * idx) + "%";
+        gradient += ", " + color + " " + (stepSize * (idx+1)) + "%";
+      });
+      gradient += ")";
+      return Ember.A(["-moz-", "-ms-", "-o-", "-webkit-", ""]).
+        map(function(prefix){ return "background-image: " + prefix + gradient; }).
+        join("; ");
+    } else {
+      return "";
+    }
+  }.property('content.status'),
   statusClasses: function(){
     var status = this.get('content.status'),
         classes = ['badge'];
@@ -41,7 +62,7 @@ GiddyUp.BubbleView = Ember.View.extend({
       classes.push('badge-important');
     }
     if(status === 'warning') {
-        classes.push('badge-warning');
+      classes.push('badge-warning');
     }
     if(status === undefined) {
       classes.push('badge-loading');


### PR DESCRIPTION
Also, fixed some formatting/stylistic things from Andrew's patch. The gradient is limited to the last 5 results so as not to overdo things.

![gradients](https://f.cloud.github.com/assets/1772/1043384/1712eaa4-0ffd-11e3-91ad-874bbd1c35ab.png)
