### PR TITLE
Add repl_bucket_types riak_test to Riak EE 2.0 test suite 

### DIFF
--- a/db/seed.rb
+++ b/db/seed.rb
@@ -281,7 +281,7 @@ platforms.each do |p|
   # Riak EE 2.0
   %w{replication2_rt_sink_connection repl_reduced
      replication2_connections repl_rt_ack repl_aae_fullsync
-     verify_dvv_repl}.each do |t|
+     verify_dvv_repl repl_bucket_types}.each do |t|
     next if p =~ PLATFORM_SKIPS['2.0']
     tags = {'platform' => p, 'min_version' => '2.0.0'}
     create_riak_test t, %w{riak_ee}, tags


### PR DESCRIPTION
riak_test for 2.0 EE MDC replication bucket types support.

PR for feature:

https://github.com/basho/riak_repl/pull/490

PR for riak_test:

https://github.com/basho/riak_test/pull/477
