### PR TITLE
Add 3 new tests for Riak 2.1.2:

### DIFF
--- a/priv/sql/158-add-proxy-overload-recovery.sql
+++ b/priv/sql/158-add-proxy-overload-recovery.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+
+-- Insert new tests for 2.0.7+ needs
+WITH s as (INSERT INTO tests (name, platform, min_version_a, max_version_a) VALUES
+       ('proxy_overload_recovery', 'centos-5-64', '{2,0,7}', '{2,0,99}'),
+       ('proxy_overload_recovery', 'centos-6-64', '{2,0,7}', '{2,0,99}'),
+       ('proxy_overload_recovery', 'fedora-17-64', '{2,0,7}', '{2,0,99}'),
+       ('proxy_overload_recovery', 'freebsd-9-64', '{2,0,7}', '{2,0,99}'),
+       ('proxy_overload_recovery', 'osx-64', '{2,0,7}', '{2,0,99}'),
+       ('proxy_overload_recovery', 'solaris-10u9-64', '{2,0,7}', '{2,0,99}'),
+       ('proxy_overload_recovery', 'ubuntu-1004-64', '{2,0,7}', '{2,0,99}'),
+       ('proxy_overload_recovery', 'ubuntu-1204-64', '{2,0,7}', '{2,0,99}')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+   SELECT projects.id, s.id FROM projects, s
+    WHERE (projects.name = 'riak' OR projects.name = 'riak_ee');
+
+-- Insert new tests for 2.1.2+ needs
+WITH t as (INSERT INTO tests (name, platform, min_version_a) VALUES
+       ('proxy_overload_recovery', 'centos-5-64', '{2,1,2}'),
+       ('proxy_overload_recovery', 'centos-6-64', '{2,1,2}'),
+       ('proxy_overload_recovery', 'fedora-17-64', '{2,1,2}'),
+       ('proxy_overload_recovery', 'freebsd-9-64', '{2,1,2}'),
+       ('proxy_overload_recovery', 'osx-64', '{2,1,2}'),
+       ('proxy_overload_recovery', 'solaris-10u9-64', '{2,1,2}'),
+       ('proxy_overload_recovery', 'ubuntu-1004-64', '{2,1,2}'),
+       ('proxy_overload_recovery', 'ubuntu-1204-64', '{2,1,2}')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+    SELECT projects.id, t.id FROM projects, t
+     WHERE (projects.name = 'riak' OR projects.name = 'riak_ee');
+
+COMMIT;

--- a/priv/sql/159-add-riak727.sql
+++ b/priv/sql/159-add-riak727.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+
+-- Insert new tests for 2.0.7+ needs
+WITH s as (INSERT INTO tests (name, platform, min_version_a, max_version_a) VALUES
+       ('riak727', 'centos-5-64', '{2,0,7}', '{2,0,99}'),
+       ('riak727', 'centos-6-64', '{2,0,7}', '{2,0,99}'),
+       ('riak727', 'fedora-17-64', '{2,0,7}', '{2,0,99}'),
+       ('riak727', 'freebsd-9-64', '{2,0,7}', '{2,0,99}'),
+       ('riak727', 'osx-64', '{2,0,7}', '{2,0,99}'),
+       ('riak727', 'solaris-10u9-64', '{2,0,7}', '{2,0,99}'),
+       ('riak727', 'ubuntu-1004-64', '{2,0,7}', '{2,0,99}'),
+       ('riak727', 'ubuntu-1204-64', '{2,0,7}', '{2,0,99}')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+   SELECT projects.id, s.id FROM projects, s
+    WHERE (projects.name = 'riak' OR projects.name = 'riak_ee');
+
+-- Insert new tests for 2.1.2+ needs
+WITH t as (INSERT INTO tests (name, platform, min_version_a) VALUES
+       ('riak727', 'centos-5-64', '{2,1,2}'),
+       ('riak727', 'centos-6-64', '{2,1,2}'),
+       ('riak727', 'fedora-17-64', '{2,1,2}'),
+       ('riak727', 'freebsd-9-64', '{2,1,2}'),
+       ('riak727', 'osx-64', '{2,1,2}'),
+       ('riak727', 'solaris-10u9-64', '{2,1,2}'),
+       ('riak727', 'ubuntu-1004-64', '{2,1,2}'),
+       ('riak727', 'ubuntu-1204-64', '{2,1,2}')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+    SELECT projects.id, t.id FROM projects, t
+     WHERE (projects.name = 'riak' OR projects.name = 'riak_ee');
+
+COMMIT;

--- a/priv/sql/160-add-verify-build-cluster-caps-race.sql
+++ b/priv/sql/160-add-verify-build-cluster-caps-race.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+
+-- Insert new tests for 2.0.7+ needs
+WITH s as (INSERT INTO tests (name, platform, min_version_a, max_version_a) VALUES
+       ('verify_build_cluster_caps_race', 'centos-5-64', '{2,0,7}', '{2,0,99}'),
+       ('verify_build_cluster_caps_race', 'centos-6-64', '{2,0,7}', '{2,0,99}'),
+       ('verify_build_cluster_caps_race', 'fedora-17-64', '{2,0,7}', '{2,0,99}'),
+       ('verify_build_cluster_caps_race', 'freebsd-9-64', '{2,0,7}', '{2,0,99}'),
+       ('verify_build_cluster_caps_race', 'osx-64', '{2,0,7}', '{2,0,99}'),
+       ('verify_build_cluster_caps_race', 'solaris-10u9-64', '{2,0,7}', '{2,0,99}'),
+       ('verify_build_cluster_caps_race', 'ubuntu-1004-64', '{2,0,7}', '{2,0,99}'),
+       ('verify_build_cluster_caps_race', 'ubuntu-1204-64', '{2,0,7}', '{2,0,99}')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+   SELECT projects.id, s.id FROM projects, s
+    WHERE (projects.name = 'riak' OR projects.name = 'riak_ee');
+
+-- Insert new tests for 2.1.2+ needs
+WITH t as (INSERT INTO tests (name, platform, min_version_a) VALUES
+       ('verify_build_cluster_caps_race', 'centos-5-64', '{2,1,2}'),
+       ('verify_build_cluster_caps_race', 'centos-6-64', '{2,1,2}'),
+       ('verify_build_cluster_caps_race', 'fedora-17-64', '{2,1,2}'),
+       ('verify_build_cluster_caps_race', 'freebsd-9-64', '{2,1,2}'),
+       ('verify_build_cluster_caps_race', 'osx-64', '{2,1,2}'),
+       ('verify_build_cluster_caps_race', 'solaris-10u9-64', '{2,1,2}'),
+       ('verify_build_cluster_caps_race', 'ubuntu-1004-64', '{2,1,2}'),
+       ('verify_build_cluster_caps_race', 'ubuntu-1204-64', '{2,1,2}')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+    SELECT projects.id, t.id FROM projects, t
+     WHERE (projects.name = 'riak' OR projects.name = 'riak_ee');
+
+COMMIT;


### PR DESCRIPTION
- proxy_overload_recovery
- riak727
- verify_build_cluster_caps_race

For testing:

```
## Use the giddyup role
export ROLES='giddyup.yml'

## Tell ansible the name of the new sql script
export EXTRA_VARS='{"sql_job":"158-add-proxy-overload-recovery.sql"}'
export EXTRA_VARS='{"sql_job":"159-add-riak727.sql"}'
export EXTRA_VARS='{"sql_job":"160-add-verify-build-cluster-caps-race.sql"}'

## Tell ansible that only the sql job should be run
export TAGS='sql'

## Tell vagrant to run the job against the existing deployment
vagrant provision ansibletest-giddyup
```
