### PR TITLE
Rename aae_test to yz_aae_test

### DIFF
--- a/priv/sql/173-rename-yz-aae-test.sql
+++ b/priv/sql/173-rename-yz-aae-test.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- From https://github.com/basho/yokozuna/pull/593
+UPDATE tests set name = 'yz_aae_test' where name = 'aae_test';
+
+COMMIT;


### PR DESCRIPTION
This is the only Yokozuna test which is not prefixed by `yz_`.
