### PR TITLE
Fix the riak_ts OSS tests

### DIFF
--- a/priv/sql/181-remove-oss-ts-versions.sql
+++ b/priv/sql/181-remove-oss-ts-versions.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+-- Start over with riak_ts tests
+DELETE FROM projects_tests WHERE project_id=(SELECT id FROM projects WHERE name='riak_ts');
+-- Copy all of the tests from riak_ts_ee into riak_ts, except those which are EE-specific
+INSERT INTO projects_tests
+SELECT (SELECT id FROM projects WHERE name='riak_ts'),tests.id
+FROM projects_tests, tests, projects
+WHERE projects_tests.project_id=projects.id
+AND tests.id=projects_tests.test_id
+AND projects.name='riak_ts_ee'
+AND tests.name NOT IN
+(SELECT tests.name FROM tests, projects_tests, projects WHERE projects_tests.test_id=tests.id
+AND projects_tests.project_id=projects.id
+AND projects.name='riak_ee'
+EXCEPT
+SELECT tests.name FROM tests, projects_tests, projects WHERE projects_tests.test_id=tests.id
+AND projects_tests.project_id=projects.id
+AND projects.name='riak');
+
+-- Fix typo
+UPDATE tests SET name='riak_shell_test_connecting'
+WHERE name='riak_shell_test_connecting.';
+
+COMMIT;


### PR DESCRIPTION
Unfortunately my first attempt to add the OSS test referred to the riak tests, not the riak_ts_ee tests.  These records have versions on them which cause TS tests not to run.

So nuke the test list and copy over all of the riak_ts_ee tests except for those which are riak_ee-only (repl, etc.)

Also fix a stupid typo in a test name.
