### PR TITLE
Break rt_cascading into 10 different subtests

### DIFF
--- a/priv/sql/184-break-up-rt-cascading.sql
+++ b/priv/sql/184-break-up-rt-cascading.sql
@@ -1,0 +1,103 @@
+BEGIN;
+
+-- From https://github.com/basho/riak_test/pull/1050
+UPDATE tests set name = 'rt_cascading_simple' where name = 'rt_cascading';
+
+-- Insert new tests
+WITH t as (INSERT INTO tests (name, platform) VALUES
+       ('rt_cascading_big_circle', 'centos-5-64'),
+       ('rt_cascading_big_circle', 'centos-6-64'),
+       ('rt_cascading_big_circle', 'fedora-17-64'),
+       ('rt_cascading_big_circle', 'freebsd-9-64'),
+       ('rt_cascading_big_circle', 'osx-64'),
+       ('rt_cascading_big_circle', 'solaris-10u9-64'),
+       ('rt_cascading_big_circle', 'ubuntu-1004-64'),
+       ('rt_cascading_big_circle', 'ubuntu-1204-64'),
+       ('rt_cascading_circle', 'centos-5-64'),
+       ('rt_cascading_circle', 'centos-6-64'),
+       ('rt_cascading_circle', 'fedora-17-64'),
+       ('rt_cascading_circle', 'freebsd-9-64'),
+       ('rt_cascading_circle', 'osx-64'),
+       ('rt_cascading_circle', 'solaris-10u9-64'),
+       ('rt_cascading_circle', 'ubuntu-1004-64'),
+       ('rt_cascading_circle', 'ubuntu-1204-64'),
+       ('rt_cascading_circle_and_spurs', 'centos-5-64'),
+       ('rt_cascading_circle_and_spurs', 'centos-6-64'),
+       ('rt_cascading_circle_and_spurs', 'fedora-17-64'),
+       ('rt_cascading_circle_and_spurs', 'freebsd-9-64'),
+       ('rt_cascading_circle_and_spurs', 'osx-64'),
+       ('rt_cascading_circle_and_spurs', 'solaris-10u9-64'),
+       ('rt_cascading_circle_and_spurs', 'ubuntu-1004-64'),
+       ('rt_cascading_circle_and_spurs', 'ubuntu-1204-64'),
+       ('rt_cascading_diamond', 'centos-5-64'),
+       ('rt_cascading_diamond', 'centos-6-64'),
+       ('rt_cascading_diamond', 'fedora-17-64'),
+       ('rt_cascading_diamond', 'freebsd-9-64'),
+       ('rt_cascading_diamond', 'osx-64'),
+       ('rt_cascading_diamond', 'solaris-10u9-64'),
+       ('rt_cascading_diamond', 'ubuntu-1004-64'),
+       ('rt_cascading_diamond', 'ubuntu-1204-64'),
+       ('rt_cascading_ensure_ack', 'centos-5-64'),
+       ('rt_cascading_ensure_ack', 'centos-6-64'),
+       ('rt_cascading_ensure_ack', 'fedora-17-64'),
+       ('rt_cascading_ensure_ack', 'freebsd-9-64'),
+       ('rt_cascading_ensure_ack', 'osx-64'),
+       ('rt_cascading_ensure_ack', 'solaris-10u9-64'),
+       ('rt_cascading_ensure_ack', 'ubuntu-1004-64'),
+       ('rt_cascading_ensure_ack', 'ubuntu-1204-64'),
+       ('rt_cascading_mixed_clusters', 'centos-5-64'),
+       ('rt_cascading_mixed_clusters', 'centos-6-64'),
+       ('rt_cascading_mixed_clusters', 'fedora-17-64'),
+       ('rt_cascading_mixed_clusters', 'freebsd-9-64'),
+       ('rt_cascading_mixed_clusters', 'osx-64'),
+       ('rt_cascading_mixed_clusters', 'solaris-10u9-64'),
+       ('rt_cascading_mixed_clusters', 'ubuntu-1004-64'),
+       ('rt_cascading_mixed_clusters', 'ubuntu-1204-64'),
+       ('rt_cascading_new_to_old', 'centos-5-64'),
+       ('rt_cascading_new_to_old', 'centos-6-64'),
+       ('rt_cascading_new_to_old', 'fedora-17-64'),
+       ('rt_cascading_new_to_old', 'freebsd-9-64'),
+       ('rt_cascading_new_to_old', 'osx-64'),
+       ('rt_cascading_new_to_old', 'solaris-10u9-64'),
+       ('rt_cascading_new_to_old', 'ubuntu-1004-64'),
+       ('rt_cascading_new_to_old', 'ubuntu-1204-64'),
+       ('rt_cascading_pyramid', 'centos-5-64'),
+       ('rt_cascading_pyramid', 'centos-6-64'),
+       ('rt_cascading_pyramid', 'fedora-17-64'),
+       ('rt_cascading_pyramid', 'freebsd-9-64'),
+       ('rt_cascading_pyramid', 'osx-64'),
+       ('rt_cascading_pyramid', 'solaris-10u9-64'),
+       ('rt_cascading_pyramid', 'ubuntu-1004-64'),
+       ('rt_cascading_pyramid', 'ubuntu-1204-64'),
+       ('rt_cascading_unacked_and_queue', 'centos-5-64'),
+       ('rt_cascading_unacked_and_queue', 'centos-6-64'),
+       ('rt_cascading_unacked_and_queue', 'fedora-17-64'),
+       ('rt_cascading_unacked_and_queue', 'freebsd-9-64'),
+       ('rt_cascading_unacked_and_queue', 'osx-64'),
+       ('rt_cascading_unacked_and_queue', 'solaris-10u9-64'),
+       ('rt_cascading_unacked_and_queue', 'ubuntu-1004-64'),
+       ('rt_cascading_unacked_and_queue', 'ubuntu-1204-64')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+   SELECT projects.id, t.id FROM projects, t
+    WHERE projects.name='riak_ee';
+
+-- Insert new TS tests
+WITH t as (INSERT INTO tests (name, platform) VALUES
+       ('rt_cascading_big_circle', 'centos-6-64'),
+       ('rt_cascading_circle', 'centos-6-64'),
+       ('rt_cascading_circle_and_spurs', 'centos-6-64'),
+       ('rt_cascading_diamond', 'centos-6-64'),
+       ('rt_cascading_ensure_ack', 'centos-6-64'),
+       ('rt_cascading_mixed_clusters', 'centos-6-64'),
+       ('rt_cascading_new_to_old', 'centos-6-64'),
+       ('rt_cascading_pyramid', 'centos-6-64'),
+       ('rt_cascading_unacked_and_queue', 'centos-6-64')
+       RETURNING id)
+
+INSERT INTO projects_tests (project_id, test_id)
+   SELECT projects.id, t.id FROM projects, t
+    WHERE projects.name='riak_ts_ee';
+
+COMMIT;


### PR DESCRIPTION
The old `rt_cascading` has been replaced with:
- rt_cascading_big_circle
- rt_cascading_circle
- rt_cascading_circle_and_spurs
- rt_cascading_diamond
- rt_cascading_ensure_ack
- rt_cascading_mixed_clusters
- rt_cascading_new_to_old
- rt_cascading_pyramid
- rt_cascading_simple
- rt_cascading_unacked_and_queue

The old `rt_cascading` is renamed `rt_cascading_simple`.

The TS versions are Centos 6 only and have no start version.  The KV ones could have a start version of `1.4.0` like `rt_cascading`, but we don't test anything that old any more so it does not matter.
