### PR TITLE
Fix deprecated verify_2i_mixed_cluster tests. Closes #140

### DIFF
--- a/priv/sql/140-fix-deprecated-platforms.sql
+++ b/priv/sql/140-fix-deprecated-platforms.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+UPDATE tests
+SET max_version = '1.4.99'
+WHERE max_version IS NULL AND
+      (platform = 'smartos-64' OR platform = 'ubuntu-1104-64');
+
+COMMIT;


### PR DESCRIPTION
Previously these tests were missing version constraints:

```
giddyup=> select * from tests where name = 'verify_2i_mixed_cluster' and (platform = 'smartos-64' or platform = 'ubuntu-1104-64');
  id  |          name           |    platform    | backend  | min_version | max_version | upgrade_version | multi_config
------+-------------------------+----------------+----------+-------------+-------------+-----------------+--------------
 1681 | verify_2i_mixed_cluster | ubuntu-1104-64 | eleveldb | 1.4.0       |             | previous        |
 1682 | verify_2i_mixed_cluster | ubuntu-1104-64 | eleveldb | 1.4.0       |             | legacy          |
 1683 | verify_2i_mixed_cluster | ubuntu-1104-64 | memory   | 1.4.0       |             | previous        |
 1684 | verify_2i_mixed_cluster | ubuntu-1104-64 | memory   | 1.4.0       |             | legacy          |
 1709 | verify_2i_mixed_cluster | smartos-64     | eleveldb | 1.4.0       |             | previous        |
 1710 | verify_2i_mixed_cluster | smartos-64     | eleveldb | 1.4.0       |             | legacy          |
 1711 | verify_2i_mixed_cluster | smartos-64     | memory   | 1.4.0       |             | previous        |
 1712 | verify_2i_mixed_cluster | smartos-64     | memory   | 1.4.0       |             | legacy          |
(8 rows)
```

Setting max_version = 1.4.99 will make them no longer show up.
