### PR TITLE
Clean up bad, old test results from riak_ee in GiddyUp

### DIFF
--- a/priv/sql/178-add-oss-ts-tests.sql
+++ b/priv/sql/178-add-oss-ts-tests.sql
@@ -1,9 +1,29 @@
 BEGIN;
 
--- Add riak tests for all EE Time Series tests
+-- Expect the next in the sequence, which currently is "7"
+INSERT INTO projects (name) VALUES ('riak_ts_ee');
+
+-- Move all existing riak_ts tests over to riak_ts_ee
+UPDATE projects_tests SET project_id=(SELECT id FROM projects WHERE name='riak_ts_ee')
+WHERE project_id=(select id FROM projects WHERE name='riak_ts');
+UPDATE scorecards SET project_id=(SELECT id FROM projects WHERE name='riak_ts_ee')
+WHERE project_id=(select id FROM projects WHERE name='riak_ts');
+
+-- Add OSS riak tests for CentOS 6
 INSERT INTO projects_tests (project_id, test_id)
-   SELECT projects.id, tests.id FROM projects, tests
-   WHERE (projects.name = 'riak') AND tests.name LIKE 'ts_%';
+   SELECT (select id FROM projects WHERE name='riak_ts'),
+          tests.id FROM projects_tests, projects, tests
+   WHERE (projects.name = 'riak') AND tests.platform = 'centos-6-64'
+   AND projects_tests.project_id=projects.id
+   AND projects_tests.test_id=tests.id;
+
+-- Add all Time Series tests for all EE Time Series tests
+INSERT INTO projects_tests (project_id, test_id)
+   SELECT (select id FROM projects WHERE name='riak_ts'),
+          tests.id FROM projects_tests, projects, tests
+   WHERE (projects.name = 'riak_ts_ee') AND tests.name LIKE 'ts_%'
+   AND projects_tests.project_id=projects.id
+   AND projects_tests.test_id=tests.id;
 
 -- Add in the new ones
 WITH newtests AS (INSERT INTO tests (name, platform, backend) VALUES
@@ -14,6 +34,6 @@ RETURNING id)
 
 INSERT INTO projects_tests (project_id, test_id)
     SELECT projects.id, newtests.id FROM projects, newtests
-    WHERE (projects.name = 'riak' OR projects.name = 'riak_ee');
+    WHERE (projects.name = 'riak_ts' OR projects.name = 'riak_ts_ee');
 
 COMMIT;

--- a/priv/sql/180-remove-old-test-results.sql
+++ b/priv/sql/180-remove-old-test-results.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+-- Remove test results from bad tests:
+DELETE FROM artifacts where test_result_id in (SELECT id FROM test_results WHERE scorecard_id in (SELECT sc.id FROM scorecards AS sc WHERE project_id=2 AND name IN ('riak_ee-ts_pb1','object_ttl_a1','43c71d91e4b92aa053716c7535914467905ab981','0.0.2')));
+DELETE FROM test_results WHERE scorecard_id in (SELECT sc.id FROM scorecards AS sc WHERE project_id=2 AND name IN ('riak_ee-ts_pb1','object_ttl_a1','43c71d91e4b92aa053716c7535914467905ab981','0.0.2'));
+DELETE FROM scorecards WHERE id IN (SELECT sc.id FROM scorecards AS sc WHERE project_id=2 AND name IN ('riak_ee-ts_pb1','object_ttl_a1','43c71d91e4b92aa053716c7535914467905ab981','0.0.2'));
+
+COMMIT;


### PR DESCRIPTION
These score cards need to die:
- riak_ee-ts_pb1
- object_ttl_a1
- 43c71d91e4b92aa053716c7535914467905ab981
- 0.0.2
