### PR TITLE
yokozuna updates to upgrade tests b/c we hit a specific version now, …

### DIFF
--- a/priv/sql/157-yokozuna-add-schema-test-rework-versions-for-upgrade-tests.sql
+++ b/priv/sql/157-yokozuna-add-schema-test-rework-versions-for-upgrade-tests.sql
@@ -1,0 +1,60 @@
+BEGIN;
+
+-- Update existing tests that were set to only run on 2.0.6 to run on the rest
+-- rest of the 2.0.x series
+UPDATE tests SET min_version_a = '{2,0,6}', max_version_a = '{2,0,99}'
+ WHERE name LIKE 'yz_%' AND (min_version_a = '{2,0,6}' AND max_version_a = '{2,0,6}');
+
+-- Update existing tests that were set to only run on 2.1.2 to run beyond that
+UPDATE tests SET min_version_a = '{2,1,2}', max_version_a = NULL
+ WHERE name LIKE 'yz_%' AND (min_version_a = '{2,1,2}' AND max_version_a = '{2,1,2}');
+
+-- Insert new tests for 2.0.7+ needs
+WITH s as (INSERT INTO tests (name, platform, min_version_a, max_version_a) VALUES
+       ('yz_schema_change_reset', 'centos-5-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_schema_change_reset', 'centos-6-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_schema_change_reset', 'fedora-17-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_schema_change_reset', 'freebsd-9-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_schema_change_reset', 'osx-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_schema_change_reset', 'solaris-10u9-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_schema_change_reset', 'ubuntu-1004-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_schema_change_reset', 'ubuntu-1204-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_search_http', 'centos-5-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_search_http', 'centos-6-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_search_http', 'fedora-17-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_search_http', 'freebsd-9-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_search_http', 'osx-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_search_http', 'solaris-10u9-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_search_http', 'ubuntu-1004-64', '{2,0,7}', '{2,0,99}'),
+       ('yz_search_http', 'ubuntu-1204-64', '{2,0,7}', '{2,0,99}')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+   SELECT projects.id, s.id FROM projects, s
+    WHERE (projects.name = 'riak' OR projects.name = 'riak_ee');
+
+-- Insert new tests for 2.1.2+ needs
+WITH t as (INSERT INTO tests (name, platform, min_version_a) VALUES
+       ('yz_schema_change_reset', 'centos-5-64', '{2,1,2}'),
+       ('yz_schema_change_reset', 'centos-6-64', '{2,1,2}'),
+       ('yz_schema_change_reset', 'fedora-17-64', '{2,1,2}'),
+       ('yz_schema_change_reset', 'freebsd-9-64', '{2,1,2}'),
+       ('yz_schema_change_reset', 'osx-64', '{2,1,2}'),
+       ('yz_schema_change_reset', 'solaris-10u9-64', '{2,1,2}'),
+       ('yz_schema_change_reset', 'ubuntu-1004-64', '{2,1,2}'),
+       ('yz_schema_change_reset', 'ubuntu-1204-64', '{2,1,2}'),
+       ('yz_search_http', 'centos-5-64', '{2,1,2}'),
+       ('yz_search_http', 'centos-6-64', '{2,1,2}'),
+       ('yz_search_http', 'fedora-17-64', '{2,1,2}'),
+       ('yz_search_http', 'freebsd-9-64', '{2,1,2}'),
+       ('yz_search_http', 'osx-64', '{2,1,2}'),
+       ('yz_search_http', 'solaris-10u9-64', '{2,1,2}'),
+       ('yz_search_http', 'ubuntu-1004-64', '{2,1,2}'),
+       ('yz_search_http', 'ubuntu-1204-64', '{2,1,2}')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+    SELECT projects.id, t.id FROM projects, t
+     WHERE (projects.name = 'riak' OR projects.name = 'riak_ee');
+
+COMMIT;


### PR DESCRIPTION
…plus some new additions w/ yz_search_http and yz_schema_change_reset

Related to needs for 2.1.2 release, mentioned in ticket RIAK-2044.

Here's out the psql output as well:

```
  id  |               name               |    platform     | backend | min_version | max_version | upgrade_version | multi_config | min_version_a | max_version_a 
------+----------------------------------+-----------------+---------+-------------+-------------+-----------------+--------------+---------------+---------------
 1425 | yz_schema_admin                  | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1426 | yz_siblings                      | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1427 | yz_wm_extract_test               | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1433 | yz_errors                        | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1434 | yz_fallback                      | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1436 | yz_index_admin                   | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1437 | yz_languages                     | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1423 | yz_rs_migration_test             | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1438 | yz_mapreduce                     | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1439 | yz_pb                            | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1442 | yz_schema_admin                  | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1443 | yz_siblings                      | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1444 | yz_wm_extract_test               | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1440 | yz_rs_migration_test             | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1460 | yz_solr_start_timeout            | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1463 | yz_solr_start_timeout            | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1466 | yz_solr_start_timeout            | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1469 | yz_solr_start_timeout            | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1472 | yz_solr_start_timeout            | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1475 | yz_solr_start_timeout            | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1478 | yz_solr_start_timeout            | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1481 | yz_solr_start_timeout            | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1332 | yz_fallback                      | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1314 | yz_errors                        | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1315 | yz_fallback                      | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1317 | yz_index_admin                   | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1318 | yz_languages                     | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1319 | yz_mapreduce                     | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1320 | yz_pb                            | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1323 | yz_schema_admin                  | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1324 | yz_siblings                      | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1325 | yz_wm_extract_test               | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1331 | yz_errors                        | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1334 | yz_index_admin                   | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1335 | yz_languages                     | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1336 | yz_mapreduce                     | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1337 | yz_pb                            | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1340 | yz_schema_admin                  | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1341 | yz_siblings                      | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1342 | yz_wm_extract_test               | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1348 | yz_errors                        | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1349 | yz_fallback                      | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1351 | yz_index_admin                   | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1352 | yz_languages                     | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1353 | yz_mapreduce                     | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1354 | yz_pb                            | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1357 | yz_schema_admin                  | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1358 | yz_siblings                      | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1359 | yz_wm_extract_test               | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1321 | yz_rs_migration_test             | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1338 | yz_rs_migration_test             | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1355 | yz_rs_migration_test             | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1365 | yz_errors                        | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1366 | yz_fallback                      | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1368 | yz_index_admin                   | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1369 | yz_languages                     | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1370 | yz_mapreduce                     | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1371 | yz_pb                            | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1374 | yz_schema_admin                  | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1375 | yz_siblings                      | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1376 | yz_wm_extract_test               | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1382 | yz_errors                        | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1383 | yz_fallback                      | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1385 | yz_index_admin                   | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1386 | yz_languages                     | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1387 | yz_mapreduce                     | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1388 | yz_pb                            | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1391 | yz_schema_admin                  | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1392 | yz_siblings                      | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1393 | yz_wm_extract_test               | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1399 | yz_errors                        | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1400 | yz_fallback                      | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1402 | yz_index_admin                   | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1403 | yz_languages                     | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1404 | yz_mapreduce                     | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1405 | yz_pb                            | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1408 | yz_schema_admin                  | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1409 | yz_siblings                      | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1410 | yz_wm_extract_test               | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1416 | yz_errors                        | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1417 | yz_fallback                      | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1419 | yz_index_admin                   | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1420 | yz_languages                     | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1421 | yz_mapreduce                     | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1372 | yz_rs_migration_test             | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1389 | yz_rs_migration_test             | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1406 | yz_rs_migration_test             | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1733 | yz_dt_test                       | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1734 | yz_monitor_solr                  | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1735 | yz_security                      | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1736 | yz_stat_test                     | ubuntu-1004-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1737 | yz_dt_test                       | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1738 | yz_monitor_solr                  | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1739 | yz_security                      | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1740 | yz_stat_test                     | ubuntu-1204-64  |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1741 | yz_dt_test                       | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1742 | yz_monitor_solr                  | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1743 | yz_security                      | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1744 | yz_stat_test                     | fedora-17-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1745 | yz_dt_test                       | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1746 | yz_monitor_solr                  | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1747 | yz_security                      | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1748 | yz_stat_test                     | centos-5-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1749 | yz_dt_test                       | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1750 | yz_monitor_solr                  | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1751 | yz_security                      | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1752 | yz_stat_test                     | centos-6-64     |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1753 | yz_dt_test                       | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1754 | yz_monitor_solr                  | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1755 | yz_security                      | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1756 | yz_stat_test                     | solaris-10u9-64 |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1757 | yz_dt_test                       | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1758 | yz_monitor_solr                  | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1759 | yz_security                      | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1760 | yz_stat_test                     | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1761 | yz_dt_test                       | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1762 | yz_monitor_solr                  | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1763 | yz_security                      | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 1764 | yz_stat_test                     | osx-64          |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 2321 | yz_ring_resizing                 | centos-5-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2322 | yz_ring_resizing                 | centos-6-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2323 | yz_ring_resizing                 | fedora-17-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2324 | yz_ring_resizing                 | freebsd-9-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2325 | yz_ring_resizing                 | osx-64          |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 1422 | yz_pb                            | freebsd-9-64    |         | 2.0.0       |             |                 |              | {2,0,0}       | 
 2337 | yz_handoff                       | centos-5-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2338 | yz_handoff                       | centos-6-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2339 | yz_handoff                       | fedora-17-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2340 | yz_handoff                       | freebsd-9-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2342 | yz_handoff                       | solaris-10u9-64 |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2343 | yz_handoff                       | ubuntu-1004-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2326 | yz_ring_resizing                 | solaris-10u9-64 |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2327 | yz_ring_resizing                 | ubuntu-1004-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2328 | yz_ring_resizing                 | ubuntu-1204-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2329 | yz_handoff_blocking              | centos-5-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2330 | yz_handoff_blocking              | centos-6-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2331 | yz_handoff_blocking              | fedora-17-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2332 | yz_handoff_blocking              | freebsd-9-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2333 | yz_handoff_blocking              | osx-64          |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2334 | yz_handoff_blocking              | solaris-10u9-64 |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2335 | yz_handoff_blocking              | ubuntu-1004-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2336 | yz_handoff_blocking              | ubuntu-1204-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2345 | yz_crdt                          | centos-5-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2346 | yz_crdt                          | centos-6-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2347 | yz_crdt                          | fedora-17-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2348 | yz_crdt                          | freebsd-9-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2349 | yz_crdt                          | osx-64          |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2350 | yz_crdt                          | solaris-10u9-64 |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2351 | yz_crdt                          | ubuntu-1004-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2352 | yz_crdt                          | ubuntu-1204-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2341 | yz_handoff                       | osx-64          |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2353 | yz_ensemble                      | centos-5-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2354 | yz_ensemble                      | centos-6-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2355 | yz_ensemble                      | fedora-17-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2356 | yz_ensemble                      | freebsd-9-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2357 | yz_ensemble                      | osx-64          |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2358 | yz_ensemble                      | solaris-10u9-64 |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2359 | yz_ensemble                      | ubuntu-1004-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2360 | yz_ensemble                      | ubuntu-1204-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2344 | yz_handoff                       | ubuntu-1204-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2449 | yz_core_properties_create_unload | centos-5-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2450 | yz_core_properties_create_unload | centos-6-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2451 | yz_core_properties_create_unload | fedora-17-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2452 | yz_core_properties_create_unload | freebsd-9-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2453 | yz_core_properties_create_unload | osx-64          |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2454 | yz_core_properties_create_unload | solaris-10u9-64 |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2455 | yz_core_properties_create_unload | ubuntu-1004-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2456 | yz_core_properties_create_unload | ubuntu-1204-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2473 | yz_core_properties_create_unload | centos-5-64     |         |             |             |                 |              | {2,1,2}       | 
 2474 | yz_core_properties_create_unload | centos-6-64     |         |             |             |                 |              | {2,1,2}       | 
 2475 | yz_core_properties_create_unload | fedora-17-64    |         |             |             |                 |              | {2,1,2}       | 
 2476 | yz_core_properties_create_unload | freebsd-9-64    |         |             |             |                 |              | {2,1,2}       | 
 2477 | yz_core_properties_create_unload | osx-64          |         |             |             |                 |              | {2,1,2}       | 
 2478 | yz_core_properties_create_unload | solaris-10u9-64 |         |             |             |                 |              | {2,1,2}       | 
 2479 | yz_core_properties_create_unload | ubuntu-1004-64  |         |             |             |                 |              | {2,1,2}       | 
 2480 | yz_core_properties_create_unload | ubuntu-1204-64  |         |             |             |                 |              | {2,1,2}       | 
 2481 | yz_ring_resizing                 | centos-5-64     |         |             |             |                 |              | {2,1,0}       | 
 2482 | yz_ring_resizing                 | centos-6-64     |         |             |             |                 |              | {2,1,0}       | 
 2483 | yz_ring_resizing                 | fedora-17-64    |         |             |             |                 |              | {2,1,0}       | 
 2484 | yz_ring_resizing                 | freebsd-9-64    |         |             |             |                 |              | {2,1,0}       | 
 2485 | yz_ring_resizing                 | osx-64          |         |             |             |                 |              | {2,1,0}       | 
 2486 | yz_ring_resizing                 | solaris-10u9-64 |         |             |             |                 |              | {2,1,0}       | 
 2487 | yz_ring_resizing                 | ubuntu-1004-64  |         |             |             |                 |              | {2,1,0}       | 
 2488 | yz_ring_resizing                 | ubuntu-1204-64  |         |             |             |                 |              | {2,1,0}       | 
 2489 | yz_handoff_blocking              | centos-5-64     |         |             |             |                 |              | {2,1,0}       | 
 2490 | yz_handoff_blocking              | centos-6-64     |         |             |             |                 |              | {2,1,0}       | 
 2491 | yz_handoff_blocking              | fedora-17-64    |         |             |             |                 |              | {2,1,0}       | 
 2492 | yz_handoff_blocking              | freebsd-9-64    |         |             |             |                 |              | {2,1,0}       | 
 2493 | yz_handoff_blocking              | osx-64          |         |             |             |                 |              | {2,1,0}       | 
 2494 | yz_handoff_blocking              | solaris-10u9-64 |         |             |             |                 |              | {2,1,0}       | 
 2495 | yz_handoff_blocking              | ubuntu-1004-64  |         |             |             |                 |              | {2,1,0}       | 
 2496 | yz_handoff_blocking              | ubuntu-1204-64  |         |             |             |                 |              | {2,1,0}       | 
 2497 | yz_handoff                       | centos-5-64     |         |             |             |                 |              | {2,1,2}       | 
 2498 | yz_handoff                       | centos-6-64     |         |             |             |                 |              | {2,1,2}       | 
 2499 | yz_handoff                       | fedora-17-64    |         |             |             |                 |              | {2,1,2}       | 
 2500 | yz_handoff                       | freebsd-9-64    |         |             |             |                 |              | {2,1,2}       | 
 2501 | yz_handoff                       | osx-64          |         |             |             |                 |              | {2,1,2}       | 
 2502 | yz_handoff                       | solaris-10u9-64 |         |             |             |                 |              | {2,1,2}       | 
 2503 | yz_handoff                       | ubuntu-1004-64  |         |             |             |                 |              | {2,1,2}       | 
 2504 | yz_handoff                       | ubuntu-1204-64  |         |             |             |                 |              | {2,1,2}       | 
 2505 | yz_crdt                          | centos-5-64     |         |             |             |                 |              | {2,1,0}       | 
 2506 | yz_crdt                          | centos-6-64     |         |             |             |                 |              | {2,1,0}       | 
 2507 | yz_crdt                          | fedora-17-64    |         |             |             |                 |              | {2,1,0}       | 
 2508 | yz_crdt                          | freebsd-9-64    |         |             |             |                 |              | {2,1,0}       | 
 2509 | yz_crdt                          | osx-64          |         |             |             |                 |              | {2,1,0}       | 
 2510 | yz_crdt                          | solaris-10u9-64 |         |             |             |                 |              | {2,1,0}       | 
 2511 | yz_crdt                          | ubuntu-1004-64  |         |             |             |                 |              | {2,1,0}       | 
 2512 | yz_crdt                          | ubuntu-1204-64  |         |             |             |                 |              | {2,1,0}       | 
 2513 | yz_ensemble                      | centos-5-64     |         |             |             |                 |              | {2,1,0}       | 
 2514 | yz_ensemble                      | centos-6-64     |         |             |             |                 |              | {2,1,0}       | 
 2515 | yz_ensemble                      | fedora-17-64    |         |             |             |                 |              | {2,1,0}       | 
 2516 | yz_ensemble                      | freebsd-9-64    |         |             |             |                 |              | {2,1,0}       | 
 2517 | yz_ensemble                      | osx-64          |         |             |             |                 |              | {2,1,0}       | 
 2518 | yz_ensemble                      | solaris-10u9-64 |         |             |             |                 |              | {2,1,0}       | 
 2519 | yz_ensemble                      | ubuntu-1004-64  |         |             |             |                 |              | {2,1,0}       | 
 2520 | yz_ensemble                      | ubuntu-1204-64  |         |             |             |                 |              | {2,1,0}       | 
 2433 | yz_extractors                    | centos-5-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2434 | yz_extractors                    | centos-6-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2435 | yz_extractors                    | fedora-17-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2436 | yz_extractors                    | freebsd-9-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2437 | yz_extractors                    | osx-64          |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2438 | yz_extractors                    | solaris-10u9-64 |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2439 | yz_extractors                    | ubuntu-1004-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2440 | yz_extractors                    | ubuntu-1204-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2457 | yz_default_bucket_type_upgrade   | centos-5-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2458 | yz_default_bucket_type_upgrade   | centos-6-64     |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2459 | yz_default_bucket_type_upgrade   | fedora-17-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2460 | yz_default_bucket_type_upgrade   | freebsd-9-64    |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2461 | yz_default_bucket_type_upgrade   | osx-64          |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2462 | yz_default_bucket_type_upgrade   | solaris-10u9-64 |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2463 | yz_default_bucket_type_upgrade   | ubuntu-1004-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2464 | yz_default_bucket_type_upgrade   | ubuntu-1204-64  |         |             |             |                 |              | {2,0,6}       | {2,0,99}
 2441 | yz_extractors                    | centos-5-64     |         |             |             |                 |              | {2,1,2}       | 
 2442 | yz_extractors                    | centos-6-64     |         |             |             |                 |              | {2,1,2}       | 
 2443 | yz_extractors                    | fedora-17-64    |         |             |             |                 |              | {2,1,2}       | 
 2444 | yz_extractors                    | freebsd-9-64    |         |             |             |                 |              | {2,1,2}       | 
 2445 | yz_extractors                    | osx-64          |         |             |             |                 |              | {2,1,2}       | 
 2446 | yz_extractors                    | solaris-10u9-64 |         |             |             |                 |              | {2,1,2}       | 
 2447 | yz_extractors                    | ubuntu-1004-64  |         |             |             |                 |              | {2,1,2}       | 
 2448 | yz_extractors                    | ubuntu-1204-64  |         |             |             |                 |              | {2,1,2}       | 
 2465 | yz_default_bucket_type_upgrade   | centos-5-64     |         |             |             |                 |              | {2,1,2}       | 
 2466 | yz_default_bucket_type_upgrade   | centos-6-64     |         |             |             |                 |              | {2,1,2}       | 
 2467 | yz_default_bucket_type_upgrade   | fedora-17-64    |         |             |             |                 |              | {2,1,2}       | 
 2468 | yz_default_bucket_type_upgrade   | freebsd-9-64    |         |             |             |                 |              | {2,1,2}       | 
 2469 | yz_default_bucket_type_upgrade   | osx-64          |         |             |             |                 |              | {2,1,2}       | 
 2470 | yz_default_bucket_type_upgrade   | solaris-10u9-64 |         |             |             |                 |              | {2,1,2}       | 
 2471 | yz_default_bucket_type_upgrade   | ubuntu-1004-64  |         |             |             |                 |              | {2,1,2}       | 
 2472 | yz_default_bucket_type_upgrade   | ubuntu-1204-64  |         |             |             |                 |              | {2,1,2}       | 
 2521 | yz_schema_change_reset           | centos-5-64     |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2522 | yz_schema_change_reset           | centos-6-64     |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2523 | yz_schema_change_reset           | fedora-17-64    |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2524 | yz_schema_change_reset           | freebsd-9-64    |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2525 | yz_schema_change_reset           | osx-64          |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2526 | yz_schema_change_reset           | solaris-10u9-64 |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2527 | yz_schema_change_reset           | ubuntu-1004-64  |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2528 | yz_schema_change_reset           | ubuntu-1204-64  |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2529 | yz_search_http                   | centos-5-64     |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2530 | yz_search_http                   | centos-6-64     |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2531 | yz_search_http                   | fedora-17-64    |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2532 | yz_search_http                   | freebsd-9-64    |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2533 | yz_search_http                   | osx-64          |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2534 | yz_search_http                   | solaris-10u9-64 |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2535 | yz_search_http                   | ubuntu-1004-64  |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2536 | yz_search_http                   | ubuntu-1204-64  |         |             |             |                 |              | {2,0,7}       | {2,0,99}
 2537 | yz_schema_change_reset           | centos-5-64     |         |             |             |                 |              | {2,1,2}       | 
 2538 | yz_schema_change_reset           | centos-6-64     |         |             |             |                 |              | {2,1,2}       | 
 2539 | yz_schema_change_reset           | fedora-17-64    |         |             |             |                 |              | {2,1,2}       | 
 2540 | yz_schema_change_reset           | freebsd-9-64    |         |             |             |                 |              | {2,1,2}       | 
 2541 | yz_schema_change_reset           | osx-64          |         |             |             |                 |              | {2,1,2}       | 
 2542 | yz_schema_change_reset           | solaris-10u9-64 |         |             |             |                 |              | {2,1,2}       | 
 2543 | yz_schema_change_reset           | ubuntu-1004-64  |         |             |             |                 |              | {2,1,2}       | 
 2544 | yz_schema_change_reset           | ubuntu-1204-64  |         |             |             |                 |              | {2,1,2}       | 
 2545 | yz_search_http                   | centos-5-64     |         |             |             |                 |              | {2,1,2}       | 
 2546 | yz_search_http                   | centos-6-64     |         |             |             |                 |              | {2,1,2}       | 
 2547 | yz_search_http                   | fedora-17-64    |         |             |             |                 |              | {2,1,2}       | 
 2548 | yz_search_http                   | freebsd-9-64    |         |             |             |                 |              | {2,1,2}       | 
 2549 | yz_search_http                   | osx-64          |         |             |             |                 |              | {2,1,2}       | 
 2550 | yz_search_http                   | solaris-10u9-64 |         |             |             |                 |              | {2,1,2}       | 
 2551 | yz_search_http                   | ubuntu-1004-64  |         |             |             |                 |              | {2,1,2}       | 
 2552 | yz_search_http                   | ubuntu-1204-64  |         |             |             |                 |              | {2,1,2}       | 
(280 rows)
```
