### PR TITLE
RTS 1752: Quit running verify_removed_capability

### DIFF
--- a/priv/sql/204-disable-verify-removed-capability.sql
+++ b/priv/sql/204-disable-verify-removed-capability.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+-- Obsolete this test
+UPDATE tests SET max_version_a='{2,2,0}'
+FROM projects_tests, projects
+WHERE tests.name='verify_removed_capability'
+AND tests.id = projects_tests.test_id
+AND projects_tests.project_id = projects.id
+AND projects.name IN ('riak', 'riak_ee');
+
+UPDATE tests SET max_version_a='{1,4,0}'
+FROM projects_tests, projects
+WHERE tests.name='verify_removed_capability'
+AND tests.id = projects_tests.test_id
+AND projects_tests.project_id = projects.id
+AND projects.name IN ('riak_ts', 'riak_ts_ee');
+
+COMMIT;


### PR DESCRIPTION
This test was for a feature backed out after TS 1.4.x